### PR TITLE
Add Gemini 3 Pro Image Preview model support (v0.2.10)

### DIFF
--- a/packages/image-generation/pyproject.toml
+++ b/packages/image-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-image-generation"
-version = "0.2.8"
+version = "0.2.9"
 description = "Image generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/image-generation/src/celeste_image_generation/io.py
+++ b/packages/image-generation/src/celeste_image_generation/io.py
@@ -29,6 +29,7 @@ class ImageGenerationUsage(Usage):
     total_tokens: int | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    reasoning_tokens: int | None = None
     generated_images: int | None = None
 
 

--- a/packages/image-generation/src/celeste_image_generation/providers/google/gemini_api.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/gemini_api.py
@@ -70,6 +70,7 @@ class GeminiImageAPIAdapter:
             input_tokens=usage_metadata.get("promptTokenCount"),
             output_tokens=usage_metadata.get("candidatesTokenCount"),
             total_tokens=usage_metadata.get("totalTokenCount"),
+            reasoning_tokens=usage_metadata.get("thoughtsTokenCount"),
             generated_images=len(candidates),
         )
 

--- a/packages/image-generation/src/celeste_image_generation/providers/google/models.py
+++ b/packages/image-generation/src/celeste_image_generation/providers/google/models.py
@@ -77,6 +77,28 @@ GEMINI_MODELS: list[Model] = [
             ),
         },
     ),
+    Model(
+        id="gemini-3-pro-image-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3 Pro Image (Preview)",
+        parameter_constraints={
+            ImageGenerationParameter.ASPECT_RATIO: Choice(
+                options=[
+                    "1:1",
+                    "2:3",
+                    "3:2",
+                    "3:4",
+                    "4:3",
+                    "4:5",
+                    "5:4",
+                    "9:16",
+                    "16:9",
+                    "21:9",
+                ]
+            ),
+            ImageGenerationParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
+        },
+    ),
 ]
 
 # Unified model list for registration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.2.9"
+version = "0.2.10"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -34,11 +34,11 @@ Issues = "https://github.com/withceleste/celeste-python/issues"
 
 [project.optional-dependencies]
 text-generation = ["celeste-text-generation>=0.2.9"]
-image-generation = ["celeste-image-generation>=0.2.8"]
+image-generation = ["celeste-image-generation>=0.2.9"]
 video-generation = ["celeste-video-generation>=0.2.8"]
 all = [
     "celeste-text-generation>=0.2.9",
-    "celeste-image-generation>=0.2.8",
+    "celeste-image-generation>=0.2.9",
     "celeste-video-generation>=0.2.8",
 ]
 


### PR DESCRIPTION
## Overview
This PR adds support for Gemini 3 Pro Image Preview model for image generation and bumps versions to trigger publishing.

## Changes
- ✅ Added `gemini-3-pro-image-preview` model with aspect_ratio and quality parameters
- ✅ Support for high-resolution outputs (1K, 2K, 4K) via unified quality parameter
- ✅ Added `reasoning_tokens` field to `ImageGenerationUsage` for thoughts/reasoning token counts
- ✅ Updated `GeminiImageAPIAdapter` to parse `thoughtsTokenCount` from API response

## Version Bumps
- **celeste-image-generation**: 0.2.8 → 0.2.9
- **celeste-ai**: 0.2.9 → 0.2.10
- Updated dependency references in main pyproject.toml

## Model Details
- **Model ID**: `gemini-3-pro-image-preview`
- **Display Name**: Gemini 3 Pro Image (Preview)
- **Aspect Ratios**: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9
- **Quality Options**: 1K, 2K, 4K

## Publishing
This PR includes version bumps that will trigger publishing when merged and tagged.