### PR TITLE
refactor: remove redundant StrEnum type annotations from ParameterMapper

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/parameters.py
@@ -1,7 +1,6 @@
 """Anthropic parameter mappers."""
 
 import json
-from enum import StrEnum
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
@@ -15,7 +14,7 @@ from celeste_text_generation.parameters import TextGenerationParameter
 class ThinkingBudgetMapper(ParameterMapper):
     """Map thinking_budget parameter to Anthropic thinking.budget_tokens."""
 
-    name: StrEnum = TextGenerationParameter.THINKING_BUDGET
+    name = TextGenerationParameter.THINKING_BUDGET
 
     def map(
         self,
@@ -64,7 +63,7 @@ class ThinkingBudgetMapper(ParameterMapper):
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to Anthropic native structured outputs (output_format)."""
 
-    name: StrEnum = TextGenerationParameter.OUTPUT_SCHEMA
+    name = TextGenerationParameter.OUTPUT_SCHEMA
 
     def map(
         self,

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/parameters.py
@@ -1,7 +1,6 @@
 """Cohere parameter mappers."""
 
 import json
-from enum import StrEnum
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
@@ -15,7 +14,7 @@ from celeste_text_generation.parameters import TextGenerationParameter
 class TemperatureMapper(ParameterMapper):
     """Map temperature parameter to Cohere temperature field."""
 
-    name: StrEnum = Parameter.TEMPERATURE
+    name = Parameter.TEMPERATURE
 
     def map(
         self,
@@ -35,7 +34,7 @@ class TemperatureMapper(ParameterMapper):
 class MaxTokensMapper(ParameterMapper):
     """Map max_tokens parameter to Cohere max_tokens field."""
 
-    name: StrEnum = Parameter.MAX_TOKENS
+    name = Parameter.MAX_TOKENS
 
     def map(
         self,
@@ -55,7 +54,7 @@ class MaxTokensMapper(ParameterMapper):
 class ThinkingBudgetMapper(ParameterMapper):
     """Map thinking_budget parameter to Cohere thinking parameter."""
 
-    name: StrEnum = TextGenerationParameter.THINKING_BUDGET
+    name = TextGenerationParameter.THINKING_BUDGET
 
     def map(
         self,
@@ -91,7 +90,7 @@ class ThinkingBudgetMapper(ParameterMapper):
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to Cohere response_format."""
 
-    name: StrEnum = TextGenerationParameter.OUTPUT_SCHEMA
+    name = TextGenerationParameter.OUTPUT_SCHEMA
 
     def map(
         self,

--- a/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
@@ -1,6 +1,5 @@
 """Google parameter mappers."""
 
-from enum import StrEnum
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
@@ -15,7 +14,7 @@ from celeste_text_generation.parameters import TextGenerationParameter
 class TemperatureMapper(ParameterMapper):
     """Map temperature parameter to Google generationConfig."""
 
-    name: StrEnum = Parameter.TEMPERATURE
+    name = Parameter.TEMPERATURE
 
     def map(
         self,
@@ -35,7 +34,7 @@ class TemperatureMapper(ParameterMapper):
 class MaxTokensMapper(ParameterMapper):
     """Map max_tokens parameter to Google generationConfig.maxOutputTokens."""
 
-    name: StrEnum = Parameter.MAX_TOKENS
+    name = Parameter.MAX_TOKENS
 
     def map(
         self,
@@ -55,7 +54,7 @@ class MaxTokensMapper(ParameterMapper):
 class ThinkingBudgetMapper(ParameterMapper):
     """Map thinking_budget parameter to Google generationConfig.thinkingConfig.thinkingBudget."""
 
-    name: StrEnum = TextGenerationParameter.THINKING_BUDGET
+    name = TextGenerationParameter.THINKING_BUDGET
 
     def map(
         self,
@@ -77,7 +76,7 @@ class ThinkingBudgetMapper(ParameterMapper):
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to Google generationConfig.responseSchema."""
 
-    name: StrEnum = TextGenerationParameter.OUTPUT_SCHEMA
+    name = TextGenerationParameter.OUTPUT_SCHEMA
 
     def map(
         self,

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/parameters.py
@@ -1,6 +1,5 @@
 """Mistral parameter mappers."""
 
-from enum import StrEnum
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
@@ -92,7 +91,7 @@ class ThinkingBudgetMapper(ParameterMapper):
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to Mistral response_format."""
 
-    name: StrEnum = TextGenerationParameter.OUTPUT_SCHEMA
+    name = TextGenerationParameter.OUTPUT_SCHEMA
 
     def map(
         self,

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/parameters.py
@@ -1,7 +1,6 @@
 """OpenAI parameter mappers."""
 
 import json
-from enum import StrEnum
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
@@ -15,7 +14,7 @@ from celeste_text_generation.parameters import TextGenerationParameter
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to OpenAI text.format."""
 
-    name: StrEnum = TextGenerationParameter.OUTPUT_SCHEMA
+    name = TextGenerationParameter.OUTPUT_SCHEMA
 
     def map(
         self,
@@ -146,7 +145,7 @@ class OutputSchemaMapper(ParameterMapper):
 class TemperatureMapper(ParameterMapper):
     """Map temperature parameter to OpenAI temperature field."""
 
-    name: StrEnum = Parameter.TEMPERATURE
+    name = Parameter.TEMPERATURE
 
     def map(
         self,
@@ -166,7 +165,7 @@ class TemperatureMapper(ParameterMapper):
 class MaxTokensMapper(ParameterMapper):
     """Map max_tokens parameter to OpenAI max_output_tokens field."""
 
-    name: StrEnum = Parameter.MAX_TOKENS
+    name = Parameter.MAX_TOKENS
 
     def map(
         self,
@@ -186,7 +185,7 @@ class MaxTokensMapper(ParameterMapper):
 class ThinkingBudgetMapper(ParameterMapper):
     """Map thinking_budget parameter to OpenAI reasoning.effort field."""
 
-    name: StrEnum = TextGenerationParameter.THINKING_BUDGET
+    name = TextGenerationParameter.THINKING_BUDGET
 
     def map(
         self,
@@ -206,7 +205,7 @@ class ThinkingBudgetMapper(ParameterMapper):
 class VerbosityMapper(ParameterMapper):
     """Map verbosity parameter to OpenAI text.verbosity field."""
 
-    name: StrEnum = TextGenerationParameter.VERBOSITY
+    name = TextGenerationParameter.VERBOSITY
 
     def map(
         self,


### PR DESCRIPTION
Remove redundant `: StrEnum` type annotations from `name` attributes in ParameterMapper subclasses across text-generation providers. The base class `ParameterMapper` already declares `name: StrEnum` as an abstract attribute, making the explicit annotation in subclasses redundant.

This change follows DRY (Don't Repeat Yourself) principles and Python typing best practices. Type checkers can correctly infer the type from:
1. The base class declaration (`ParameterMapper.name: StrEnum`)
2. The enum value's type (`Parameter.TEMPERATURE` is already `StrEnum`)

Also removes unused `from enum import StrEnum` imports where no longer needed.

Affected providers:
- Anthropic
- Cohere
- Google
- Mistral
- OpenAI