### PR TITLE
feat: add gemini-3-flash-preview model

### DIFF
--- a/packages/capabilities/text-generation/src/celeste_text_generation/providers/google/models.py
+++ b/packages/capabilities/text-generation/src/celeste_text_generation/providers/google/models.py
@@ -61,4 +61,16 @@ MODELS: list[Model] = [
             TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
         },
     ),
+    Model(
+        id="gemini-3-flash-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3 Flash",
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextGenerationParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
+            TextGenerationParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
 ]


### PR DESCRIPTION
Adds Gemini 3 Flash Preview model to Google text generation models.

This model supports:
- Thinking level parameter (low/high)
- Output schema

Related to: https://withceleste.ai/models/gemini-3-flash-preview