### PR TITLE
feat: add artifacts and mime_types core modules

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/src/celeste/artifacts.py
+++ b/src/celeste/artifacts.py
@@ -1,0 +1,52 @@
+"""Unified artifact types for Celeste."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from celeste.mime_types import AudioMimeType, ImageMimeType, MimeType, VideoMimeType
+
+
+class Artifact(BaseModel):
+    """Base class for all media artifacts."""
+
+    url: str | None = None
+    data: bytes | None = None
+    path: str | None = None
+    mime_type: MimeType | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def has_content(self) -> bool:
+        """Check if artifact has any content."""
+        return bool(
+            (self.url and self.url.strip())
+            or self.data
+            or (self.path and self.path.strip())
+        )
+
+
+class ImageArtifact(Artifact):
+    """Image artifact from generation/edit operations."""
+
+    mime_type: ImageMimeType | None = None
+
+
+class VideoArtifact(Artifact):
+    """Video artifact from generation operations."""
+
+    mime_type: VideoMimeType | None = None
+
+
+class AudioArtifact(Artifact):
+    """Audio artifact from TTS/transcription operations."""
+
+    mime_type: AudioMimeType | None = None
+
+
+__all__ = [
+    "Artifact",
+    "AudioArtifact",
+    "ImageArtifact",
+    "VideoArtifact",
+]

--- a/src/celeste/mime_types.py
+++ b/src/celeste/mime_types.py
@@ -1,0 +1,47 @@
+"""MIME type enumerations for Celeste."""
+
+from enum import StrEnum
+
+
+class MimeType(StrEnum):
+    """Base class for all MIME types."""
+
+    pass
+
+
+class ImageMimeType(MimeType):
+    """Standard MIME types for images."""
+
+    PNG = "image/png"
+    JPEG = "image/jpeg"
+    WEBP = "image/webp"
+
+
+class VideoMimeType(MimeType):
+    """Standard MIME types for videos."""
+
+    MP4 = "video/mp4"
+    AVI = "video/x-msvideo"
+    MOV = "video/quicktime"
+
+
+class AudioMimeType(MimeType):
+    """Standard MIME types for audio."""
+
+    MP3 = "audio/mpeg"
+    WAV = "audio/wav"
+    OGG = "audio/ogg"
+    WEBM = "audio/webm"
+    AAC = "audio/aac"
+    FLAC = "audio/flac"
+    AIFF = "audio/aiff"
+    M4A = "audio/mp4"
+    WMA = "audio/x-ms-wma"
+
+
+__all__ = [
+    "AudioMimeType",
+    "ImageMimeType",
+    "MimeType",
+    "VideoMimeType",
+]


### PR DESCRIPTION
Fixes CEL-119

Adds two missing core modules to complete the core module migration:

- **mime_types.py**: MIME type enumerations (ImageMimeType, VideoMimeType, AudioMimeType)
- **artifacts.py**: Unified artifact types for media (Artifact, ImageArtifact, VideoArtifact, AudioArtifact)

These modules are prerequisites for migrating test files and enabling full core functionality.

**Files Added:**
- `src/celeste/mime_types.py` - MIME type enums following StrEnum pattern
- `src/celeste/artifacts.py` - Artifact classes with Pydantic BaseModel

**Verification:**
- Syntax validation passed
- Type checking passed (mypy)
- Linting passed
- Code style matches existing modules
- Docstrings follow CLAUDE.md guidelines (one-liners for simple classes)

**Related:**
- Part of CEL-119: Add supporting core modules
- Completes core module migration (all modules now in public repo)