### PR TITLE
refactor: add _json_headers() helper to APIMixin

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -13,6 +13,7 @@ from celeste.core import Modality, Provider
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.http import HTTPClient, get_http_client
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
+from celeste.mime_types import ApplicationMimeType
 from celeste.models import Model
 from celeste.parameters import ParameterMapper, Parameters
 from celeste.streaming import Stream
@@ -51,6 +52,10 @@ class APIMixin(ABC):
     def http_client(self) -> HTTPClient:
         """HTTP client with connection pooling for this provider."""
         ...
+
+    def _json_headers(self) -> dict[str, str]:
+        """Build standard JSON request headers with auth."""
+        return {**self.auth.get_headers(), "Content-Type": ApplicationMimeType.JSON}
 
     @staticmethod
     def _deep_merge(

--- a/src/celeste/protocols/chatcompletions/client.py
+++ b/src/celeste/protocols/chatcompletions/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -79,10 +78,7 @@ class ChatCompletionsClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -104,10 +100,7 @@ class ChatCompletionsClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             self._build_url(endpoint, streaming=True),

--- a/src/celeste/protocols/openresponses/client.py
+++ b/src/celeste/protocols/openresponses/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -79,10 +78,7 @@ class OpenResponsesClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -104,10 +100,7 @@ class OpenResponsesClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             self._build_url(endpoint, streaming=True),

--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -49,12 +49,7 @@ class BFLImagesClient(APIMixin):
         2. Poll polling_url until Ready/Failed
         3. Return response with _submit_metadata for usage parsing
         """
-        auth_headers = self.auth.get_headers()
-        headers = {
-            **auth_headers,
-            "Content-Type": ApplicationMimeType.JSON,
-            "Accept": ApplicationMimeType.JSON,
-        }
+        headers = {**self._json_headers(), "Accept": ApplicationMimeType.JSON}
 
         if endpoint is None:
             endpoint = config.BFLImagesEndpoint.CREATE_IMAGE
@@ -77,10 +72,7 @@ class BFLImagesClient(APIMixin):
 
         # Phase 2: Poll for completion
         start_time = time.monotonic()
-        poll_headers = {
-            **auth_headers,
-            "Accept": ApplicationMimeType.JSON,
-        }
+        poll_headers = {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON}
 
         while True:
             elapsed = time.monotonic() - start_time

--- a/src/celeste/providers/byteplus/images/client.py
+++ b/src/celeste/providers/byteplus/images/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -57,10 +56,7 @@ class BytePlusImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -82,10 +78,7 @@ class BytePlusImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/byteplus/videos/client.py
+++ b/src/celeste/providers/byteplus/videos/client.py
@@ -10,7 +10,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -67,11 +66,7 @@ class BytePlusVideosClient(APIMixin):
         2. Poll CONTENT_STATUS endpoint until succeeded/failed/canceled
         3. Return response with final status data
         """
-        auth_headers = self.auth.get_headers()
-        headers = {
-            **auth_headers,
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         if endpoint is None:
             endpoint = config.BytePlusVideosEndpoint.CREATE_VIDEO

--- a/src/celeste/providers/cohere/chat/client.py
+++ b/src/celeste/providers/cohere/chat/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -59,10 +58,7 @@ class CohereChatClient(APIMixin):
         if endpoint is None:
             endpoint = config.CohereChatEndpoint.CREATE_CHAT
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -84,10 +80,7 @@ class CohereChatClient(APIMixin):
         if endpoint is None:
             endpoint = config.CohereChatEndpoint.CREATE_CHAT
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/elevenlabs/text_to_speech/client.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/client.py
@@ -7,7 +7,7 @@ import httpx
 
 from celeste.client import APIMixin
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType, AudioMimeType
+from celeste.mime_types import AudioMimeType
 
 from . import config
 
@@ -55,10 +55,7 @@ class ElevenLabsTextToSpeechClient(APIMixin):
             endpoint = config.ElevenLabsTextToSpeechEndpoint.CREATE_SPEECH
         endpoint = endpoint.format(voice_id=voice_id)
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -96,10 +93,7 @@ class ElevenLabsTextToSpeechClient(APIMixin):
             endpoint = config.ElevenLabsTextToSpeechEndpoint.STREAM_SPEECH
         endpoint = endpoint.format(voice_id=voice_id)
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self._stream_binary_audio(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/google/cloud_tts/client.py
+++ b/src/celeste/providers/google/cloud_tts/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from ..auth import GoogleADC
 from . import config
@@ -67,10 +66,7 @@ class GoogleCloudTTSClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleCloudTTSEndpoint.CREATE_SPEECH
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/google/embeddings/client.py
+++ b/src/celeste/providers/google/embeddings/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from ..auth import GoogleADC
 from . import config
@@ -96,10 +95,7 @@ class GoogleEmbeddingsClient(APIMixin):
         if endpoint is None:
             endpoint = endpoint_template
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             self._build_url(endpoint),

--- a/src/celeste/providers/google/generate_content/client.py
+++ b/src/celeste/providers/google/generate_content/client.py
@@ -6,7 +6,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from ..auth import GoogleADC
 from . import config
@@ -70,10 +69,7 @@ class GoogleGenerateContentClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleGenerateContentEndpoint.GENERATE_CONTENT
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         response = await self.http_client.post(
             url=self._build_url(endpoint),
             headers=headers,
@@ -94,10 +90,7 @@ class GoogleGenerateContentClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleGenerateContentEndpoint.STREAM_GENERATE_CONTENT
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         return self.http_client.stream_post(
             url=self._build_url(endpoint),
             headers=headers,

--- a/src/celeste/providers/google/imagen/client.py
+++ b/src/celeste/providers/google/imagen/client.py
@@ -7,7 +7,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from ..auth import GoogleADC
 from . import config
@@ -67,10 +66,7 @@ class GoogleImagenClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleImagenEndpoint.CREATE_IMAGE
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         response = await self.http_client.post(
             self._build_url(endpoint),
             headers=headers,

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -8,7 +8,6 @@ import httpx
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -66,10 +65,7 @@ class GoogleInteractionsClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
@@ -90,10 +86,7 @@ class GoogleInteractionsClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleInteractionsEndpoint.STREAM_INTERACTION
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,

--- a/src/celeste/providers/google/veo/client.py
+++ b/src/celeste/providers/google/veo/client.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from ..auth import GoogleADC
 from . import config
@@ -72,10 +71,7 @@ class GoogleVeoClient(APIMixin):
         Vertex AI uses POST to fetchPredictOperation with operationName in body.
         AI Studio uses GET to /v1beta/{operation_name}.
         """
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
         poll_url = self._build_poll_url(operation_name)
 
         if isinstance(self.auth, GoogleADC):
@@ -117,11 +113,7 @@ class GoogleVeoClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
 
-        auth_headers = self.auth.get_headers()
-        headers = {
-            **auth_headers,
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         logger.info(f"Initiating video generation with model {self.model.id}")
         response = await self.http_client.post(

--- a/src/celeste/providers/ollama/generate/client.py
+++ b/src/celeste/providers/ollama/generate/client.py
@@ -7,7 +7,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -56,10 +55,7 @@ class OllamaGenerateClient(APIMixin):
         if base_url is None:
             base_url = config.DEFAULT_BASE_URL
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{base_url}{endpoint}",
@@ -84,10 +80,7 @@ class OllamaGenerateClient(APIMixin):
         if base_url is None:
             base_url = config.DEFAULT_BASE_URL
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post_ndjson(
             f"{base_url}{endpoint}",

--- a/src/celeste/providers/openai/audio/client.py
+++ b/src/celeste/providers/openai/audio/client.py
@@ -6,7 +6,7 @@ from typing import Any
 from celeste.client import APIMixin
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType, AudioMimeType
+from celeste.mime_types import AudioMimeType
 
 from . import config
 
@@ -68,10 +68,7 @@ class OpenAIAudioClient(APIMixin):
         if endpoint is None:
             endpoint = config.OpenAIAudioEndpoint.CREATE_SPEECH
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -11,7 +11,6 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 from celeste.utils import detect_mime_type
 
 from . import config
@@ -75,10 +74,7 @@ class OpenAIImagesClient(APIMixin):
         if self.model.id in ("dall-e-2", "dall-e-3"):
             request_body.setdefault("response_format", "b64_json")
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -141,10 +137,7 @@ class OpenAIImagesClient(APIMixin):
         if "partial_images" not in request_body:
             request_body["partial_images"] = 1
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/openai/videos/client.py
+++ b/src/celeste/providers/openai/videos/client.py
@@ -14,7 +14,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -86,10 +85,7 @@ class OpenAIVideosClient(APIMixin):
         if endpoint is None:
             endpoint = config.OpenAIVideosEndpoint.CREATE_VIDEO
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         files, data = await self._prepare_multipart_request(request_body.copy())
 

--- a/src/celeste/providers/xai/images/client.py
+++ b/src/celeste/providers/xai/images/client.py
@@ -7,7 +7,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -54,10 +53,7 @@ class XAIImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.XAIImagesEndpoint.CREATE_IMAGE
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/xai/videos/client.py
+++ b/src/celeste/providers/xai/videos/client.py
@@ -8,7 +8,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -66,10 +65,7 @@ class XAIVideosClient(APIMixin):
         if endpoint is None:
             endpoint = config.XAIVideosEndpoint.CREATE_VIDEO
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         # Submit video generation request
         response = await self.http_client.post(

--- a/templates/providers/{provider_slug}/{api_slug}/client.py.template
+++ b/templates/providers/{provider_slug}/{api_slug}/client.py.template
@@ -9,7 +9,6 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
 
 from . import config
 
@@ -85,10 +84,7 @@ class {Provider}{Api}Client(APIMixin):
         if endpoint is None:
             endpoint = config.{Provider}{Api}Endpoint.CREATE_...
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -122,10 +118,7 @@ class {Provider}{Api}Client(APIMixin):
         if endpoint is None:
             endpoint = config.{Provider}{Api}Endpoint.CREATE_...
 
-        headers = {
-            **self.auth.get_headers(),
-            "Content-Type": ApplicationMimeType.JSON,
-        }
+        headers = self._json_headers()
 
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",


### PR DESCRIPTION
## Summary

- Adds `APIMixin._json_headers() -> dict[str, str]` — a one-line helper that returns `{**self.auth.get_headers(), "Content-Type": ApplicationMimeType.JSON}`
- Replaces all verbatim call sites across every provider and protocol client with `headers = self._json_headers()`
- Providers that add extra headers compose naturally: `{**self._json_headers(), "Accept": ApplicationMimeType.JSON}` (BFL)
- Updates the provider scaffolding template so new providers get the pattern for free
- Removes now-unused `ApplicationMimeType` imports from each affected file

## Files changed

| File | Change |
|------|--------|
| `src/celeste/client.py` | Add `_json_headers()` to `APIMixin` |
| `src/celeste/protocols/chatcompletions/client.py` | 2 call sites |
| `src/celeste/protocols/openresponses/client.py` | 2 call sites |
| `src/celeste/providers/bfl/images/client.py` | 1 call site (composes with extra `Accept` header) |
| `src/celeste/providers/byteplus/images/client.py` | 2 call sites |
| `src/celeste/providers/byteplus/videos/client.py` | 1 call site |
| `src/celeste/providers/cohere/chat/client.py` | 2 call sites |
| `src/celeste/providers/elevenlabs/text_to_speech/client.py` | 2 call sites |
| `src/celeste/providers/google/cloud_tts/client.py` | 1 call site |
| `src/celeste/providers/google/embeddings/client.py` | 1 call site |
| `src/celeste/providers/google/generate_content/client.py` | 2 call sites |
| `src/celeste/providers/google/imagen/client.py` | 1 call site |
| `src/celeste/providers/google/interactions/client.py` | 2 call sites |
| `src/celeste/providers/google/veo/client.py` | 2 call sites |
| `src/celeste/providers/ollama/generate/client.py` | 2 call sites |
| `src/celeste/providers/openai/audio/client.py` | 1 call site |
| `src/celeste/providers/openai/images/client.py` | 2 call sites |
| `src/celeste/providers/openai/videos/client.py` | 1 call site |
| `src/celeste/providers/xai/images/client.py` | 1 call site |
| `src/celeste/providers/xai/videos/client.py` | 1 call site |
| `templates/providers/{provider_slug}/{api_slug}/client.py.template` | 2 call sites |

## Test plan

- [x] All pre-commit hooks pass (ruff, mypy, bandit, coverage)
- [x] No behavioral changes — identical header construction logic, only location changed

Closes #156