### PR TITLE
fix: add missing provider dependencies to capability packages

### DIFF
--- a/packages/capabilities/image-generation/pyproject.toml
+++ b/packages/capabilities/image-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-image-generation"
-version = "0.3.0"
+version = "0.3.3"
 description = "Image generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -19,11 +19,11 @@ classifiers = [
 ]
 keywords = ["ai", "image-generation", "dall-e", "imagen", "openai", "google", "byteplus"]
 dependencies = [
-    "celeste-ai>=0.3.0",
-    "celeste-bfl>=0.3.0",
-    "celeste-byteplus>=0.3.0",
-    "celeste-google>=0.3.0",
-    "celeste-openai>=0.3.0",
+    "celeste-ai>=0.3.3",
+    "celeste-bfl>=0.3.3",
+    "celeste-byteplus>=0.3.3",
+    "celeste-google>=0.3.3",
+    "celeste-openai>=0.3.3",
 ]
 
 [project.urls]

--- a/packages/capabilities/speech-generation/pyproject.toml
+++ b/packages/capabilities/speech-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-speech-generation"
-version = "0.3.2"
+version = "0.3.3"
 description = "Speech generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -19,11 +19,11 @@ classifiers = [
 ]
 keywords = ["ai", "speech-generation", "tts", "text-to-speech", "openai", "google", "elevenlabs", "gradium", "audio-ai"]
 dependencies = [
-    "celeste-ai>=0.3.0",
-    "celeste-elevenlabs>=0.3.0",
-    "celeste-google>=0.3.0",
-    "celeste-gradium>=0.3.0",
-    "celeste-openai>=0.3.0",
+    "celeste-ai>=0.3.3",
+    "celeste-elevenlabs>=0.3.3",
+    "celeste-google>=0.3.3",
+    "celeste-gradium>=0.3.3",
+    "celeste-openai>=0.3.3",
 ]
 
 [project.urls]

--- a/packages/capabilities/text-generation/pyproject.toml
+++ b/packages/capabilities/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.3.0"
+version = "0.3.3"
 description = "Text generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -19,13 +19,13 @@ classifiers = [
 ]
 keywords = ["ai", "text-generation", "llm", "openai", "anthropic", "claude", "gemini", "mistral", "cohere"]
 dependencies = [
-    "celeste-ai>=0.3.0",
-    "celeste-anthropic>=0.3.0",
-    "celeste-cohere>=0.3.0",
-    "celeste-google>=0.3.0",
-    "celeste-mistral>=0.3.0",
-    "celeste-openai>=0.3.0",
-    "celeste-xai>=0.3.0",
+    "celeste-ai>=0.3.3",
+    "celeste-anthropic>=0.3.3",
+    "celeste-cohere>=0.3.3",
+    "celeste-google>=0.3.3",
+    "celeste-mistral>=0.3.3",
+    "celeste-openai>=0.3.3",
+    "celeste-xai>=0.3.3",
 ]
 
 [project.urls]

--- a/packages/capabilities/video-generation/pyproject.toml
+++ b/packages/capabilities/video-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-video-generation"
-version = "0.3.0"
+version = "0.3.3"
 description = "Video generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -19,10 +19,10 @@ classifiers = [
 ]
 keywords = ["ai", "video-generation", "sora", "runway", "openai", "google", "video-ai"]
 dependencies = [
-    "celeste-ai>=0.3.0",
-    "celeste-byteplus>=0.3.0",
-    "celeste-google>=0.3.0",
-    "celeste-openai>=0.3.0",
+    "celeste-ai>=0.3.3",
+    "celeste-byteplus>=0.3.3",
+    "celeste-google>=0.3.3",
+    "celeste-openai>=0.3.3",
     "pillow>=10.0.0",
 ]
 

--- a/packages/providers/anthropic/pyproject.toml
+++ b/packages/providers/anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-anthropic"
-version = "0.3.0"
+version = "0.3.3"
 description = "Anthropic provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/bfl/pyproject.toml
+++ b/packages/providers/bfl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-bfl"
-version = "0.3.0"
+version = "0.3.3"
 description = "BFL (Black Forest Labs) provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/byteplus/pyproject.toml
+++ b/packages/providers/byteplus/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-byteplus"
-version = "0.3.0"
+version = "0.3.3"
 description = "BytePlus provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/cohere/pyproject.toml
+++ b/packages/providers/cohere/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-cohere"
-version = "0.3.0"
+version = "0.3.3"
 description = "Cohere provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/elevenlabs/pyproject.toml
+++ b/packages/providers/elevenlabs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-elevenlabs"
-version = "0.3.0"
+version = "0.3.3"
 description = "ElevenLabs provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/google/pyproject.toml
+++ b/packages/providers/google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-google"
-version = "0.3.2"
+version = "0.3.3"
 description = "Google (Gemini API) provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/gradium/pyproject.toml
+++ b/packages/providers/gradium/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-gradium"
-version = "0.3.1"
+version = "0.3.3"
 description = "Gradium provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/mistral/pyproject.toml
+++ b/packages/providers/mistral/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-mistral"
-version = "0.3.0"
+version = "0.3.3"
 description = "Mistral provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/openai/pyproject.toml
+++ b/packages/providers/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-openai"
-version = "0.3.0"
+version = "0.3.3"
 description = "OpenAI provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/packages/providers/xai/pyproject.toml
+++ b/packages/providers/xai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-xai"
-version = "0.3.0"
+version = "0.3.3"
 description = "xAI provider package for Celeste AI"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.3.2"
+version = "0.3.3"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"
@@ -34,15 +34,15 @@ Repository = "https://github.com/withceleste/celeste-python"
 Issues = "https://github.com/withceleste/celeste-python/issues"
 
 [project.optional-dependencies]
-text-generation = ["celeste-text-generation>=0.3.0"]
-image-generation = ["celeste-image-generation>=0.3.0"]
-video-generation = ["celeste-video-generation>=0.3.0"]
-speech-generation = ["celeste-speech-generation>=0.3.0"]
+text-generation = ["celeste-text-generation>=0.3.3"]
+image-generation = ["celeste-image-generation>=0.3.3"]
+video-generation = ["celeste-video-generation>=0.3.3"]
+speech-generation = ["celeste-speech-generation>=0.3.3"]
 all = [
-    "celeste-text-generation>=0.3.0",
-    "celeste-image-generation>=0.3.0",
-    "celeste-video-generation>=0.3.0",
-    "celeste-speech-generation>=0.3.0",
+    "celeste-text-generation>=0.3.3",
+    "celeste-image-generation>=0.3.3",
+    "celeste-video-generation>=0.3.3",
+    "celeste-speech-generation>=0.3.3",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Problem
Website CI fails with `ModuleNotFoundError: No module named 'celeste_elevenlabs'` when installing from PyPI.

## Root Cause
Capability packages (e.g., `celeste-speech-generation`) had `[tool.uv.sources]` for workspace development but **no `dependencies`** section for PyPI distribution. When published, the provider packages weren't installed.

## Fix
Added `dependencies` section to all capability `pyproject.toml` files:
- `speech-generation`: celeste-ai, celeste-elevenlabs, celeste-google, celeste-gradium, celeste-openai
- `text-generation`: celeste-ai, celeste-anthropic, celeste-cohere, celeste-google, celeste-mistral, celeste-openai, celeste-xai
- `image-generation`: celeste-ai, celeste-bfl, celeste-byteplus, celeste-google, celeste-openai
- `video-generation`: celeste-ai, celeste-byteplus, celeste-google, celeste-openai (already had pillow)

## Test Plan
- [ ] CI passes
- [ ] `uv pip install celeste-ai[all]` from PyPI installs all provider packages