### PR TITLE
refactor: unify generate() and stream() methods to base Client class

### DIFF
--- a/src/celeste/artifacts.py
+++ b/src/celeste/artifacts.py
@@ -8,7 +8,15 @@ from celeste.mime_types import AudioMimeType, ImageMimeType, MimeType, VideoMime
 
 
 class Artifact(BaseModel):
-    """Base class for all media artifacts."""
+    """Base class for all media artifacts.
+
+    Artifacts can be represented in three ways:
+    - url: Remote HTTP/HTTPS URL (may expire, e.g., DALL-E URLs last 1 hour)
+    - data: In-memory bytes (for immediate use without download)
+    - path: Local filesystem path (for local providers or saved files)
+
+    Providers typically populate only one of these fields.
+    """
 
     url: str | None = None
     data: bytes | None = None

--- a/src/celeste/models.py
+++ b/src/celeste/models.py
@@ -14,6 +14,7 @@ class Model(BaseModel):
     display_name: str
     capabilities: set[Capability] = Field(default_factory=set)
     parameter_constraints: dict[str, Constraint] = Field(default_factory=dict)
+    streaming: bool = Field(default=False)
 
     @property
     def supported_parameters(self) -> set[str]:
@@ -51,6 +52,7 @@ def register_models(models: Model | list[Model], capability: Capability) -> None
                 display_name=model.display_name,
                 capabilities=set(),
                 parameter_constraints={},
+                streaming=model.streaming,
             ),
         )
 


### PR DESCRIPTION
## Summary

This PR unifies the `generate()` and `stream()` methods in the base `Client` class, reducing code duplication across providers and improving maintainability.

## Changes Made

### Core Architecture
- **Unified `generate()` method**: Moved common orchestration logic to base `Client` class
- **Unified `stream()` method**: Moved common streaming logic to base `Client` class
- **New abstract methods**: Added `_create_inputs()`, `_make_request()`, `_output_class()`, `_stream_class()`, `_make_stream_request()`
- **Model streaming field**: Added `streaming: bool` field to `Model` class to indicate per-model streaming support

### Files Changed
- `src/celeste/client.py`: Unified generate/stream methods, added abstract methods
- `src/celeste/models.py`: Added streaming field to Model class
- `src/celeste/artifacts.py`: Improved docstring for Artifact class
- `tests/unit_tests/test_client.py`: Updated ConcreteClient to implement new abstract methods

## Benefits

- **Reduced duplication**: Common logic centralized in base class
- **Consistency**: All providers follow the same pattern
- **Maintainability**: Changes to core logic only need to be made in one place
- **Type safety**: Better type narrowing with abstract methods