### PR TITLE
feat: add sora-2-2025-12-08 snapshot for OpenAI video generation

### DIFF
--- a/packages/video-generation/src/celeste_video_generation/providers/openai/models.py
+++ b/packages/video-generation/src/celeste_video_generation/providers/openai/models.py
@@ -33,4 +33,14 @@ MODELS: list[Model] = [
             ),
         },
     ),
+    Model(
+        id="sora-2-2025-12-08",
+        provider=Provider.OPENAI,
+        display_name="Sora 2 (December 2025)",
+        parameter_constraints={
+            VideoGenerationParameter.DURATION: Choice(options=["4", "8", "12"]),
+            VideoGenerationParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoGenerationParameter.RESOLUTION: Choice(options=["720p"]),
+        },
+    ),
 ]


### PR DESCRIPTION
## Summary
Adds the latest Sora 2 snapshot (`sora-2-2025-12-08`) to the OpenAI video generation provider.

## Changes
- Added `sora-2-2025-12-08` snapshot model with appropriate parameter constraints:
  - Duration: 4/8/12 seconds
  - Aspect Ratio: 16:9, 9:16
  - Resolution: 720p

## Model Details
- **Model ID**: `sora-2-2025-12-08`
- **Display Name**: Sora 2 (December 2025)
- **Provider**: OpenAI
- **Status**: Latest snapshot version (December 8, 2025)

## Validation
- Model validated in playground
- Snapshot version verified against OpenAI API documentation