### PR TITLE
feat: add GPT-5.1 model support

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
@@ -88,6 +88,22 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="gpt-5.1-codex",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.1 Codex",
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextGenerationParameter.THINKING_BUDGET: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
+            TextGenerationParameter.VERBOSITY: Choice(
+                options=["low", "medium", "high"]
+            ),
+            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
         id="gpt-5-mini",
         provider=Provider.OPENAI,
         display_name="GPT-5 Mini",


### PR DESCRIPTION
Add GPT-5.1 and GPT-5.1 Codex models to OpenAI text-generation provider.

## Changes
- Added GPT-5.1 model with:
  - Max tokens: 128,000
  - Thinking budget: minimal, low, medium, high
  - Verbosity: low, medium, high
  - Output schema support
  - Streaming support

- Added GPT-5.1 Codex model with:
  - Max tokens: 128,000
  - Thinking budget: minimal, low, medium, high
  - Verbosity: low, medium, high
  - Output schema support
  - Streaming support

GPT-5.1 is OpenAI's flagship model for coding and agentic tasks with configurable reasoning effort.