### PR TITLE
fix: use strict=False in json.loads for structured output parsing

### DIFF
--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -208,7 +208,7 @@ class OutputFormatMapper(ParameterMapper):
         if isinstance(content, dict):
             parsed = content
         elif isinstance(content, str):
-            parsed = json.loads(content)
+            parsed = json.loads(content, strict=False)
         else:
             parsed = content
 

--- a/src/celeste/providers/cohere/chat/parameters.py
+++ b/src/celeste/providers/cohere/chat/parameters.py
@@ -125,7 +125,7 @@ class ResponseFormatMapper(ParameterMapper):
             return content
 
         if isinstance(content, str):
-            parsed = json.loads(content)
+            parsed = json.loads(content, strict=False)
         else:
             parsed = content
 

--- a/src/celeste/providers/deepseek/chat/parameters.py
+++ b/src/celeste/providers/deepseek/chat/parameters.py
@@ -79,7 +79,7 @@ class ResponseFormatMapper(ParameterMapper):
             return content
 
         if isinstance(content, str):
-            parsed = json.loads(content)
+            parsed = json.loads(content, strict=False)
         else:
             parsed = content
 

--- a/src/celeste/providers/google/generate_content/parameters.py
+++ b/src/celeste/providers/google/generate_content/parameters.py
@@ -232,7 +232,9 @@ class ResponseJsonSchemaMapper(ParameterMapper):
         if isinstance(content, list) and content and isinstance(content[0], BaseModel):
             return content
 
-        parsed = json.loads(content) if isinstance(content, str) else content
+        parsed = (
+            json.loads(content, strict=False) if isinstance(content, str) else content
+        )
 
         # For list[T], handle various formats Google might return
         origin = get_origin(value)

--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -210,7 +210,9 @@ class ResponseFormatMapper(ParameterMapper):
         if isinstance(content, list) and content and isinstance(content[0], BaseModel):
             return content
 
-        parsed = json.loads(content) if isinstance(content, str) else content
+        parsed = (
+            json.loads(content, strict=False) if isinstance(content, str) else content
+        )
 
         # For list[T], handle various formats Google might return
         origin = get_origin(value)

--- a/src/celeste/providers/groq/chat/parameters.py
+++ b/src/celeste/providers/groq/chat/parameters.py
@@ -108,7 +108,9 @@ class ResponseFormatMapper(ParameterMapper):
         if isinstance(content, list) and content and isinstance(content[0], BaseModel):
             return content
 
-        parsed_json = json.loads(content) if isinstance(content, str) else content
+        parsed_json = (
+            json.loads(content, strict=False) if isinstance(content, str) else content
+        )
 
         # Unwrap list from items wrapper
         origin = get_origin(value)

--- a/src/celeste/providers/mistral/chat/parameters.py
+++ b/src/celeste/providers/mistral/chat/parameters.py
@@ -121,7 +121,7 @@ class ResponseFormatMapper(ParameterMapper):
             return content
 
         if isinstance(content, str):
-            parsed = json.loads(content)
+            parsed = json.loads(content, strict=False)
         else:
             parsed = content
         return TypeAdapter(value).validate_python(parsed)

--- a/src/celeste/providers/moonshot/chat/parameters.py
+++ b/src/celeste/providers/moonshot/chat/parameters.py
@@ -79,7 +79,7 @@ class ResponseFormatMapper(ParameterMapper):
             return content
 
         if isinstance(content, str):
-            parsed = json.loads(content)
+            parsed = json.loads(content, strict=False)
         else:
             parsed = content
 


### PR DESCRIPTION
## Summary
- Fix `json.loads` strict mode crashing structured output parsing across all providers
- LLM-generated structured output (e.g. thinking fields with literal `\n`) causes `Invalid control character` errors on the second JSON decode in `parse_output()`
- Changed `json.loads(content)` → `json.loads(content, strict=False)` in all 8 provider `parse_output` methods

## Files changed
- `providers/anthropic/messages/parameters.py`
- `providers/cohere/chat/parameters.py`
- `providers/deepseek/chat/parameters.py`
- `providers/google/generate_content/parameters.py`
- `providers/google/interactions/parameters.py`
- `providers/groq/chat/parameters.py`
- `providers/mistral/chat/parameters.py`
- `providers/moonshot/chat/parameters.py`

## Why not centralized
`_transform_output` in `client.py` is a generic mapper dispatcher — adding JSON-specific pre-processing there would couple the dispatcher to one mapper's implementation detail. The fix belongs where `json.loads` is called.

## Test plan
- [x] All 472 unit tests pass
- [x] Coverage threshold met (80%+)
- [x] mypy passes
- [x] Ruff lint and format pass