### PR TITLE
feat: add Devstral 2 and Devstral Small 2 models

### DIFF
--- a/packages/text-generation/src/celeste_text_generation/providers/mistral/models.py
+++ b/packages/text-generation/src/celeste_text_generation/providers/mistral/models.py
@@ -9,7 +9,7 @@ MODELS: list[Model] = [
     Model(
         id="mistral-large-latest",
         provider=Provider.MISTRAL,
-        display_name="Mistral Large 3",
+        display_name="Mistral Large",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
@@ -20,7 +20,7 @@ MODELS: list[Model] = [
     Model(
         id="mistral-medium-latest",
         provider=Provider.MISTRAL,
-        display_name="Mistral Medium 3.1",
+        display_name="Mistral Medium",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
@@ -31,7 +31,7 @@ MODELS: list[Model] = [
     Model(
         id="mistral-small-latest",
         provider=Provider.MISTRAL,
-        display_name="Mistral Small 3.2",
+        display_name="Mistral Small",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
@@ -141,7 +141,7 @@ MODELS: list[Model] = [
     Model(
         id="ministral-3b-latest",
         provider=Provider.MISTRAL,
-        display_name="Ministral 3 3B",
+        display_name="Ministral 3B",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
@@ -152,7 +152,7 @@ MODELS: list[Model] = [
     Model(
         id="ministral-8b-latest",
         provider=Provider.MISTRAL,
-        display_name="Ministral 3 8B",
+        display_name="Ministral 8B",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
@@ -163,7 +163,7 @@ MODELS: list[Model] = [
     Model(
         id="ministral-14b-latest",
         provider=Provider.MISTRAL,
-        display_name="Ministral 3 14B",
+        display_name="Ministral 14B",
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),


### PR DESCRIPTION
## Changes

- Added Devstral 2 model with:
  - Max tokens: 32,768
  - Temperature: 0.0-2.0
  - Output schema support
  - Streaming support

- Added Devstral Small 2 (labs-devstral-small-2512) model with:
  - Max tokens: 32,768
  - Temperature: 0.0-2.0
  - Output schema support
  - Streaming support

Devstral 2 models are enterprise-grade text models designed for software engineering tasks, including codebase exploration, multi-file editing, and powering software engineering agents.

## Testing

All pre-commit hooks passed:
- Type checking with mypy
- Security check with Bandit
- Tests with coverage

## References

- [Mistral Models Page](https://docs.mistral.ai/getting-started/models)
- [Devstral 2 Documentation](https://docs.mistral.ai/models/devstral-2-25-12)
- [Devstral Small 2 Documentation](https://docs.mistral.ai/models/devstral-small-2-25-12)
