### PR TITLE
feat(core): make capability optional in create_client

### DIFF
--- a/packages/capabilities/text-generation/src/celeste_text_generation/providers/mistral/models.py
+++ b/packages/capabilities/text-generation/src/celeste_text_generation/providers/mistral/models.py
@@ -62,28 +62,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="open-mixtral-8x7b",
-        provider=Provider.MISTRAL,
-        display_name="Open Mixtral 8x7B",
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
-        },
-    ),
-    Model(
-        id="open-mixtral-8x22b",
-        provider=Provider.MISTRAL,
-        display_name="Open Mixtral 8x22B",
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
-        },
-    ),
-    Model(
         id="codestral-latest",
         provider=Provider.MISTRAL,
         display_name="Codestral",

--- a/packages/providers/anthropic/src/celeste_anthropic/messages/config.py
+++ b/packages/providers/anthropic/src/celeste_anthropic/messages/config.py
@@ -8,6 +8,8 @@ class AnthropicMessagesEndpoint(StrEnum):
 
     CREATE_MESSAGE = "/v1/messages"
     COUNT_MESSAGE_TOKENS = "/v1/messages/count_tokens"
+    LIST_MODELS = "/v1/models"
+    GET_MODEL = "/v1/models/{model_id}"
 
 
 BASE_URL = "https://api.anthropic.com"

--- a/packages/providers/cohere/src/celeste_cohere/chat/config.py
+++ b/packages/providers/cohere/src/celeste_cohere/chat/config.py
@@ -7,6 +7,8 @@ class CohereChatEndpoint(StrEnum):
     """Endpoints for Chat API."""
 
     CREATE_CHAT = "/v2/chat"
+    LIST_MODELS = "/v2/models"
+    GET_MODEL = "/v2/models/{model_id}"
 
 
 BASE_URL = "https://api.cohere.com"

--- a/packages/providers/elevenlabs/src/celeste_elevenlabs/text_to_speech/config.py
+++ b/packages/providers/elevenlabs/src/celeste_elevenlabs/text_to_speech/config.py
@@ -9,6 +9,7 @@ class ElevenLabsTextToSpeechEndpoint(StrEnum):
     CREATE_SPEECH = "/v1/text-to-speech/{voice_id}"
     STREAM_SPEECH = "/v1/text-to-speech/{voice_id}/stream"
     LIST_VOICES = "/v1/voices"
+    LIST_MODELS = "/v1/models"
 
 
 BASE_URL = "https://api.elevenlabs.io"

--- a/packages/providers/openai/src/celeste_openai/responses/config.py
+++ b/packages/providers/openai/src/celeste_openai/responses/config.py
@@ -7,6 +7,8 @@ class OpenAIResponsesEndpoint(StrEnum):
     """Endpoints for Responses API."""
 
     CREATE_RESPONSE = "/v1/responses"
+    LIST_MODELS = "/v1/models"
+    GET_MODEL = "/v1/models/{model_id}"
 
 
 BASE_URL = "https://api.openai.com"

--- a/packages/providers/xai/src/celeste_xai/responses/config.py
+++ b/packages/providers/xai/src/celeste_xai/responses/config.py
@@ -7,6 +7,8 @@ class XAIResponsesEndpoint(StrEnum):
     """Endpoints for Responses API."""
 
     CREATE_RESPONSE = "/v1/responses"
+    LIST_MODELS = "/v1/models"
+    GET_MODEL = "/v1/models/{model_id}"
 
 
 BASE_URL = "https://api.x.ai"

--- a/tests/unit_tests/test_init.py
+++ b/tests/unit_tests/test_init.py
@@ -91,15 +91,13 @@ class TestCreateClient:
 
             mock_get_model.assert_called_once_with("claude-3", Provider.ANTHROPIC)
 
-    def test_create_client_string_model_without_provider_raises_error(self) -> None:
-        """Test that string model ID without provider raises ValueError."""
-        # Act & Assert
-        with pytest.raises(
-            ValueError, match="provider required when model is a string ID"
-        ):
+    def test_create_client_string_model_not_found_raises_error(self) -> None:
+        """Test that unknown model ID raises ModelNotFoundError."""
+        # Act & Assert - model lookup searches all providers, raises if not found
+        with pytest.raises(ModelNotFoundError, match=r"Model.*not found"):
             create_client(
                 capability=Capability.TEXT_GENERATION,
-                model="some-model",  # provider=None - should error
+                model="nonexistent-model",
             )
 
     def test_create_client_filters_by_provider_when_specified(


### PR DESCRIPTION
## Summary
- Add capability inference from model when capability is not explicitly provided
- Models with single capability auto-infer (e.g., `SeeDream` → `IMAGE_GENERATION`)
- Models with multiple capabilities raise clear error asking for explicit capability
- Add `LIST_MODELS` and `GET_MODEL` endpoints to provider configs
- Remove deprecated Mixtral 8x7B and 8x22B models

## Usage
```python
# Before: required capability
celeste.create_client(capability=Capability.IMAGE_GENERATION, model="seedream-4-5-251128")

# After: inferred from model (SeeDream only has IMAGE_GENERATION)
celeste.create_client(model="seedream-4-5-251128")

# Multi-capability models still require explicit capability
celeste.create_client(model="gpt-4o")  # Raises ValueError with clear message
```

## Test plan
- [x] Tested single-capability model inference (SeeDream)
- [x] Tested multi-capability model error (GPT-4o)
- [x] All tests pass
- [x] Lint passes