### PR TITLE
fix: use integration-tests environment for API keys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,8 @@ jobs:
   integration-test:
     needs: [validate-release, run-ci]
     runs-on: ubuntu-latest
+    environment:
+      name: integration-tests
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

Integration tests were failing because the workflow was trying to use repository-level secrets, but the API keys were added to the `integration-tests` environment.

## Solution

Add `environment: name: integration-tests` to the `integration-test` job so it uses the environment secrets.

## Changes

- Added `environment:` specification to `integration-test` job
- Secrets will now be pulled from the `integration-tests` environment

Fixes integration test failures due to missing API keys.