### PR TITLE
fix: catch UnicodeDecodeError in _handle_error_response

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -324,7 +324,13 @@ class ModalityClient[In: Input, Out: Output, Params: Parameters, Content](
         if not response.is_success:
             try:
                 error_msg = response.json()["error"]["message"]
-            except (JSONDecodeError, KeyError, TypeError, IndexError):
+            except (
+                JSONDecodeError,
+                KeyError,
+                TypeError,
+                IndexError,
+                UnicodeDecodeError,
+            ):
                 error_msg = response.text or f"HTTP {response.status_code}"
 
             raise httpx.HTTPStatusError(


### PR DESCRIPTION
Closes #170

## Summary

- `_handle_error_response` now catches `UnicodeDecodeError` from `response.json()` on binary error bodies
- Adds parametrized unit tests covering three binary payload patterns (`0xff`, UTF-32-LE BOM, high bytes)

## Root cause

`json.loads()` performs BOM detection on raw bytes. When a provider returns a binary error body (e.g. `b'\xff ...'`), `json.loads()` raises `UnicodeDecodeError` — not `JSONDecodeError` — which was not in the `except` tuple, causing it to escape instead of the expected `httpx.HTTPStatusError`.

## Test plan

- [x] All existing unit tests pass
- [x] New `TestHandleErrorResponse` tests verify `httpx.HTTPStatusError` is raised for binary bodies
- [x] Pre-commit hooks pass (ruff, mypy, bandit)