### PR TITLE
Standardize provider docstrings with capability suffixes

### DIFF
--- a/packages/image-generation/src/celeste_image_generation/providers/bytedance/__init__.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/bytedance/__init__.py
@@ -1,4 +1,4 @@
-"""ByteDance provider."""
+"""ByteDance provider for image generation."""
 
 from .client import ByteDanceImageGenerationClient
 from .models import MODELS

--- a/packages/image-generation/src/celeste_image_generation/providers/bytedance/client.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/bytedance/client.py
@@ -1,4 +1,4 @@
-"""ByteDance client implementation."""
+"""ByteDance client implementation for image generation."""
 
 import base64
 from collections.abc import AsyncIterator

--- a/packages/image-generation/src/celeste_image_generation/providers/bytedance/config.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/bytedance/config.py
@@ -1,4 +1,4 @@
-"""ByteDance provider configuration."""
+"""ByteDance provider configuration for image generation."""
 
 # HTTP Configuration
 BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"

--- a/packages/image-generation/src/celeste_image_generation/providers/bytedance/models.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/bytedance/models.py
@@ -1,4 +1,4 @@
-"""ByteDance models."""
+"""ByteDance models for image generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Bool, Choice

--- a/packages/image-generation/src/celeste_image_generation/providers/bytedance/parameters.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/bytedance/parameters.py
@@ -1,4 +1,4 @@
-"""ByteDance parameter mappers."""
+"""ByteDance parameter mappers for image generation."""
 
 from typing import Any
 

--- a/packages/image-generation/src/celeste_image_generation/providers/google/__init__.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/__init__.py
@@ -1,4 +1,4 @@
-"""Google provider."""
+"""Google provider for image generation."""
 
 from .client import GoogleImageGenerationClient
 from .models import MODELS

--- a/packages/image-generation/src/celeste_image_generation/providers/google/client.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/client.py
@@ -1,4 +1,4 @@
-"""Google client implementation."""
+"""Google client implementation for image generation."""
 
 import base64
 from typing import Any, Unpack

--- a/packages/image-generation/src/celeste_image_generation/providers/google/config.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/config.py
@@ -1,4 +1,4 @@
-"""Google provider configuration."""
+"""Google provider configuration for image generation."""
 
 # HTTP Configuration
 BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"

--- a/packages/image-generation/src/celeste_image_generation/providers/google/models.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/models.py
@@ -1,4 +1,4 @@
-"""Google models."""
+"""Google models for image generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Choice

--- a/packages/image-generation/src/celeste_image_generation/providers/google/parameters.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/parameters.py
@@ -1,4 +1,4 @@
-"""Google parameter mappers."""
+"""Google parameter mappers for image generation."""
 
 from typing import Any
 

--- a/packages/image-generation/src/celeste_image_generation/providers/openai/__init__.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/openai/__init__.py
@@ -1,4 +1,4 @@
-"""OpenAI provider."""
+"""OpenAI provider for image generation."""
 
 from .client import OpenAIImageGenerationClient
 from .models import MODELS

--- a/packages/image-generation/src/celeste_image_generation/providers/openai/client.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/openai/client.py
@@ -1,4 +1,4 @@
-"""OpenAI client implementation."""
+"""OpenAI client implementation for image generation."""
 
 import base64
 from collections.abc import AsyncIterator

--- a/packages/image-generation/src/celeste_image_generation/providers/openai/config.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/openai/config.py
@@ -1,4 +1,4 @@
-"""OpenAI provider configuration."""
+"""OpenAI provider configuration for image generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.openai.com"

--- a/packages/image-generation/src/celeste_image_generation/providers/openai/models.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/openai/models.py
@@ -1,4 +1,4 @@
-"""OpenAI models."""
+"""OpenAI models for image generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Choice, Range

--- a/packages/image-generation/src/celeste_image_generation/providers/openai/parameters.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/openai/parameters.py
@@ -1,4 +1,4 @@
-"""OpenAI parameter mappers."""
+"""OpenAI parameter mappers for image generation."""
 
 from typing import Any
 

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/__init__.py
@@ -1,4 +1,4 @@
-"""Anthropic provider."""
+"""Anthropic provider for text generation."""
 
 from .client import AnthropicTextGenerationClient
 from .models import MODELS

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/client.py
@@ -1,4 +1,4 @@
-"""Anthropic client implementation."""
+"""Anthropic client implementation for text generation."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/config.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/config.py
@@ -1,4 +1,4 @@
-"""Anthropic provider configuration."""
+"""Anthropic provider configuration for text generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.anthropic.com"

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/models.py
@@ -1,4 +1,4 @@
-"""Anthropic models."""
+"""Anthropic models for text generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Range, Schema

--- a/packages/text-generation/src/celeste_text_generation/providers/anthropic/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/anthropic/parameters.py
@@ -1,4 +1,4 @@
-"""Anthropic parameter mappers."""
+"""Anthropic parameter mappers for text generation."""
 
 import json
 from typing import Any, get_args, get_origin

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/__init__.py
@@ -1,4 +1,4 @@
-"""Cohere provider."""
+"""Cohere provider for text generation."""
 
 from .client import CohereTextGenerationClient
 from .models import MODELS

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/client.py
@@ -1,4 +1,4 @@
-"""Cohere client implementation."""
+"""Cohere client implementation for text generation."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/config.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/config.py
@@ -1,4 +1,4 @@
-"""Cohere provider configuration."""
+"""Cohere provider configuration for text generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.cohere.com"

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/models.py
@@ -1,4 +1,4 @@
-"""Cohere models."""
+"""Cohere models for text generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Range, Schema

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/parameters.py
@@ -1,4 +1,4 @@
-"""Cohere parameter mappers."""
+"""Cohere parameter mappers for text generation."""
 
 import json
 from typing import Any, get_args, get_origin

--- a/packages/text-generation/src/celeste_text_generation/providers/google/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/__init__.py
@@ -1,4 +1,4 @@
-"""Google provider."""
+"""Google provider for text generation."""
 
 from .client import GoogleTextGenerationClient
 from .models import MODELS

--- a/packages/text-generation/src/celeste_text_generation/providers/google/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/client.py
@@ -1,4 +1,4 @@
-"""Google client implementation."""
+"""Google client implementation for text generation."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack

--- a/packages/text-generation/src/celeste_text_generation/providers/google/config.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/config.py
@@ -1,4 +1,4 @@
-"""Google provider configuration."""
+"""Google provider configuration for text generation."""
 
 # HTTP Configuration
 BASE_URL = "https://generativelanguage.googleapis.com"

--- a/packages/text-generation/src/celeste_text_generation/providers/google/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/models.py
@@ -1,4 +1,4 @@
-"""Google models."""
+"""Google models for text generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Range, Schema

--- a/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
@@ -1,4 +1,4 @@
-"""Google parameter mappers."""
+"""Google parameter mappers for text generation."""
 
 from typing import Any, get_args, get_origin
 

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/__init__.py
@@ -1,4 +1,4 @@
-"""Mistral provider."""
+"""Mistral provider for text generation."""
 
 from .client import MistralTextGenerationClient
 from .models import MODELS

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/client.py
@@ -1,4 +1,4 @@
-"""Mistral client implementation."""
+"""Mistral client implementation for text generation."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/config.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/config.py
@@ -1,4 +1,4 @@
-"""Mistral provider configuration."""
+"""Mistral provider configuration for text generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.mistral.ai"

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/models.py
@@ -1,4 +1,4 @@
-"""Mistral models."""
+"""Mistral models for text generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Range, Schema

--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/parameters.py
@@ -1,4 +1,4 @@
-"""Mistral parameter mappers."""
+"""Mistral parameter mappers for text generation."""
 
 from typing import Any, get_args, get_origin
 

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/__init__.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/__init__.py
@@ -1,4 +1,4 @@
-"""OpenAI provider."""
+"""OpenAI provider for text generation."""
 
 from .client import OpenAITextGenerationClient
 from .models import MODELS

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/client.py
@@ -1,4 +1,4 @@
-"""OpenAI client implementation."""
+"""OpenAI client implementation for text generation."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/config.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/config.py
@@ -1,4 +1,4 @@
-"""OpenAI provider configuration."""
+"""OpenAI provider configuration for text generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.openai.com"

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
@@ -1,4 +1,4 @@
-"""OpenAI models."""
+"""OpenAI models for text generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Choice, Range, Schema

--- a/packages/text-generation/src/celeste_text_generation/providers/openai/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/parameters.py
@@ -1,4 +1,4 @@
-"""OpenAI parameter mappers."""
+"""OpenAI parameter mappers for text generation."""
 
 import json
 from typing import Any, get_args, get_origin

--- a/packages/video-generation/src/celeste_video_generation/client.py
+++ b/packages/video-generation/src/celeste_video_generation/client.py
@@ -7,6 +7,7 @@ import httpx
 
 from celeste.artifacts import VideoArtifact
 from celeste.client import Client
+from celeste.exceptions import ValidationError
 from celeste_video_generation.io import (
     VideoGenerationInput,
     VideoGenerationOutput,
@@ -37,11 +38,17 @@ class VideoGenerationClient(
         """Parse content from provider response."""
 
     def _create_inputs(
-        self,
-        prompt: str,
-        **parameters: Unpack[VideoGenerationParameters],
+        self, *args: str, **parameters: Unpack[VideoGenerationParameters]
     ) -> VideoGenerationInput:
         """Map positional arguments to Input type."""
+        if args:
+            return VideoGenerationInput(prompt=args[0])
+        prompt: str | None = parameters.get("prompt")
+        if prompt is None:
+            msg = (
+                "prompt is required (either as positional argument or keyword argument)"
+            )
+            raise ValidationError(msg)
         return VideoGenerationInput(prompt=prompt)
 
     @classmethod

--- a/packages/video-generation/src/celeste_video_generation/providers/bytedance/config.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/bytedance/config.py
@@ -1,4 +1,4 @@
-"""ByteDance provider configuration."""
+"""ByteDance provider configuration for video generation."""
 
 # HTTP Configuration
 BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"

--- a/packages/video-generation/src/celeste_video_generation/providers/bytedance/parameters.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/bytedance/parameters.py
@@ -1,4 +1,4 @@
-"""ByteDance parameter mappers."""
+"""ByteDance parameter mappers for video generation."""
 
 from typing import Any
 

--- a/packages/video-generation/src/celeste_video_generation/providers/google/config.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/google/config.py
@@ -1,4 +1,4 @@
-"""Google provider configuration."""
+"""Google provider configuration for video generation."""
 
 BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 GENERATE_ENDPOINT = "/models/{model_id}:predictLongRunning"

--- a/packages/video-generation/src/celeste_video_generation/providers/google/models.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/google/models.py
@@ -1,4 +1,4 @@
-"""Google models."""
+"""Google models for video generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Choice, ImageConstraint, ImagesConstraint

--- a/packages/video-generation/src/celeste_video_generation/providers/google/parameters.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/google/parameters.py
@@ -1,4 +1,4 @@
-"""Google parameter mappers."""
+"""Google parameter mappers for video generation."""
 
 from typing import Any
 

--- a/packages/video-generation/src/celeste_video_generation/providers/openai/client.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/openai/client.py
@@ -1,4 +1,4 @@
-"""OpenAI client implementation."""
+"""OpenAI client implementation for video generation."""
 
 import asyncio
 import base64

--- a/packages/video-generation/src/celeste_video_generation/providers/openai/config.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/openai/config.py
@@ -1,4 +1,4 @@
-"""OpenAI provider configuration."""
+"""OpenAI provider configuration for video generation."""
 
 # HTTP Configuration
 BASE_URL = "https://api.openai.com"

--- a/packages/video-generation/src/celeste_video_generation/providers/openai/models.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/openai/models.py
@@ -1,4 +1,4 @@
-"""OpenAI models."""
+"""OpenAI models for video generation."""
 
 from celeste import Model, Provider
 from celeste.constraints import Choice, ImageConstraint

--- a/packages/video-generation/src/celeste_video_generation/providers/openai/parameters.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/openai/parameters.py
@@ -1,4 +1,4 @@
-"""OpenAI parameter mappers."""
+"""OpenAI parameter mappers for video generation."""
 
 from typing import Any
 


### PR DESCRIPTION
## Summary

This PR standardizes all provider-related docstrings to consistently include capability suffixes, ensuring clarity when the same provider appears in multiple packages.

## Changes

- **Provider  files**: Updated to 
- **Provider  files**: Updated to 
- **Provider  files**: Updated to 
- **Provider  files**: Updated to 
- **Provider  files**: Updated to 
- **Google docstrings**: Removed "Gemini" references for consistency (since image generation uses both Imagen and Gemini)

## Files Changed

- 50 files updated across text-generation, image-generation, and video-generation packages
- All provider files now follow consistent docstring patterns

## Benefits

- Eliminates ambiguity when providers appear in multiple packages
- Makes it immediately clear which capability each provider file serves
- Consistent naming convention across the entire codebase