### PR TITLE
chore: bump version to 0.2.2 and add image-intelligence optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.2.1"
+version = "0.2.2"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -35,7 +35,12 @@ Issues = "https://github.com/withceleste/celeste-python/issues"
 [project.optional-dependencies]
 text-generation = ["celeste-text-generation>=0.2.1"]
 image-generation = ["celeste-image-generation>=0.2.1"]
-all = ["celeste-text-generation>=0.2.1", "celeste-image-generation>=0.2.1"]
+image-intelligence = ["celeste-image-intelligence>=0.2.1"]
+all = [
+    "celeste-text-generation>=0.2.1",
+    "celeste-image-generation>=0.2.1",
+    "celeste-image-intelligence>=0.2.1",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Bump version to 0.2.2 and add celeste-image-intelligence as an optional dependency