### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "text-generation"
-version = "0.0.3"
+version = "0.1.0"
 description = "Type-safe text generation for Celeste AI. Unified interface for OpenAI, Anthropic, Google, Mistral, Cohere, and more"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.0.3"
+version = "0.1.0"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"


### PR DESCRIPTION
## Version Bump: 0.0.3 → 0.1.0

This is a **minor version bump** following SemVer best practices, as this release adds a new feature/capability:

### What's New
- ✨ **Text Generation Package**: Complete text generation capability with support for:
  - OpenAI (GPT-3.5, GPT-4)
  - Anthropic (Claude)
  - Google (Gemini)
  - Mistral
  - Cohere
- 🧪 **Integration Tests**: Parametrized integration tests demonstrating unified API across all providers
- 🔧 **CI/CD**: Integration tests run automatically before release

### SemVer Rationale
- **MINOR** version bump (0.0.x → 0.1.0) because we're adding new functionality (text-generation capability)
- During initial development (0.y.z), MINOR version increments indicate new features
- PATCH version (0.0.x) would be for bug fixes only

### Next Steps
After merge:
1. Create tag: `git tag v0.1.0`
2. Push tag: `git push origin v0.1.0`
3. This will trigger the publish workflow to release to PyPI