### PR TITLE
fix: preserve finish_reason in streaming final chunk

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/__init__.py
@@ -18,6 +18,8 @@ def register_package() -> None:
 
 # Import after register_package is defined to avoid circular imports
 from celeste_text_generation.io import (  # noqa: E402
+    TextGenerationChunk,
+    TextGenerationFinishReason,
     TextGenerationInput,
     TextGenerationOutput,
     TextGenerationUsage,
@@ -25,6 +27,8 @@ from celeste_text_generation.io import (  # noqa: E402
 from celeste_text_generation.streaming import TextGenerationStream  # noqa: E402
 
 __all__ = [
+    "TextGenerationChunk",
+    "TextGenerationFinishReason",
     "TextGenerationInput",
     "TextGenerationOutput",
     "TextGenerationStream",

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/streaming.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/streaming.py
@@ -38,6 +38,7 @@ class AnthropicTextGenerationStream(TextGenerationStream):
         self._tool_use_blocks: list[dict[str, Any]] = []
         self._current_tool_use: dict[str, Any] | None = None
         self._current_tool_use_partial_json: str = ""
+        self._last_finish_reason: TextGenerationFinishReason | None = None
 
     def _parse_chunk(self, event: dict[str, Any]) -> Chunk | None:
         """Parse SSE event into Chunk."""
@@ -208,6 +209,7 @@ class AnthropicTextGenerationStream(TextGenerationStream):
             finish_reason: TextGenerationFinishReason | None = None
             if stop_reason is not None:
                 finish_reason = TextGenerationFinishReason(reason=stop_reason)
+                self._last_finish_reason = finish_reason
 
             usage = self._parse_usage_from_event(event)
 
@@ -223,7 +225,7 @@ class AnthropicTextGenerationStream(TextGenerationStream):
 
             return TextGenerationChunk(
                 content="",
-                finish_reason=None,
+                finish_reason=self._last_finish_reason,
                 usage=usage,
             )
 


### PR DESCRIPTION
Preserves finish_reason in the final empty chunk of streaming responses.

**Changes:**
- Track `_last_finish_reason` in `AnthropicTextGenerationStream`
- Use `_last_finish_reason` instead of `None` in final empty chunk
- Export `TextGenerationChunk` and `TextGenerationFinishReason` from package

**Why:**
Previously, the final chunk always had `finish_reason=None` even when the stream completed with a stop reason. This fix ensures the finish_reason is preserved and available in the final chunk.