### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.0.2"
+version = "0.0.3"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"


### PR DESCRIPTION
Version bump for release v0.0.3

- Update version in pyproject.toml: 0.0.2 → 0.0.3
- Tag v0.0.3 has been created and publish workflow is running
- This PR merges the version bump to main for consistency