### PR TITLE
chore: bump versions to 0.3.4

### DIFF
--- a/packages/capabilities/text-generation/pyproject.toml
+++ b/packages/capabilities/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.3.3"
+version = "0.3.4"
 description = "Text generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.3.3"
+version = "0.3.4"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"


### PR DESCRIPTION
Bump versions for celeste-ai and celeste-text-generation to 0.3.4.

This version bump includes the addition of gemini-3-flash-preview model.