### PR TITLE
fix(speech-generation): return correct finish reason type in Google provider

### DIFF
--- a/packages/capabilities/speech-generation/src/celeste_speech_generation/providers/google/client.py
+++ b/packages/capabilities/speech-generation/src/celeste_speech_generation/providers/google/client.py
@@ -10,6 +10,7 @@ from celeste.mime_types import AudioMimeType
 from celeste.parameters import ParameterMapper
 from celeste_speech_generation.client import SpeechGenerationClient
 from celeste_speech_generation.io import (
+    SpeechGenerationFinishReason,
     SpeechGenerationInput,
     SpeechGenerationUsage,
 )
@@ -40,6 +41,13 @@ class GoogleSpeechGenerationClient(GoogleCloudTTSClient, SpeechGenerationClient)
         """Parse usage from response."""
         usage = super()._parse_usage(response_data)
         return SpeechGenerationUsage(**usage)
+
+    def _parse_finish_reason(
+        self, response_data: dict[str, Any]
+    ) -> SpeechGenerationFinishReason:
+        """Parse finish reason from response."""
+        finish_reason = super()._parse_finish_reason(response_data)
+        return SpeechGenerationFinishReason(reason=finish_reason.reason)
 
     def _parse_content(
         self,


### PR DESCRIPTION
Override _parse_finish_reason to return SpeechGenerationFinishReason instead of base FinishReason class, fixing Pydantic validation error in integration tests.