### PR TITLE
fix: strip whitespace from API keys to prevent HTTP header errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celeste-ai"
-version = "0.9.1"
+version = "0.9.2"
 description = "Open source, type-safe primitives for multi-modal AI. All capabilities, all providers, one interface"
 authors = [{name = "Kamilbenkirane", email = "kamil@withceleste.ai"}]
 readme = "README.md"

--- a/src/celeste/auth.py
+++ b/src/celeste/auth.py
@@ -37,12 +37,12 @@ class AuthHeader(Authentication):
     def convert_to_secret(cls, v: str | SecretStr) -> SecretStr:
         """Accept plain strings, auto-convert to SecretStr."""
         if isinstance(v, str):
-            return SecretStr(v)
+            return SecretStr(v.strip())
         return v
 
     def get_headers(self) -> dict[str, str]:
         """Return authentication header."""
-        return {self.header: f"{self.prefix}{self.secret.get_secret_value()}"}
+        return {self.header: f"{self.prefix}{self.secret.get_secret_value().strip()}"}
 
 
 class NoAuth(Authentication):


### PR DESCRIPTION
## Summary
- Strip whitespace from API keys when converting to SecretStr
- Strip whitespace when extracting secret value for HTTP headers

Fixes `LocalProtocolError: Illegal header value` when API keys contain trailing newlines (common when pasting from terminals or Colab Secrets).

## Test plan
- [ ] Verify API keys with trailing whitespace no longer cause HTTP errors