### PR TITLE
Configure celeste-text-generation for PyPI publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup-python-uv
-      - run: uv build
+      - run: uv build --all-packages
       - run: |
           uv pip install twine
           uv run twine check dist/*

--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "text-generation"
+name = "celeste-text-generation"
 version = "0.1.0"
 description = "Type-safe text generation for Celeste AI. Unified interface for OpenAI, Anthropic, Google, Mistral, Cohere, and more"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ Documentation = "https://withceleste.ai/docs"
 Repository = "https://github.com/withceleste/celeste-python"
 Issues = "https://github.com/withceleste/celeste-python/issues"
 
+[project.optional-dependencies]
+text-generation = ["celeste-text-generation>=0.1.0"]
+all = ["celeste-text-generation>=0.1.0"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",
@@ -48,6 +52,9 @@ dev = [
 
 [tool.uv.workspace]
 members = ["packages/*"]
+
+[tool.uv.sources]
+celeste-text-generation = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
This PR configures the `celeste-text-generation` package for PyPI publication:

- Renames package from `text-generation` to `celeste-text-generation` to avoid PyPI name conflict
- Updates optional dependencies in root `pyproject.toml` to reference `celeste-text-generation`
- Adds workspace source configuration so `uv` knows it's a workspace package
- Updates publish workflow to build all workspace packages using `--all-packages` flag

When a tag is pushed, both `celeste-ai` and `celeste-text-generation` will be built and published to PyPI.