### PR TITLE
fix: use Google favicon service for OpenAI logo (403 Forbidden fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ No special cases. No separate libraries. **One consistent interface.**
 
 <img src="https://www.google.com/favicon.ico" width="32" height="32" alt="Google" title="Google">
 <img src="https://www.anthropic.com/favicon.ico" width="32" height="32" alt="Anthropic" title="Anthropic">
-<img src="https://www.openai.com/favicon.ico" width="32" height="32" alt="OpenAI" title="OpenAI">
+<img src="https://www.google.com/s2/favicons?domain=openai.com&sz=64" width="32" height="32" alt="OpenAI" title="OpenAI">
 <img src="https://mistral.ai/favicon.ico" width="32" height="32" alt="Mistral" title="Mistral">
 <img src="https://cohere.com/favicon.ico" width="32" height="32" alt="Cohere" title="Cohere">
 <img src="https://x.ai/favicon.ico" width="32" height="32" alt="xAI" title="xAI">


### PR DESCRIPTION
OpenAI's favicon.ico returns HTTP 403 Forbidden, causing rendering failures in READMEs. This PR replaces the direct OpenAI favicon URL with Google's favicon service which bypasses the restriction and provides better quality (sz=64).