### PR TITLE
refactor(client): add APIMixin abstract base for type-safe provider mixins

### DIFF
--- a/packages/providers/anthropic/src/celeste_anthropic/messages/client.py
+++ b/packages/providers/anthropic/src/celeste_anthropic/messages/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class AnthropicMessagesClient:
+class AnthropicMessagesClient(APIMixin):
     """Mixin for Anthropic Messages API capabilities.
 
     Provides shared implementation for all capabilities using the Messages API:
@@ -39,8 +40,8 @@ class AnthropicMessagesClient:
         **parameters: Any,
     ) -> Any:
         """Build request with Anthropic-specific defaults."""
-        request = super()._build_request(inputs, **parameters)  # type: ignore[misc]
-        request["model"] = self.model.id  # type: ignore[attr-defined]
+        request = super()._build_request(inputs, **parameters)
+        request["model"] = self.model.id
 
         # Apply max_tokens default if not set (Anthropic requires it)
         if "max_tokens" not in request:
@@ -53,7 +54,7 @@ class AnthropicMessagesClient:
         beta_features: list[str] = request_body.pop("_beta_features", [])
 
         headers: dict[str, str] = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             config.HEADER_ANTHROPIC_VERSION: config.ANTHROPIC_VERSION,
             "Content-Type": ApplicationMimeType.JSON,
         }
@@ -75,7 +76,7 @@ class AnthropicMessagesClient:
         """Make HTTP request to Anthropic Messages API endpoint."""
         headers = self._build_headers(request_body)
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.AnthropicMessagesEndpoint.CREATE_MESSAGE}",
             headers=headers,
             json_body=request_body,
@@ -90,7 +91,7 @@ class AnthropicMessagesClient:
         request_body["stream"] = True
         headers = self._build_headers(request_body)
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.AnthropicMessagesEndpoint.CREATE_MESSAGE}",
             headers=headers,
             json_body=request_body,
@@ -147,7 +148,7 @@ class AnthropicMessagesClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["AnthropicMessagesClient"]

--- a/packages/providers/byteplus/src/celeste_byteplus/images/client.py
+++ b/packages/providers/byteplus/src/celeste_byteplus/images/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class BytePlusImagesClient:
+class BytePlusImagesClient(APIMixin):
     """Mixin for BytePlus Images API capabilities.
 
     Provides shared implementation for all capabilities using the Images API:
@@ -39,11 +40,11 @@ class BytePlusImagesClient:
         request_body["stream"] = False
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.BytePlusImagesEndpoint.CREATE_IMAGE}",
             headers=headers,
             json_body=request_body,
@@ -58,11 +59,11 @@ class BytePlusImagesClient:
         request_body["stream"] = True
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.BytePlusImagesEndpoint.CREATE_IMAGE}",
             headers=headers,
             json_body=request_body,
@@ -114,7 +115,7 @@ class BytePlusImagesClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        metadata = super()._build_metadata(filtered_data)  # type: ignore[misc]
+        metadata = super()._build_metadata(filtered_data)
 
         # Add provider-specific parsed fields
         seed = response_data.get("seed")

--- a/packages/providers/cohere/src/celeste_cohere/chat/client.py
+++ b/packages/providers/cohere/src/celeste_cohere/chat/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class CohereChatClient:
+class CohereChatClient(APIMixin):
     """Mixin for Cohere Chat API capabilities.
 
     Provides shared implementation for all capabilities using the Chat API:
@@ -37,14 +38,14 @@ class CohereChatClient:
         **parameters: Any,
     ) -> httpx.Response:
         """Make HTTP request to Cohere Chat API endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.CohereChatEndpoint.CREATE_CHAT}",
             headers=headers,
             json_body=request_body,
@@ -56,15 +57,15 @@ class CohereChatClient:
         **parameters: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Make streaming request to Cohere Chat API endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
         request_body["stream"] = True
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.CohereChatEndpoint.CREATE_CHAT}",
             headers=headers,
             json_body=request_body,
@@ -113,7 +114,7 @@ class CohereChatClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["CohereChatClient"]

--- a/packages/providers/elevenlabs/src/celeste_elevenlabs/text_to_speech/client.py
+++ b/packages/providers/elevenlabs/src/celeste_elevenlabs/text_to_speech/client.py
@@ -5,12 +5,13 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.mime_types import ApplicationMimeType, AudioMimeType
 
 from . import config
 
 
-class ElevenLabsTextToSpeechClient:
+class ElevenLabsTextToSpeechClient(APIMixin):
     """Mixin for ElevenLabs Text-to-Speech API.
 
     Provides shared implementation for speech generation:
@@ -44,7 +45,7 @@ class ElevenLabsTextToSpeechClient:
             voice_id = parameters.get("voice", config.DEFAULT_VOICE_ID)
 
         # Set model_id
-        request_body["model_id"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model_id"] = self.model.id
 
         # Build URL with voice_id in path
         endpoint = config.ElevenLabsTextToSpeechEndpoint.CREATE_SPEECH.format(
@@ -52,11 +53,11 @@ class ElevenLabsTextToSpeechClient:
         )
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
             json_body=request_body,
@@ -78,7 +79,7 @@ class ElevenLabsTextToSpeechClient:
             voice_id = parameters.get("voice", config.DEFAULT_VOICE_ID)
 
         # Set model_id
-        request_body["model_id"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model_id"] = self.model.id
 
         # Build URL with voice_id in path
         endpoint = config.ElevenLabsTextToSpeechEndpoint.STREAM_SPEECH.format(
@@ -86,7 +87,7 @@ class ElevenLabsTextToSpeechClient:
         )
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
@@ -106,7 +107,7 @@ class ElevenLabsTextToSpeechClient:
 
         Wraps httpx streaming to yield dicts compatible with Stream interface.
         """
-        client = await self.http_client._get_client()  # type: ignore[attr-defined]
+        client = await self.http_client._get_client()
 
         async with client.stream(
             "POST",

--- a/packages/providers/google/src/celeste_google/generate_content/client.py
+++ b/packages/providers/google/src/celeste_google/generate_content/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class GoogleGenerateContentClient:
+class GoogleGenerateContentClient(APIMixin):
     """Mixin for GenerateContent API capabilities.
 
     Provides shared implementation for all capabilities using the GenerateContent API:
@@ -40,13 +41,13 @@ class GoogleGenerateContentClient:
     ) -> httpx.Response:
         """Make HTTP request to generateContent endpoint."""
         endpoint = config.GoogleGenerateContentEndpoint.GENERATE_CONTENT.format(
-            model_id=self.model.id  # type: ignore[attr-defined]
+            model_id=self.model.id
         )
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
             json_body=request_body,
@@ -59,13 +60,13 @@ class GoogleGenerateContentClient:
     ) -> AsyncIterator[dict[str, Any]]:
         """Make streaming request to streamGenerateContent endpoint."""
         endpoint = config.GoogleGenerateContentEndpoint.STREAM_GENERATE_CONTENT.format(
-            model_id=self.model.id  # type: ignore[attr-defined]
+            model_id=self.model.id
         )
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
             json_body=request_body,
@@ -118,7 +119,7 @@ class GoogleGenerateContentClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["GoogleGenerateContentClient"]

--- a/packages/providers/google/src/celeste_google/imagen/client.py
+++ b/packages/providers/google/src/celeste_google/imagen/client.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -11,7 +12,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class GoogleImagenClient:
+class GoogleImagenClient(APIMixin):
     """Mixin for Imagen API capabilities.
 
     Provides shared implementation for capabilities using the Imagen API:
@@ -37,13 +38,13 @@ class GoogleImagenClient:
     ) -> httpx.Response:
         """Make HTTP request to Imagen :predict endpoint."""
         endpoint = config.GoogleImagenEndpoint.CREATE_IMAGE.format(
-            model_id=self.model.id  # type: ignore[attr-defined]
+            model_id=self.model.id
         )
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
             json_body=request_body,
@@ -90,7 +91,7 @@ class GoogleImagenClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["GoogleImagenClient"]

--- a/packages/providers/mistral/src/celeste_mistral/chat/client.py
+++ b/packages/providers/mistral/src/celeste_mistral/chat/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class MistralChatClient:
+class MistralChatClient(APIMixin):
     """Mixin for Mistral Chat API capabilities.
 
     Provides shared implementation for chat-based capabilities:
@@ -35,14 +36,14 @@ class MistralChatClient:
         **parameters: Any,
     ) -> httpx.Response:
         """Make HTTP request to Mistral Chat API."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.MistralChatEndpoint.CREATE_CHAT_COMPLETION}",
             headers=headers,
             json_body=request_body,
@@ -54,15 +55,15 @@ class MistralChatClient:
         **parameters: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Make HTTP streaming request to Mistral Chat API."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
         request_body["stream"] = True
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.MistralChatEndpoint.CREATE_CHAT_COMPLETION}",
             headers=headers,
             json_body=request_body,
@@ -108,7 +109,7 @@ class MistralChatClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["MistralChatClient"]

--- a/packages/providers/openai/src/celeste_openai/audio/client.py
+++ b/packages/providers/openai/src/celeste_openai/audio/client.py
@@ -4,12 +4,13 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.mime_types import ApplicationMimeType, AudioMimeType
 
 from . import config
 
 
-class OpenAIAudioClient:
+class OpenAIAudioClient(APIMixin):
     """Mixin for OpenAI Audio API speech generation.
 
     Provides shared implementation for speech generation:
@@ -35,14 +36,14 @@ class OpenAIAudioClient:
 
         Returns the raw response with binary audio content.
         """
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.OpenAIAudioEndpoint.CREATE_SPEECH}",
             headers=headers,
             json_body=request_body,

--- a/packages/providers/openai/src/celeste_openai/images/client.py
+++ b/packages/providers/openai/src/celeste_openai/images/client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -16,7 +17,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class OpenAIImagesClient:
+class OpenAIImagesClient(APIMixin):
     """Mixin for OpenAI Images API image generation.
 
     Provides shared implementation for image generation:
@@ -40,18 +41,18 @@ class OpenAIImagesClient:
         **parameters: Any,
     ) -> httpx.Response:
         """Make HTTP request to OpenAI Images API generations endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         # DALL-E 2/3 need b64_json response format
-        if self.model.id in ("dall-e-2", "dall-e-3"):  # type: ignore[attr-defined]
+        if self.model.id in ("dall-e-2", "dall-e-3"):
             request_body.setdefault("response_format", "b64_json")
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.OpenAIImagesEndpoint.CREATE_IMAGE}",
             headers=headers,
             json_body=request_body,
@@ -66,18 +67,18 @@ class OpenAIImagesClient:
 
         Streaming is only supported for gpt-image-1.
         """
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
         request_body["stream"] = True
 
         if "partial_images" not in request_body:
             request_body["partial_images"] = 1
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.OpenAIImagesEndpoint.CREATE_IMAGE}",
             headers=headers,
             json_body=request_body,
@@ -126,7 +127,7 @@ class OpenAIImagesClient:
             k: v for k, v in response_data.items() if k not in content_fields
         }
 
-        metadata = super()._build_metadata(filtered_data)  # type: ignore[misc]
+        metadata = super()._build_metadata(filtered_data)
 
         return metadata
 

--- a/packages/providers/openai/src/celeste_openai/responses/client.py
+++ b/packages/providers/openai/src/celeste_openai/responses/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class OpenAIResponsesClient:
+class OpenAIResponsesClient(APIMixin):
     """Mixin for OpenAI Responses API capabilities.
 
     Provides shared implementation for all capabilities using the Responses API:
@@ -41,14 +42,14 @@ class OpenAIResponsesClient:
         **parameters: Any,
     ) -> httpx.Response:
         """Make HTTP request to OpenAI Responses API endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.OpenAIResponsesEndpoint.CREATE_RESPONSE}",
             headers=headers,
             json_body=request_body,
@@ -60,15 +61,15 @@ class OpenAIResponsesClient:
         **parameters: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Make streaming request to OpenAI Responses API endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
         request_body["stream"] = True
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.OpenAIResponsesEndpoint.CREATE_RESPONSE}",
             headers=headers,
             json_body=request_body,
@@ -126,7 +127,7 @@ class OpenAIResponsesClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["OpenAIResponsesClient"]

--- a/packages/providers/xai/src/celeste_xai/responses/client.py
+++ b/packages/providers/xai/src/celeste_xai/responses/client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 from celeste.mime_types import ApplicationMimeType
@@ -12,7 +13,7 @@ from celeste.mime_types import ApplicationMimeType
 from . import config
 
 
-class XAIResponsesClient:
+class XAIResponsesClient(APIMixin):
     """Mixin for XAI Responses API capabilities.
 
     Provides shared implementation for all capabilities using the Responses API:
@@ -43,14 +44,14 @@ class XAIResponsesClient:
         **parameters: Any,
     ) -> httpx.Response:
         """Make HTTP request to XAI Responses endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return await self.http_client.post(  # type: ignore[attr-defined,no-any-return]
+        return await self.http_client.post(
             f"{config.BASE_URL}{config.XAIResponsesEndpoint.CREATE_RESPONSE}",
             headers=headers,
             json_body=request_body,
@@ -62,15 +63,15 @@ class XAIResponsesClient:
         **parameters: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Make streaming request to XAI Responses endpoint."""
-        request_body["model"] = self.model.id  # type: ignore[attr-defined]
+        request_body["model"] = self.model.id
         request_body["stream"] = True
 
         headers = {
-            **self.auth.get_headers(),  # type: ignore[attr-defined]
+            **self.auth.get_headers(),
             "Content-Type": ApplicationMimeType.JSON,
         }
 
-        return self.http_client.stream_post(  # type: ignore[attr-defined,no-any-return]
+        return self.http_client.stream_post(
             f"{config.BASE_URL}{config.XAIResponsesEndpoint.CREATE_RESPONSE}",
             headers=headers,
             json_body=request_body,
@@ -121,7 +122,7 @@ class XAIResponsesClient:
         filtered_data = {
             k: v for k, v in response_data.items() if k not in content_fields
         }
-        return super()._build_metadata(filtered_data)  # type: ignore[misc,no-any-return]
+        return super()._build_metadata(filtered_data)
 
 
 __all__ = ["XAIResponsesClient"]


### PR DESCRIPTION
## Summary

- **New `APIMixin` class** in `src/celeste/client.py` as abstract base for all provider API mixins
- **Type-safe interface** declaring `model`, `auth`, `provider` attributes and abstract `http_client` property
- **MRO chaining** via stub methods (`_build_request`, `_build_metadata`, `_handle_error_response`)
- **Updates 15 provider client mixins** to inherit from `APIMixin`

## Changes

### Core Changes
- `src/celeste/client.py`: Added `APIMixin(ABC)` class with proper type hints
- `Client` now inherits from `APIMixin` to complete the MRO chain

### Provider Updates
All 15 provider mixins now inherit from `APIMixin`:
- `anthropic/messages`, `bfl/images`, `byteplus/images`, `byteplus/videos`
- `cohere/chat`, `elevenlabs/text_to_speech`, `google/generate_content`
- `google/imagen`, `google/veo`, `mistral/chat`, `openai/audio`
- `openai/images`, `openai/responses`, `openai/videos`, `xai/responses`

## Impact

- **Eliminates ~50 `# type: ignore` comments** across provider clients
- **Better IDE support** with autocomplete for `self.model`, `self.auth`, etc.
- **Same runtime behavior** - no functional changes, pure type system improvement

## Test Plan

- [x] All 295 unit tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Security scan passes (bandit)