### PR TITLE
chore: bump version to 0.0.4

### DIFF
--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "text-generation"
-version = "0.0.3"
+version = "0.0.4"
 description = "Type-safe text generation for Celeste AI. Unified interface for OpenAI, Anthropic, Google, Mistral, Cohere, and more"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.0.3"
+version = "0.0.4"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"


### PR DESCRIPTION
Bump version to 0.0.4 to prepare for release with text-generation package.

After merge, create tag v0.0.4 to trigger publish workflow.