### PR TITLE
fix: Cohere usage parsing and remove deprecated models

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/client.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/client.py
@@ -41,10 +41,10 @@ class CohereTextGenerationClient(TextGenerationClient):
 
     def _parse_usage(self, response_data: dict[str, Any]) -> TextGenerationUsage:
         """Parse usage from response."""
-        meta = response_data.get("meta", {})
+        usage_data = response_data.get("usage", {})
 
-        billed_units = meta.get("billed_units", {})
-        tokens = meta.get("tokens", {})
+        billed_units = usage_data.get("billed_units", {})
+        tokens = usage_data.get("tokens", {})
 
         input_tokens = billed_units.get("input_tokens")
         output_tokens = billed_units.get("output_tokens")
@@ -54,7 +54,7 @@ class CohereTextGenerationClient(TextGenerationClient):
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 total_tokens=tokens.get("total_tokens") if tokens else None,
-                cached_tokens=meta.get("cached_tokens"),
+                cached_tokens=usage_data.get("cached_tokens"),
             )
 
         return TextGenerationUsage()

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/models.py
@@ -19,31 +19,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="command-r-plus",
-        provider=Provider.COHERE,
-        display_name="Command R+",
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=4096, step=1),
-            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
-            # command-r-plus supports reasoning (optimized for complex reasoning)
-            TextGenerationParameter.THINKING_BUDGET: Range(min=-1, max=31000, step=1),
-        },
-    ),
-    Model(
-        id="command-r",
-        provider=Provider.COHERE,
-        display_name="Command R",
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=4096, step=1),
-            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
-            # thinking_budget: Support unclear, omit constraint for now
-        },
-    ),
-    Model(
         id="command-r7b-12-2024",
         provider=Provider.COHERE,
         display_name="Command R7B",

--- a/packages/text-generation/src/celeste_text_generation/providers/cohere/streaming.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/cohere/streaming.py
@@ -94,11 +94,11 @@ class CohereTextGenerationStream(TextGenerationStream):
                 else None
             )
 
-            meta = event.get("meta", {})
+            usage_data = event.get("usage", {})
             usage = None
-            if isinstance(meta, dict):
-                billed_units = meta.get("billed_units", {})
-                tokens = meta.get("tokens", {})
+            if isinstance(usage_data, dict):
+                billed_units = usage_data.get("billed_units", {})
+                tokens = usage_data.get("tokens", {})
 
                 input_tokens = billed_units.get("input_tokens")
                 output_tokens = billed_units.get("output_tokens")
@@ -108,7 +108,7 @@ class CohereTextGenerationStream(TextGenerationStream):
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         total_tokens=tokens.get("total_tokens") if tokens else None,
-                        cached_tokens=meta.get("cached_tokens"),
+                        cached_tokens=usage_data.get("cached_tokens"),
                     )
 
             return TextGenerationChunk(


### PR DESCRIPTION
## Changes

- **Fix usage parsing bug**: Changed from looking for `meta` field to `usage` field in Cohere API response
  - Fixes issue where `input_tokens`, `output_tokens`, and `total_tokens` were `None` even when data existed
  - Updated both non-streaming client and streaming stream-end event handler

- **Remove deprecated models**: Removed `command-r` and `command-r-plus` models that were deprecated by Cohere on September 15, 2025
  - These models are no longer available in the Cohere API
  - Users should use `command-a-03-2025` or `command-r7b-12-2024` instead

## Files Changed
- `packages/text-generation/src/celeste_text_generation/providers/cohere/client.py`
- `packages/text-generation/src/celeste_text_generation/providers/cohere/models.py`
- `packages/text-generation/src/celeste_text_generation/providers/cohere/streaming.py`