### PR TITLE
refactor: centralize usage/finish_reason type conversion

### DIFF
--- a/src/celeste/modalities/audio/client.py
+++ b/src/celeste/modalities/audio/client.py
@@ -8,7 +8,7 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import AudioContent
 
-from .io import AudioInput, AudioOutput
+from .io import AudioFinishReason, AudioInput, AudioOutput, AudioUsage
 from .parameters import AudioParameters
 from .streaming import AudioStream
 
@@ -19,6 +19,8 @@ class AudioClient(
     """Base audio client. Providers implement speak() method."""
 
     modality: Modality = Modality.AUDIO
+    _usage_class = AudioUsage
+    _finish_reason_class = AudioFinishReason
 
     @classmethod
     def _output_class(cls) -> type[AudioOutput]:

--- a/src/celeste/modalities/audio/providers/elevenlabs/client.py
+++ b/src/celeste/modalities/audio/providers/elevenlabs/client.py
@@ -15,10 +15,8 @@ from celeste.providers.elevenlabs.text_to_speech.streaming import (
 from ...client import AudioClient
 from ...io import (
     AudioChunk,
-    AudioFinishReason,
     AudioInput,
     AudioOutput,
-    AudioUsage,
 )
 from ...parameters import AudioParameters
 from ...streaming import AudioStream
@@ -28,28 +26,12 @@ from .parameters import ELEVENLABS_PARAMETER_MAPPERS
 class ElevenLabsAudioStream(_ElevenLabsTextToSpeechStream, AudioStream):
     """ElevenLabs streaming for audio modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> AudioUsage | None:
-        """Parse and wrap usage from event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return AudioUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> AudioFinishReason | None:
-        """Parse and wrap finish reason from event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return AudioFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> AudioChunk | None:
         """Parse binary audio chunk from stream event."""
         chunk_data = self._parse_chunk_content(event_data)
         if not chunk_data:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             # Chunk with usage/finish_reason only (no audio)
@@ -62,8 +44,8 @@ class ElevenLabsAudioStream(_ElevenLabsTextToSpeechStream, AudioStream):
 
         return AudioChunk(
             content=chunk_data,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -110,11 +92,6 @@ class ElevenLabsAudioClient(ElevenLabsTextToSpeechMixin, AudioClient):
         """Initialize request with text input."""
         return {"text": inputs.text}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> AudioUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return AudioUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -130,11 +107,6 @@ class ElevenLabsAudioClient(ElevenLabsTextToSpeechMixin, AudioClient):
         mime_type = self._map_output_format_to_mime_type(output_format)
 
         return AudioArtifact(data=audio_bytes, mime_type=mime_type)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> AudioFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return AudioFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[AudioStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/audio/providers/google/client.py
+++ b/src/celeste/modalities/audio/providers/google/client.py
@@ -12,10 +12,8 @@ from celeste.providers.google.cloud_tts.client import (
 
 from ...client import AudioClient
 from ...io import (
-    AudioFinishReason,
     AudioInput,
     AudioOutput,
-    AudioUsage,
 )
 from ...parameters import AudioParameter, AudioParameters
 from .parameters import GOOGLE_PARAMETER_MAPPERS
@@ -49,11 +47,6 @@ class GoogleAudioClient(GoogleCloudTTSMixin, AudioClient):
             "audioConfig": {},
         }
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> AudioUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return AudioUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -66,11 +59,6 @@ class GoogleAudioClient(GoogleCloudTTSMixin, AudioClient):
         mime_type = AudioMimeType(output_format) if output_format else AudioMimeType.MP3
 
         return AudioArtifact(data=audio_b64, mime_type=mime_type)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> AudioFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return AudioFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["GoogleAudioClient"]

--- a/src/celeste/modalities/audio/providers/openai/client.py
+++ b/src/celeste/modalities/audio/providers/openai/client.py
@@ -8,7 +8,7 @@ from celeste.providers.openai.audio import config
 from celeste.providers.openai.audio.client import OpenAIAudioClient as OpenAIAudioMixin
 
 from ...client import AudioClient
-from ...io import AudioFinishReason, AudioInput, AudioOutput, AudioUsage
+from ...io import AudioFinishReason, AudioInput, AudioOutput
 from ...parameters import AudioParameters
 from .parameters import OPENAI_PARAMETER_MAPPERS
 
@@ -36,11 +36,6 @@ class OpenAIAudioClient(OpenAIAudioMixin, AudioClient):
     def _init_request(self, inputs: AudioInput) -> dict[str, Any]:
         """Initialize request with text input."""
         return {"input": inputs.text}
-
-    def _parse_usage(self, response_data: dict[str, Any]) -> AudioUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return AudioUsage(**usage)
 
     def _parse_content(
         self,

--- a/src/celeste/modalities/audio/streaming.py
+++ b/src/celeste/modalities/audio/streaming.py
@@ -20,6 +20,9 @@ from .parameters import AudioParameters
 class AudioStream(Stream[AudioOutput, AudioParameters, AudioChunk]):
     """Streaming for audio modality."""
 
+    _usage_class = AudioUsage
+    _finish_reason_class = AudioFinishReason
+
     def __init__(
         self,
         sse_iterator: AsyncIterator[dict[str, Any]],

--- a/src/celeste/modalities/embeddings/client.py
+++ b/src/celeste/modalities/embeddings/client.py
@@ -8,7 +8,12 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import EmbeddingsContent
 
-from .io import EmbeddingsInput, EmbeddingsOutput
+from .io import (
+    EmbeddingsFinishReason,
+    EmbeddingsInput,
+    EmbeddingsOutput,
+    EmbeddingsUsage,
+)
 from .parameters import EmbeddingsParameters
 
 
@@ -20,6 +25,8 @@ class EmbeddingsClient(
     """Base embeddings client. Providers implement operation methods."""
 
     modality: Modality = Modality.EMBEDDINGS
+    _usage_class = EmbeddingsUsage
+    _finish_reason_class = EmbeddingsFinishReason
 
     @classmethod
     def _output_class(cls) -> type[EmbeddingsOutput]:

--- a/src/celeste/modalities/embeddings/providers/google/client.py
+++ b/src/celeste/modalities/embeddings/providers/google/client.py
@@ -9,11 +9,7 @@ from celeste.providers.google.embeddings.client import (
 from celeste.types import EmbeddingsContent
 
 from ...client import EmbeddingsClient
-from ...io import (
-    EmbeddingsFinishReason,
-    EmbeddingsInput,
-    EmbeddingsUsage,
-)
+from ...io import EmbeddingsInput
 from ...parameters import EmbeddingsParameters
 from .parameters import GOOGLE_PARAMETER_MAPPERS
 
@@ -43,11 +39,6 @@ class GoogleEmbeddingsClient(GoogleEmbeddingsMixin, EmbeddingsClient):
                 ]
             }
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> EmbeddingsUsage:
-        """Parse usage from response (embeddings API doesn't provide usage)."""
-        usage = super()._parse_usage(response_data)
-        return EmbeddingsUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -55,13 +46,6 @@ class GoogleEmbeddingsClient(GoogleEmbeddingsMixin, EmbeddingsClient):
     ) -> EmbeddingsContent:
         """Parse embedding vectors from response."""
         return super()._parse_content(response_data)
-
-    def _parse_finish_reason(
-        self, response_data: dict[str, Any]
-    ) -> EmbeddingsFinishReason:
-        """Parse finish reason (embeddings API doesn't provide finish reasons)."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return EmbeddingsFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["GoogleEmbeddingsClient"]

--- a/src/celeste/modalities/images/client.py
+++ b/src/celeste/modalities/images/client.py
@@ -9,7 +9,7 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import ImageContent
 
-from .io import ImageInput, ImageOutput
+from .io import ImageFinishReason, ImageInput, ImageOutput, ImageUsage
 from .parameters import ImageParameters
 from .streaming import ImagesStream
 
@@ -20,6 +20,8 @@ class ImagesClient(
     """Base images client. Providers implement generate/edit methods."""
 
     modality: Modality = Modality.IMAGES
+    _usage_class = ImageUsage
+    _finish_reason_class = ImageFinishReason
 
     @classmethod
     def _output_class(cls) -> type[ImageOutput]:

--- a/src/celeste/modalities/images/providers/bfl/client.py
+++ b/src/celeste/modalities/images/providers/bfl/client.py
@@ -9,7 +9,7 @@ from celeste.providers.bfl.images.client import BFLImagesClient as _BFLImagesCli
 from celeste.providers.bfl.images.utils import encode_image
 
 from ...client import ImagesClient
-from ...io import ImageFinishReason, ImageInput, ImageOutput, ImageUsage
+from ...io import ImageFinishReason, ImageInput, ImageOutput
 from ...parameters import ImageParameters
 from .parameters import BFL_PARAMETER_MAPPERS
 
@@ -54,11 +54,6 @@ class BFLImagesClient(_BFLImagesClient, ImagesClient):
         if inputs.image is not None:
             request["input_image"] = encode_image(inputs.image)
         return request
-
-    def _parse_usage(self, response_data: dict[str, Any]) -> ImageUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return ImageUsage(**usage)
 
     def _parse_content(
         self,

--- a/src/celeste/modalities/images/providers/google/imagen.py
+++ b/src/celeste/modalities/images/providers/google/imagen.py
@@ -10,7 +10,7 @@ from celeste.providers.google.imagen.client import GoogleImagenClient
 from celeste.types import ImageContent
 
 from ...client import ImagesClient
-from ...io import ImageFinishReason, ImageInput, ImageOutput, ImageUsage
+from ...io import ImageInput, ImageOutput
 from ...parameters import ImageParameters
 from .parameters import IMAGEN_PARAMETER_MAPPERS
 
@@ -41,11 +41,6 @@ class ImagenImagesClient(GoogleImagenClient, ImagesClient):
             "parameters": {},
         }
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> ImageUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return ImageUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -70,11 +65,6 @@ class ImagenImagesClient(GoogleImagenClient, ImagesClient):
         if len(images) == 1:
             return images[0]
         return images if images else ImageArtifact()
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> ImageFinishReason:
-        """Imagen API doesn't provide finish reasons."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return ImageFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["ImagenImagesClient"]

--- a/src/celeste/modalities/images/providers/xai/client.py
+++ b/src/celeste/modalities/images/providers/xai/client.py
@@ -9,10 +9,8 @@ from celeste.providers.xai.images.client import XAIImagesClient as XAIImagesMixi
 
 from ...client import ImagesClient
 from ...io import (
-    ImageFinishReason,
     ImageInput,
     ImageOutput,
-    ImageUsage,
 )
 from ...parameters import ImageParameters
 from .parameters import XAI_PARAMETER_MAPPERS
@@ -65,11 +63,6 @@ class XAIImagesClient(XAIImagesMixin, ImagesClient):
             **parameters,
         )
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> ImageUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return ImageUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -90,11 +83,6 @@ class XAIImagesClient(XAIImagesMixin, ImagesClient):
 
         msg = "No image URL or base64 data in response"
         raise ValueError(msg)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> ImageFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return ImageFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["XAIImagesClient"]

--- a/src/celeste/modalities/images/streaming.py
+++ b/src/celeste/modalities/images/streaming.py
@@ -16,6 +16,9 @@ from .parameters import ImageParameters
 class ImagesStream(Stream[ImageOutput, ImageParameters, ImageChunk]):
     """Streaming for images modality."""
 
+    _usage_class = ImageUsage
+    _finish_reason_class = ImageFinishReason
+
     def __init__(
         self,
         sse_iterator: AsyncIterator[dict[str, Any]],

--- a/src/celeste/modalities/text/client.py
+++ b/src/celeste/modalities/text/client.py
@@ -8,7 +8,7 @@ from celeste.client import ModalityClient
 from celeste.core import InputType, Modality
 from celeste.types import AudioContent, ImageContent, Message, TextContent, VideoContent
 
-from .io import TextInput, TextOutput
+from .io import TextFinishReason, TextInput, TextOutput, TextUsage
 from .parameters import TextParameters
 from .streaming import TextStream
 
@@ -20,6 +20,8 @@ class TextClient(ModalityClient[TextInput, TextOutput, TextParameters, TextConte
     """
 
     modality: Modality = Modality.TEXT
+    _usage_class = TextUsage
+    _finish_reason_class = TextFinishReason
 
     @classmethod
     def _output_class(cls) -> type[TextOutput]:

--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -16,10 +16,8 @@ from celeste.utils import detect_mime_type
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -33,22 +31,6 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
         super().__init__(*args, **kwargs)
         self._message_start: dict[str, Any] | None = None
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         event_type = event_data.get("type")
@@ -60,16 +42,16 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
 
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -189,11 +171,6 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
             "data": base64_data,
         }
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -209,11 +186,6 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
                 break
 
         return self._transform_output(text_content, **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/cohere/client.py
+++ b/src/celeste/modalities/text/providers/cohere/client.py
@@ -13,10 +13,8 @@ from celeste.utils import build_image_data_url
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -26,36 +24,20 @@ from .parameters import COHERE_PARAMETER_MAPPERS
 class CohereTextStream(_CohereChatStream, TextStream):
     """Cohere streaming for text modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -126,11 +108,6 @@ class CohereTextClient(CohereChatClient, TextClient):
 
         return {"messages": [{"role": "user", "content": content}]}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -141,11 +118,6 @@ class CohereTextClient(CohereChatClient, TextClient):
         first_content = content_array[0]
         text = first_content.get("text") or ""
         return self._transform_output(text, **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/deepseek/client.py
+++ b/src/celeste/modalities/text/providers/deepseek/client.py
@@ -12,10 +12,8 @@ from celeste.types import Message, TextContent
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -25,36 +23,20 @@ from .parameters import DEEPSEEK_PARAMETER_MAPPERS
 class DeepSeekTextStream(_DeepSeekChatStream, TextStream):
     """DeepSeek streaming for text modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -106,11 +88,6 @@ class DeepSeekTextClient(DeepSeekChatClient, TextClient):
 
         return {"messages": messages}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -121,11 +98,6 @@ class DeepSeekTextClient(DeepSeekChatClient, TextClient):
         message = choices[0].get("message", {})
         content = message.get("content") or ""
         return self._transform_output(content, **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -16,10 +16,8 @@ from celeste.utils import detect_mime_type
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -29,36 +27,20 @@ from .parameters import GOOGLE_PARAMETER_MAPPERS
 class GoogleTextStream(_GoogleGenerateContentStream, TextStream):
     """Google streaming for text modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -218,11 +200,6 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
 
         return {"inline_data": {"mime_type": mime_str, "data": b64}}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -233,11 +210,6 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
         parts = candidates[0].get("content", {}).get("parts", [])
         text = parts[0].get("text") if parts else ""
         return self._transform_output(text or "", **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/mistral/client.py
+++ b/src/celeste/modalities/text/providers/mistral/client.py
@@ -13,10 +13,8 @@ from celeste.utils import build_image_data_url
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -26,36 +24,20 @@ from .parameters import MISTRAL_PARAMETER_MAPPERS
 class MistralTextStream(_MistralChatStream, TextStream):
     """Mistral streaming for text modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -123,11 +105,6 @@ class MistralTextClient(MistralChatClient, TextClient):
 
         return {"messages": [{"role": "user", "content": content}]}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -148,11 +125,6 @@ class MistralTextClient(MistralChatClient, TextClient):
             content = "".join(text_parts)
 
         return self._transform_output(content, **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/moonshot/client.py
+++ b/src/celeste/modalities/text/providers/moonshot/client.py
@@ -13,10 +13,8 @@ from celeste.utils import build_image_data_url
 from ...client import TextClient
 from ...io import (
     TextChunk,
-    TextFinishReason,
     TextInput,
     TextOutput,
-    TextUsage,
 )
 from ...parameters import TextParameters
 from ...streaming import TextStream
@@ -26,36 +24,20 @@ from .parameters import MOONSHOT_PARAMETER_MAPPERS
 class MoonshotTextStream(_MoonshotChatStream, TextStream):
     """Moonshot streaming for text modality."""
 
-    def _parse_chunk_usage(self, event_data: dict[str, Any]) -> TextUsage | None:
-        """Parse and wrap usage from SSE event."""
-        usage = super()._parse_chunk_usage(event_data)
-        if usage:
-            return TextUsage(**usage)
-        return None
-
-    def _parse_chunk_finish_reason(
-        self, event_data: dict[str, Any]
-    ) -> TextFinishReason | None:
-        """Parse and wrap finish reason from SSE event."""
-        finish_reason = super()._parse_chunk_finish_reason(event_data)
-        if finish_reason:
-            return TextFinishReason(reason=finish_reason.reason)
-        return None
-
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
         """Parse one SSE event into a typed chunk."""
         content = self._parse_chunk_content(event_data)
         if content is None:
-            usage = self._parse_chunk_usage(event_data)
-            finish_reason = self._parse_chunk_finish_reason(event_data)
+            usage = self._get_chunk_usage(event_data)
+            finish_reason = self._get_chunk_finish_reason(event_data)
             if usage is None and finish_reason is None:
                 return None
             content = ""
 
         return TextChunk(
             content=content,
-            finish_reason=self._parse_chunk_finish_reason(event_data),
-            usage=self._parse_chunk_usage(event_data),
+            finish_reason=self._get_chunk_finish_reason(event_data),
+            usage=self._get_chunk_usage(event_data),
             metadata={"event_data": event_data},
         )
 
@@ -123,11 +105,6 @@ class MoonshotTextClient(MoonshotChatClient, TextClient):
 
         return {"messages": [{"role": "user", "content": content}]}
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> TextUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return TextUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -138,11 +115,6 @@ class MoonshotTextClient(MoonshotChatClient, TextClient):
         message = choices[0].get("message", {})
         content = message.get("content") or ""
         return self._transform_output(content, **parameters)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> TextFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return TextFinishReason(reason=finish_reason.reason)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/streaming.py
+++ b/src/celeste/modalities/text/streaming.py
@@ -15,6 +15,9 @@ from .parameters import TextParameters
 class TextStream(Stream[TextOutput, TextParameters, TextChunk]):
     """Streaming for text modality."""
 
+    _usage_class = TextUsage
+    _finish_reason_class = TextFinishReason
+
     def __init__(
         self,
         sse_iterator: AsyncIterator[dict[str, Any]],

--- a/src/celeste/modalities/videos/client.py
+++ b/src/celeste/modalities/videos/client.py
@@ -8,7 +8,7 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import VideoContent
 
-from .io import VideoInput, VideoOutput
+from .io import VideoFinishReason, VideoInput, VideoOutput, VideoUsage
 from .parameters import VideoParameters
 
 
@@ -18,6 +18,8 @@ class VideosClient(
     """Base videos client. Providers implement generate method."""
 
     modality: Modality = Modality.VIDEOS
+    _usage_class = VideoUsage
+    _finish_reason_class = VideoFinishReason
 
     @classmethod
     def _output_class(cls) -> type[VideoOutput]:

--- a/src/celeste/modalities/videos/providers/byteplus/client.py
+++ b/src/celeste/modalities/videos/providers/byteplus/client.py
@@ -10,7 +10,7 @@ from celeste.providers.byteplus.videos.client import (
 )
 
 from ...client import VideosClient
-from ...io import VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from ...io import VideoInput, VideoOutput
 from ...parameters import VideoParameters
 from .parameters import BYTEPLUS_PARAMETER_MAPPERS
 
@@ -41,11 +41,6 @@ class BytePlusVideosClient(BytePlusVideosMixin, VideosClient):
             **parameters,
         )
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> VideoUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return VideoUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -58,11 +53,6 @@ class BytePlusVideosClient(BytePlusVideosMixin, VideosClient):
             msg = "No video_url in response content"
             raise ValueError(msg)
         return VideoArtifact(url=video_url)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return VideoFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["BytePlusVideosClient"]

--- a/src/celeste/modalities/videos/providers/google/client.py
+++ b/src/celeste/modalities/videos/providers/google/client.py
@@ -9,7 +9,7 @@ from celeste.providers.google.veo import config
 from celeste.providers.google.veo.client import GoogleVeoClient as GoogleVeoMixin
 
 from ...client import VideosClient
-from ...io import VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from ...io import VideoInput, VideoOutput
 from ...parameters import VideoParameters
 from .parameters import GOOGLE_PARAMETER_MAPPERS
 
@@ -40,11 +40,6 @@ class GoogleVideosClient(GoogleVeoMixin, VideosClient):
             **parameters,
         )
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> VideoUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return VideoUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -59,11 +54,6 @@ class GoogleVideosClient(GoogleVeoMixin, VideosClient):
                 data=video_data["bytesBase64Encoded"], mime_type=mime_type
             )
         return VideoArtifact(url=video_data.get("uri"))
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return VideoFinishReason(reason=finish_reason.reason)
 
     async def download_content(self, artifact: VideoArtifact) -> VideoArtifact:
         """Download video content from GCS URL.

--- a/src/celeste/modalities/videos/providers/openai/client.py
+++ b/src/celeste/modalities/videos/providers/openai/client.py
@@ -11,7 +11,7 @@ from celeste.providers.openai.videos.client import (
 )
 
 from ...client import VideosClient
-from ...io import VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from ...io import VideoInput, VideoOutput
 from ...parameters import VideoParameters
 from .parameters import OPENAI_PARAMETER_MAPPERS
 
@@ -42,11 +42,6 @@ class OpenAIVideosClient(OpenAIVideosMixin, VideosClient):
             **parameters,
         )
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> VideoUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return VideoUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -58,11 +53,6 @@ class OpenAIVideosClient(OpenAIVideosMixin, VideosClient):
             data=video_data_b64,
             mime_type=VideoMimeType.MP4,
         )
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return VideoFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["OpenAIVideosClient"]

--- a/src/celeste/modalities/videos/providers/xai/client.py
+++ b/src/celeste/modalities/videos/providers/xai/client.py
@@ -8,7 +8,7 @@ from celeste.providers.xai.videos import config
 from celeste.providers.xai.videos.client import XAIVideosClient as XAIVideosMixin
 
 from ...client import VideosClient
-from ...io import VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from ...io import VideoInput, VideoOutput
 from ...parameters import VideoParameters
 from .parameters import XAI_PARAMETER_MAPPERS
 
@@ -54,11 +54,6 @@ class XAIVideosClient(XAIVideosMixin, VideosClient):
             **parameters,
         )
 
-    def _parse_usage(self, response_data: dict[str, Any]) -> VideoUsage:
-        """Parse usage from response."""
-        usage = super()._parse_usage(response_data)
-        return VideoUsage(**usage)
-
     def _parse_content(
         self,
         response_data: dict[str, Any],
@@ -68,11 +63,6 @@ class XAIVideosClient(XAIVideosMixin, VideosClient):
         # xAI returns video URL directly
         url = super()._parse_content(response_data)
         return VideoArtifact(url=url)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
-        """Parse finish reason from response."""
-        finish_reason = super()._parse_finish_reason(response_data)
-        return VideoFinishReason(reason=finish_reason.reason)
 
 
 __all__ = ["XAIVideosClient"]

--- a/src/celeste/types.py
+++ b/src/celeste/types.py
@@ -19,6 +19,8 @@ type EmbeddingsContent = list[float] | list[list[float]]
 
 type Content = str | JsonValue | dict[str, Any] | list[JsonValue | dict[str, Any]]
 
+type RawUsage = dict[str, int | float | None]
+
 
 class Role(StrEnum):
     """Message role in a conversation."""
@@ -45,6 +47,7 @@ __all__ = [
     "ImageContent",
     "JsonValue",
     "Message",
+    "RawUsage",
     "Role",
     "TextContent",
     "VideoContent",


### PR DESCRIPTION
## Summary
- Move modality-specific type wrapping (e.g. `Usage` → `TextUsage`) from individual provider overrides into base `ModalityClient` and `Stream` classes via `_usage_class`/`_finish_reason_class` class variables and `_get_*` wrapper methods
- Eliminate identical boilerplate `_parse_usage`/`_parse_finish_reason`/`_parse_chunk_usage`/`_parse_chunk_finish_reason` overrides across ~25 provider clients
- Add `RawUsage` type alias in `types.py` for the provider-layer dict format

## Test plan
- [x] All existing unit tests pass (472 passed)
- [x] Coverage threshold met (80%+)
- [x] mypy passes with no errors
- [x] Ruff lint and format pass