### PR TITLE
fix(xai): use ImageUrl struct format for image edits

### DIFF
--- a/src/celeste/modalities/images/providers/xai/client.py
+++ b/src/celeste/modalities/images/providers/xai/client.py
@@ -29,11 +29,13 @@ class XAIImagesClient(XAIImagesMixin, ImagesClient):
         """Initialize request from inputs."""
         request: dict[str, Any] = {"prompt": inputs.prompt}
         if inputs.image is not None:
-            # xAI accepts URL or base64 string
+            # xAI expects {"image": {"url": "..."}} with URL or data URI
             if inputs.image.url:
-                request["image"] = inputs.image.url
+                request["image"] = {"url": inputs.image.url}
             else:
-                request["image"] = inputs.image.get_base64()
+                mime_type = inputs.image.mime_type
+                base64_data = inputs.image.get_base64()
+                request["image"] = {"url": f"data:{mime_type};base64,{base64_data}"}
         return request
 
     async def generate(


### PR DESCRIPTION
## Summary

Fix xAI image edit to use the correct request format.

## Problem

xAI API expects `{"image": {"url": "..."}}` struct, not a raw string. The previous implementation sent the image as a plain string which caused deserialization errors.

## Fix

Changed from:
```python
request["image"] = inputs.image.url  # or base64 string
```

To:
```python
request["image"] = {"url": inputs.image.url}  # or data URI
```

## Test

```bash
pytest tests/integration_tests/images/test_edit.py::test_edit -k xai -v
```

🤖 Generated with [Claude Code](https://claude.ai/code)