### PR TITLE
ci: add XAI_API_KEY to integration test workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,7 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           BYTEDANCE_API_KEY: ${{ secrets.BYTEDANCE_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         run: make integration-test
 
   build:


### PR DESCRIPTION
Add XAI_API_KEY environment variable to the integration-test job in publish.yml workflow to support XAI provider integration tests.