### PR TITLE
feat: add artifacts and mime_types core modules

### DIFF
--- a/src/celeste/artifacts.py
+++ b/src/celeste/artifacts.py
@@ -1,0 +1,52 @@
+"""Unified artifact types for Celeste."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from celeste.mime_types import AudioMimeType, ImageMimeType, MimeType, VideoMimeType
+
+
+class Artifact(BaseModel):
+    """Base class for all media artifacts."""
+
+    url: str | None = None
+    data: bytes | None = None
+    path: str | None = None
+    mime_type: MimeType | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def has_content(self) -> bool:
+        """Check if artifact has any content."""
+        return bool(
+            (self.url and self.url.strip())
+            or self.data
+            or (self.path and self.path.strip())
+        )
+
+
+class ImageArtifact(Artifact):
+    """Image artifact from generation/edit operations."""
+
+    mime_type: ImageMimeType | None = None
+
+
+class VideoArtifact(Artifact):
+    """Video artifact from generation operations."""
+
+    mime_type: VideoMimeType | None = None
+
+
+class AudioArtifact(Artifact):
+    """Audio artifact from TTS/transcription operations."""
+
+    mime_type: AudioMimeType | None = None
+
+
+__all__ = [
+    "Artifact",
+    "AudioArtifact",
+    "ImageArtifact",
+    "VideoArtifact",
+]

--- a/src/celeste/mime_types.py
+++ b/src/celeste/mime_types.py
@@ -1,0 +1,47 @@
+"""MIME type enumerations for Celeste."""
+
+from enum import StrEnum
+
+
+class MimeType(StrEnum):
+    """Base class for all MIME types."""
+
+    pass
+
+
+class ImageMimeType(MimeType):
+    """Standard MIME types for images."""
+
+    PNG = "image/png"
+    JPEG = "image/jpeg"
+    WEBP = "image/webp"
+
+
+class VideoMimeType(MimeType):
+    """Standard MIME types for videos."""
+
+    MP4 = "video/mp4"
+    AVI = "video/x-msvideo"
+    MOV = "video/quicktime"
+
+
+class AudioMimeType(MimeType):
+    """Standard MIME types for audio."""
+
+    MP3 = "audio/mpeg"
+    WAV = "audio/wav"
+    OGG = "audio/ogg"
+    WEBM = "audio/webm"
+    AAC = "audio/aac"
+    FLAC = "audio/flac"
+    AIFF = "audio/aiff"
+    M4A = "audio/mp4"
+    WMA = "audio/x-ms-wma"
+
+
+__all__ = [
+    "AudioMimeType",
+    "ImageMimeType",
+    "MimeType",
+    "VideoMimeType",
+]


### PR DESCRIPTION
Fixes CEL-119

Adds core modules for artifacts and MIME types:

- `src/celeste/mime_types.py` - MIME type enumerations (ImageMimeType, VideoMimeType, AudioMimeType)
- `src/celeste/artifacts.py` - Artifact types for media (Artifact, ImageArtifact, VideoArtifact, AudioArtifact)

**Verification:**
- Type checking passed
- Linting passed
- Code style matches existing modules