### PR TITLE
feat: add missing ElevenLabs models and voices

### DIFF
--- a/packages/speech-generation/pyproject.toml
+++ b/packages/speech-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-speech-generation"
-version = "0.2.8"
+version = "0.2.9"
 description = "Speech generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/speech-generation/src/celeste_speech_generation/providers/elevenlabs/models.py
+++ b/packages/speech-generation/src/celeste_speech_generation/providers/elevenlabs/models.py
@@ -9,9 +9,45 @@ from .voices import ELEVENLABS_VOICES
 
 MODELS: list[Model] = [
     Model(
+        id="eleven_v3",
+        provider=Provider.ELEVENLABS,
+        display_name="Eleven v3",
+        streaming=True,
+        parameter_constraints={
+            SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),
+            SpeechGenerationParameter.SPEED: Range(min=0.7, max=1.2),
+            SpeechGenerationParameter.RESPONSE_FORMAT: Choice(
+                options=[
+                    "mp3_44100_128",
+                    "pcm_22050_16",
+                    "pcm_24000_16",
+                    "pcm_44100_16",
+                ]
+            ),
+        },
+    ),
+    Model(
         id="eleven_multilingual_v2",
         provider=Provider.ELEVENLABS,
         display_name="Eleven Multilingual v2",
+        streaming=True,
+        parameter_constraints={
+            SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),
+            SpeechGenerationParameter.SPEED: Range(min=0.7, max=1.2),
+            SpeechGenerationParameter.RESPONSE_FORMAT: Choice(
+                options=[
+                    "mp3_44100_128",
+                    "pcm_22050_16",
+                    "pcm_24000_16",
+                    "pcm_44100_16",
+                ]
+            ),
+        },
+    ),
+    Model(
+        id="eleven_turbo_v2_5",
+        provider=Provider.ELEVENLABS,
+        display_name="Eleven Turbo v2.5",
         streaming=True,
         parameter_constraints={
             SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),
@@ -48,6 +84,42 @@ MODELS: list[Model] = [
         id="eleven_flash_v2_5",
         provider=Provider.ELEVENLABS,
         display_name="Eleven Flash v2.5",
+        streaming=True,
+        parameter_constraints={
+            SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),
+            SpeechGenerationParameter.SPEED: Range(min=0.7, max=1.2),
+            SpeechGenerationParameter.RESPONSE_FORMAT: Choice(
+                options=[
+                    "mp3_44100_128",
+                    "pcm_22050_16",
+                    "pcm_24000_16",
+                    "pcm_44100_16",
+                ]
+            ),
+        },
+    ),
+    Model(
+        id="eleven_flash_v2",
+        provider=Provider.ELEVENLABS,
+        display_name="Eleven Flash v2",
+        streaming=True,
+        parameter_constraints={
+            SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),
+            SpeechGenerationParameter.SPEED: Range(min=0.7, max=1.2),
+            SpeechGenerationParameter.RESPONSE_FORMAT: Choice(
+                options=[
+                    "mp3_44100_128",
+                    "pcm_22050_16",
+                    "pcm_24000_16",
+                    "pcm_44100_16",
+                ]
+            ),
+        },
+    ),
+    Model(
+        id="eleven_multilingual_v1",
+        provider=Provider.ELEVENLABS,
+        display_name="Eleven Multilingual v1",
         streaming=True,
         parameter_constraints={
             SpeechGenerationParameter.VOICE: VoiceConstraint(voices=ELEVENLABS_VOICES),

--- a/packages/speech-generation/src/celeste_speech_generation/providers/elevenlabs/voices.py
+++ b/packages/speech-generation/src/celeste_speech_generation/providers/elevenlabs/voices.py
@@ -23,6 +23,12 @@ ELEVENLABS_VOICES = [
         name="Laura",
         languages=set(),
     ),  # NEW - replaces Domi (ID confirmed from API)
+    Voice(
+        id="NOpBlnGInO9m6vDvFkFC",
+        provider=Provider.ELEVENLABS,
+        name="Spuds",
+        languages=set(),
+    ),  # Spuds (Grandpa Spuds Oxley)
     # TODO: Add Janet when available in API (replaces Rachel, Serena, Glinda)
     # TODO: Add Peter when available in API (replaces Elli, Fin)
     # TODO: Add Craig when available in API (replaces Josh, Jeremy)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.2.13"
+version = "0.2.14"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -36,12 +36,12 @@ Issues = "https://github.com/withceleste/celeste-python/issues"
 text-generation = ["celeste-text-generation>=0.2.10"]
 image-generation = ["celeste-image-generation>=0.2.9"]
 video-generation = ["celeste-video-generation>=0.2.8"]
-speech-generation = ["celeste-speech-generation>=0.2.8"]
+speech-generation = ["celeste-speech-generation>=0.2.9"]
 all = [
     "celeste-text-generation>=0.2.10",
     "celeste-image-generation>=0.2.9",
     "celeste-video-generation>=0.2.8",
-    "celeste-speech-generation>=0.2.8",
+    "celeste-speech-generation>=0.2.9",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Changes

### New Models
Added four missing ElevenLabs models:
- `eleven_v3` - Eleven v3 model
- `eleven_turbo_v2_5` - Eleven Turbo v2.5 model  
- `eleven_flash_v2` - Eleven Flash v2 model
- `eleven_multilingual_v1` - Eleven Multilingual v1 model

All models support:
- Voice selection from available voices
- Speed control (0.7-1.2)
- Multiple response formats (mp3_44100_128, pcm_22050_16, pcm_24000_16, pcm_44100_16)
- Streaming support

### New Voice
- Added `Spuds` voice (Grandpa Spuds Oxley) - ID: `NOpBlnGInO9m6vDvFkFC`

### Version Bumps
- `celeste-speech-generation`: 0.2.8 → 0.2.9
- `celeste-ai`: 0.2.13 → 0.2.14
- Updated dependency requirements in root `pyproject.toml`

## Testing
- All models follow the same parameter constraints pattern as existing ElevenLabs models
- Voice constraint updated to include new Spuds voice