### PR TITLE
feat: Add Gemini 3 Pro support with thinking_level parameter

### DIFF
--- a/packages/text-generation/pyproject.toml
+++ b/packages/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.2.8"
+version = "0.2.9"
 description = "Text generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/text-generation/src/celeste_text_generation/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/parameters.py
@@ -11,6 +11,7 @@ class TextGenerationParameter(StrEnum):
     """Unified parameter names for text generation capability."""
 
     THINKING_BUDGET = "thinking_budget"
+    THINKING_LEVEL = "thinking_level"
     OUTPUT_SCHEMA = "output_schema"
     VERBOSITY = "verbosity"
 
@@ -21,5 +22,6 @@ class TextGenerationParameters(Parameters):
     temperature: float | None
     max_tokens: int | None
     thinking_budget: int | None
+    thinking_level: str | None
     verbosity: str | None
     output_schema: type[BaseModel] | None

--- a/packages/text-generation/src/celeste_text_generation/providers/google/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/models.py
@@ -1,7 +1,7 @@
 """Google models for text generation."""
 
 from celeste import Model, Provider
-from celeste.constraints import Range, Schema
+from celeste.constraints import Choice, Range, Schema
 from celeste.core import Parameter
 from celeste_text_generation.parameters import TextGenerationParameter
 
@@ -13,7 +13,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=8192),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
             # Flash: allows -1 (dynamic), 0 (disable), or >= 0
             TextGenerationParameter.THINKING_BUDGET: Range(min=-1, max=24576),
             TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
@@ -26,7 +26,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=8192),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
             # Flash Lite: allows -1 (dynamic), 0 (disable), or >= 512
             TextGenerationParameter.THINKING_BUDGET: Range(
                 min=512, max=24576, special_values=[-1, 0]
@@ -41,11 +41,23 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=8192),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
             # Pro: allows -1 (dynamic) or >= 128 (cannot use 0)
             TextGenerationParameter.THINKING_BUDGET: Range(
                 min=128, max=32768, special_values=[-1]
             ),
+            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
+        id="gemini-3-pro-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3 Pro",
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextGenerationParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
             TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
         },
     ),

--- a/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/google/parameters.py
@@ -73,6 +73,28 @@ class ThinkingBudgetMapper(ParameterMapper):
         return request
 
 
+class ThinkingLevelMapper(ParameterMapper):
+    """Map thinking_level parameter to Google generationConfig.thinkingConfig.thinkingLevel."""
+
+    name = TextGenerationParameter.THINKING_LEVEL
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform thinking_level into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        request.setdefault("generationConfig", {}).setdefault("thinkingConfig", {})[
+            "thinkingLevel"
+        ] = validated_value
+        return request
+
+
 class OutputSchemaMapper(ParameterMapper):
     """Map output_schema parameter to Google generationConfig.responseSchema."""
 
@@ -220,6 +242,7 @@ GOOGLE_PARAMETER_MAPPERS: list[ParameterMapper] = [
     TemperatureMapper(),
     MaxTokensMapper(),
     ThinkingBudgetMapper(),
+    ThinkingLevelMapper(),
     OutputSchemaMapper(),
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.2.8"
+version = "0.2.9"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -33,11 +33,11 @@ Repository = "https://github.com/withceleste/celeste-python"
 Issues = "https://github.com/withceleste/celeste-python/issues"
 
 [project.optional-dependencies]
-text-generation = ["celeste-text-generation>=0.2.8"]
+text-generation = ["celeste-text-generation>=0.2.9"]
 image-generation = ["celeste-image-generation>=0.2.8"]
 video-generation = ["celeste-video-generation>=0.2.8"]
 all = [
-    "celeste-text-generation>=0.2.8",
+    "celeste-text-generation>=0.2.9",
     "celeste-image-generation>=0.2.8",
     "celeste-video-generation>=0.2.8",
 ]


### PR DESCRIPTION
## Changes

- Add `gemini-3-pro-preview` model with 65,536 output token limit
- Add `thinking_level` parameter (low/high) for Gemini 3 Pro
- Update all Gemini 2.5 models to correct 65,536 output token limits
  - gemini-2.5-flash: 8,192 → 65,536
  - gemini-2.5-flash-lite: 8,192 → 65,536
  - gemini-2.5-pro: 8,192 → 65,536
- Add `ThinkingLevelMapper` for Google provider
- Bump version to 0.2.9

## Testing

All pre-commit hooks passed:
- ✅ Type checking with mypy
- ✅ Security check with Bandit
- ✅ Tests with coverage

## References

- [Gemini 3 Documentation](https://ai.google.dev/gemini-api/docs/gemini-3)
- [Gemini Models Page](https://ai.google.dev/gemini-api/docs/models)