### PR TITLE
feat: add GPT-5.2, GPT-5.2 Pro, and GPT-5.2 Instant models

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/openai/models.py
@@ -72,6 +72,45 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="gpt-5.2",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.2",
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextGenerationParameter.THINKING_BUDGET: Choice(
+                options=["minimal", "low", "medium", "high", "xhigh"]
+            ),
+            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
+        id="gpt-5.2-pro",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.2 Pro",
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextGenerationParameter.THINKING_BUDGET: Choice(
+                options=["minimal", "low", "medium", "high", "xhigh"]
+            ),
+            TextGenerationParameter.VERBOSITY: Choice(
+                options=["low", "medium", "high"]
+            ),
+            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
+        id="gpt-5.2-chat-latest",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.2 Instant",
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+        },
+    ),
+    Model(
         id="gpt-5.1",
         provider=Provider.OPENAI,
         display_name="GPT-5.1",


### PR DESCRIPTION
## Changes

- Added GPT-5.2 model with:
  - Max tokens: 128,000
  - Thinking budget: minimal, low, medium, high, xhigh
  - Output schema support
  - Streaming support

- Added GPT-5.2 Pro model with:
  - Max tokens: 128,000
  - Thinking budget: minimal, low, medium, high, xhigh
  - Verbosity: low, medium, high
  - Output schema support
  - Streaming support

- Added GPT-5.2 Instant (gpt-5.2-chat-latest) model with:
  - Max tokens: 128,000
  - Temperature: 0.0-2.0
  - Streaming support

GPT-5.2 models introduce enhanced reasoning capabilities with the new "xhigh" thinking budget option for maximum reasoning depth.

## Testing

All pre-commit hooks passed:
- Type checking with mypy
- Security check with Bandit
- Tests with coverage

## References

- [OpenAI GPT-5.2 Documentation](https://openai.com/index/introducing-gpt-5-2/)
- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)