### PR TITLE
fix(capabilities): add explicit usage and finish_reason types to Output classes

### DIFF
--- a/packages/capabilities/image-generation/pyproject.toml
+++ b/packages/capabilities/image-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-image-generation"
-version = "0.3.6"
+version = "0.3.7"
 description = "Image generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/capabilities/image-generation/src/celeste_image_generation/io.py
+++ b/packages/capabilities/image-generation/src/celeste_image_generation/io.py
@@ -1,5 +1,7 @@
 """Input and output types for image generation."""
 
+from pydantic import Field
+
 from celeste.artifacts import ImageArtifact
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
 
@@ -39,7 +41,8 @@ class ImageGenerationUsage(Usage):
 class ImageGenerationOutput(Output[ImageArtifact | list[ImageArtifact]]):
     """Output with ImageArtifact content (single or multiple)."""
 
-    pass
+    usage: ImageGenerationUsage = Field(default_factory=ImageGenerationUsage)
+    finish_reason: ImageGenerationFinishReason | None = None
 
 
 class ImageGenerationChunk(Chunk[ImageArtifact]):

--- a/packages/capabilities/speech-generation/pyproject.toml
+++ b/packages/capabilities/speech-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-speech-generation"
-version = "0.3.6"
+version = "0.3.7"
 description = "Speech generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/capabilities/speech-generation/src/celeste_speech_generation/io.py
+++ b/packages/capabilities/speech-generation/src/celeste_speech_generation/io.py
@@ -1,5 +1,7 @@
 """Input and output types for speech generation."""
 
+from pydantic import Field
+
 from celeste.artifacts import AudioArtifact
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
 
@@ -23,6 +25,9 @@ class SpeechGenerationFinishReason(FinishReason):
 
 class SpeechGenerationOutput(Output[AudioArtifact]):
     """Output with audio artifact content."""
+
+    usage: SpeechGenerationUsage = Field(default_factory=SpeechGenerationUsage)
+    finish_reason: SpeechGenerationFinishReason | None = None
 
 
 class SpeechGenerationChunk(Chunk[bytes]):

--- a/packages/capabilities/text-generation/pyproject.toml
+++ b/packages/capabilities/text-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-text-generation"
-version = "0.3.6"
+version = "0.3.7"
 description = "Text generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/capabilities/text-generation/src/celeste_text_generation/io.py
+++ b/packages/capabilities/text-generation/src/celeste_text_generation/io.py
@@ -1,5 +1,7 @@
 """Input and output types for text generation."""
 
+from pydantic import Field
+
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
 
 
@@ -35,7 +37,8 @@ class TextGenerationUsage(Usage):
 class TextGenerationOutput[Content](Output[Content]):
     """Output with text or structured content."""
 
-    pass
+    usage: TextGenerationUsage = Field(default_factory=TextGenerationUsage)
+    finish_reason: TextGenerationFinishReason | None = None
 
 
 class TextGenerationChunk(Chunk[str]):

--- a/packages/capabilities/video-generation/pyproject.toml
+++ b/packages/capabilities/video-generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-video-generation"
-version = "0.3.6"
+version = "0.3.7"
 description = "Video generation package for Celeste AI. Unified interface for all providers"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/packages/capabilities/video-generation/src/celeste_video_generation/io.py
+++ b/packages/capabilities/video-generation/src/celeste_video_generation/io.py
@@ -1,5 +1,7 @@
 """Input and output types for video generation."""
 
+from pydantic import Field
+
 from celeste.artifacts import VideoArtifact
 from celeste.io import Input, Output, Usage
 
@@ -23,7 +25,7 @@ class VideoGenerationUsage(Usage):
 class VideoGenerationOutput(Output[VideoArtifact]):
     """Output with VideoArtifact content."""
 
-    pass
+    usage: VideoGenerationUsage = Field(default_factory=VideoGenerationUsage)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Override `usage` and `finish_reason` field types in capability Output classes
- Ensures proper Pydantic serialization with capability-specific subclass fields
- Without explicit type annotations, Pydantic uses base schema (empty `{}`)

## Changes
- `text-generation/io.py` - Add `TextGenerationUsage` and `TextGenerationFinishReason` to Output
- `image-generation/io.py` - Add `ImageGenerationUsage` and `ImageGenerationFinishReason` to Output
- `video-generation/io.py` - Add `VideoGenerationUsage` to Output
- `speech-generation/io.py` - Add `SpeechGenerationUsage` and `SpeechGenerationFinishReason` to Output
- Bump all capability versions to 0.3.7

## Test plan
- [x] Verify `TextGenerationOutput.model_dump()` includes usage fields
- [x] Pre-commit hooks pass
- [x] Type checks pass