### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.1.0"
+version = "0.1.1"
 description = "Type-safe text generation for Celeste AI. Unified interface for OpenAI, Anthropic, Google, Mistral, Cohere, and more"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.1.0"
+version = "0.1.1"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"


### PR DESCRIPTION
Bump version to 0.1.1 to include optional dependencies configuration in published package.

This version will include:
- Optional dependencies for `text-generation` and `all` extras
- Updated workflow to build all workspace packages
- Package renamed to `celeste-text-generation`

After merging, the tag `v0.1.1` will trigger the publish workflow.