### PR TITLE
Bump versions to 0.2.8

### DIFF
--- a/packages/image-generation/pyproject.toml
+++ b/packages/image-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-image-generation"
-version = "0.2.7"
+version = "0.2.8"
 description = "Image generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.2.7"
+version = "0.2.8"
 description = "Text generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/video-generation/pyproject.toml
+++ b/packages/video-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-video-generation"
-version = "0.2.7"
+version = "0.2.8"
 description = "Video generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.2.7"
+version = "0.2.8"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -33,17 +33,13 @@ Repository = "https://github.com/withceleste/celeste-python"
 Issues = "https://github.com/withceleste/celeste-python/issues"
 
 [project.optional-dependencies]
-text-generation = ["celeste-text-generation>=0.2.7"]
-image-generation = ["celeste-image-generation>=0.2.7"]
-video-generation = ["celeste-video-generation>=0.2.7"]
-image-intelligence = ["celeste-image-intelligence>=0.2.1"]
-speech-generation = ["celeste-speech-generation>=0.2.3"]
+text-generation = ["celeste-text-generation>=0.2.8"]
+image-generation = ["celeste-image-generation>=0.2.8"]
+video-generation = ["celeste-video-generation>=0.2.8"]
 all = [
-    "celeste-text-generation>=0.2.7",
-    "celeste-image-generation>=0.2.7",
-    "celeste-video-generation>=0.2.7",
-    "celeste-image-intelligence>=0.2.1",
-    "celeste-speech-generation>=0.2.3",
+    "celeste-text-generation>=0.2.8",
+    "celeste-image-generation>=0.2.8",
+    "celeste-video-generation>=0.2.8",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Bump all package versions from 0.2.7 to 0.2.8 to trigger new publish.

## Changes
- Bump celeste-ai to 0.2.8
- Bump celeste-text-generation to 0.2.8
- Bump celeste-image-generation to 0.2.8
- Bump celeste-video-generation to 0.2.8
- Update optional-dependencies version constraints to >=0.2.8

## Notes
- speech-generation package remains at 0.2.7 and is not included in this release