### PR TITLE
refactor: consolidate __init__, _build_stream_metadata, _parse_output into base Stream

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -225,7 +225,11 @@ class ModalityClient[In: Input, Out: Output, Params: Parameters, Content](
         return stream_class(
             sse_iterator,
             transform_output=self._transform_output,
-            client=self,
+            stream_metadata={
+                "model": self.model.id,
+                "provider": self.provider,
+                "modality": self.modality,
+            },
             **parameters,
         )
 

--- a/src/celeste/modalities/audio/providers/elevenlabs/client.py
+++ b/src/celeste/modalities/audio/providers/elevenlabs/client.py
@@ -30,8 +30,9 @@ class ElevenLabsAudioStream(_ElevenLabsTextToSpeechStream, AudioStream):
         """Aggregate audio content from chunks into AudioArtifact."""
         audio_bytes = b"".join(chunk.content for chunk in chunks if chunk.content)
         output_format = self._parameters.get("output_format")
-        client: ElevenLabsAudioClient = self._client
-        mime_type = client._map_output_format_to_mime_type(output_format)
+        mime_type = ElevenLabsTextToSpeechMixin._map_output_format_to_mime_type(
+            output_format
+        )
         return AudioArtifact(data=audio_bytes, mime_type=mime_type)
 
 

--- a/src/celeste/modalities/audio/providers/gradium/client.py
+++ b/src/celeste/modalities/audio/providers/gradium/client.py
@@ -30,8 +30,9 @@ class GradiumAudioStream(_GradiumTextToSpeechStream, AudioStream):
         """Aggregate audio content from chunks into AudioArtifact."""
         audio_bytes = b"".join(chunk.content for chunk in chunks if chunk.content)
         output_format = self._parameters.get("output_format")
-        client: GradiumAudioClient = self._client
-        mime_type = client._map_output_format_to_mime_type(output_format)
+        mime_type = GradiumTextToSpeechMixin._map_output_format_to_mime_type(
+            output_format
+        )
         return AudioArtifact(data=audio_bytes, mime_type=mime_type)
 
 

--- a/src/celeste/modalities/audio/streaming.py
+++ b/src/celeste/modalities/audio/streaming.py
@@ -1,11 +1,8 @@
 """Audio streaming primitives."""
 
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Callable
-from typing import Any, Unpack
 
 from celeste.artifacts import AudioArtifact
-from celeste.client import ModalityClient
 from celeste.streaming import Stream
 
 from .io import (
@@ -23,50 +20,13 @@ class AudioStream(Stream[AudioOutput, AudioParameters, AudioChunk]):
     _usage_class = AudioUsage
     _finish_reason_class = AudioFinishReason
     _chunk_class = AudioChunk
+    _output_class = AudioOutput
     _empty_content = b""
-
-    def __init__(
-        self,
-        sse_iterator: AsyncIterator[dict[str, Any]],
-        transform_output: Callable[..., AudioArtifact],
-        client: ModalityClient,
-        **parameters: Unpack[AudioParameters],
-    ) -> None:
-        super().__init__(sse_iterator, **parameters)
-        self._transform_output = transform_output
-        self._client = client
 
     @abstractmethod
     def _aggregate_content(self, chunks: list[AudioChunk]) -> AudioArtifact:
         """Aggregate content from chunks into AudioArtifact."""
         ...
-
-    def _build_stream_metadata(
-        self, raw_events: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Build streaming metadata."""
-        return {
-            "model": self._client.model.id,
-            "provider": self._client.provider,
-            "modality": self._client.modality,
-            "raw_events": raw_events,
-        }
-
-    def _parse_output(
-        self,
-        chunks: list[AudioChunk],
-        **parameters: Unpack[AudioParameters],
-    ) -> AudioOutput:
-        """Assemble chunks into final output."""
-        raw_content = self._aggregate_content(chunks)
-        content: AudioArtifact = self._transform_output(raw_content, **parameters)
-        raw_events = self._aggregate_event_data(chunks)
-        return AudioOutput(
-            content=content,
-            usage=self._aggregate_usage(chunks),
-            finish_reason=self._aggregate_finish_reason(chunks),
-            metadata=self._build_stream_metadata(raw_events),
-        )
 
 
 __all__ = ["AudioStream"]

--- a/src/celeste/modalities/images/streaming.py
+++ b/src/celeste/modalities/images/streaming.py
@@ -1,13 +1,10 @@
 """Images streaming primitives."""
 
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Callable
-from typing import Any, Unpack
+from typing import Any
 
 from celeste.artifacts import ImageArtifact
-from celeste.client import ModalityClient
 from celeste.streaming import Stream
-from celeste.types import ImageContent
 
 from .io import ImageChunk, ImageFinishReason, ImageOutput, ImageUsage
 from .parameters import ImageParameters
@@ -19,19 +16,8 @@ class ImagesStream(Stream[ImageOutput, ImageParameters, ImageChunk]):
     _usage_class = ImageUsage
     _finish_reason_class = ImageFinishReason
     _chunk_class = ImageChunk
+    _output_class = ImageOutput
     _empty_content = ImageArtifact(data=b"")
-
-    def __init__(
-        self,
-        sse_iterator: AsyncIterator[dict[str, Any]],
-        transform_output: Callable[..., ImageContent],
-        client: ModalityClient,
-        **parameters: Unpack[ImageParameters],
-    ) -> None:
-        """Initialize stream with output transformation support."""
-        super().__init__(sse_iterator, **parameters)
-        self._transform_output = transform_output
-        self._client = client
 
     def _wrap_chunk_content(self, raw_content: Any) -> ImageArtifact:  # noqa: ANN401
         """Wrap raw content (base64 string) into ImageArtifact."""
@@ -41,37 +27,6 @@ class ImagesStream(Stream[ImageOutput, ImageParameters, ImageChunk]):
     def _aggregate_content(self, chunks: list[ImageChunk]) -> ImageArtifact:
         """Aggregate content from chunks into raw content (modality-specific)."""
         ...
-
-    def _build_stream_metadata(
-        self, raw_events: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Build streaming metadata. Provider API Stream overrides to filter content."""
-        return {
-            "model": self._client.model.id,
-            "provider": self._client.provider,
-            "modality": self._client.modality,
-            "raw_events": raw_events,
-        }
-
-    def _parse_output(
-        self,
-        chunks: list[ImageChunk],
-        **parameters: Unpack[ImageParameters],
-    ) -> ImageOutput:
-        """Assemble chunks into final output."""
-        if not chunks:
-            msg = "No chunks received from stream"
-            raise ValueError(msg)
-
-        raw_content = self._aggregate_content(chunks)
-        content: ImageContent = self._transform_output(raw_content, **parameters)
-        raw_events = self._aggregate_event_data(chunks)
-        return ImageOutput(
-            content=content,
-            usage=self._aggregate_usage(chunks),
-            finish_reason=self._aggregate_finish_reason(chunks),
-            metadata=self._build_stream_metadata(raw_events),
-        )
 
 
 __all__ = ["ImagesStream"]

--- a/src/celeste/modalities/text/streaming.py
+++ b/src/celeste/modalities/text/streaming.py
@@ -1,11 +1,6 @@
 """Text streaming primitives."""
 
-from collections.abc import AsyncIterator, Callable
-from typing import Any, Unpack
-
-from celeste.client import ModalityClient
 from celeste.streaming import Stream
-from celeste.types import TextContent
 
 from .io import TextChunk, TextFinishReason, TextOutput, TextUsage
 from .parameters import TextParameters
@@ -17,50 +12,12 @@ class TextStream(Stream[TextOutput, TextParameters, TextChunk]):
     _usage_class = TextUsage
     _finish_reason_class = TextFinishReason
     _chunk_class = TextChunk
+    _output_class = TextOutput
     _empty_content = ""
-
-    def __init__(
-        self,
-        sse_iterator: AsyncIterator[dict[str, Any]],
-        transform_output: Callable[..., TextContent],
-        client: ModalityClient,
-        **parameters: Unpack[TextParameters],
-    ) -> None:
-        """Initialize stream with output transformation support."""
-        super().__init__(sse_iterator, **parameters)
-        self._transform_output = transform_output
-        self._client = client
 
     def _aggregate_content(self, chunks: list[TextChunk]) -> str:
         """Aggregate content from chunks into raw text."""
         return "".join(chunk.content for chunk in chunks)
-
-    def _build_stream_metadata(
-        self, raw_events: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Build streaming metadata. Provider API Stream overrides to filter content."""
-        return {
-            "model": self._client.model.id,
-            "provider": self._client.provider,
-            "modality": self._client.modality,
-            "raw_events": raw_events,
-        }
-
-    def _parse_output(
-        self,
-        chunks: list[TextChunk],
-        **parameters: Unpack[TextParameters],
-    ) -> TextOutput:
-        """Assemble chunks into final output."""
-        raw_content = self._aggregate_content(chunks)
-        content: TextContent = self._transform_output(raw_content, **parameters)
-        raw_events = self._aggregate_event_data(chunks)
-        return TextOutput(
-            content=content,
-            usage=self._aggregate_usage(chunks),
-            finish_reason=self._aggregate_finish_reason(chunks),
-            metadata=self._build_stream_metadata(raw_events),
-        )
 
 
 __all__ = ["TextStream"]

--- a/src/celeste/providers/elevenlabs/text_to_speech/client.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/client.py
@@ -159,8 +159,9 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         """ElevenLabs TTS doesn't provide finish reasons."""
         return FinishReason(reason=None)
 
+    @staticmethod
     def _map_output_format_to_mime_type(
-        self, output_format: str | None
+        output_format: str | None,
     ) -> AudioMimeType:
         """Map ElevenLabs output_format to AudioMimeType.
 

--- a/src/celeste/providers/gradium/text_to_speech/client.py
+++ b/src/celeste/providers/gradium/text_to_speech/client.py
@@ -163,8 +163,8 @@ class GradiumTextToSpeechClient(APIMixin):
             "output_format": output_format,
         }
 
+    @staticmethod
     def _map_output_format_to_mime_type(
-        self,
         output_format: str | None,
     ) -> AudioMimeType:
         """Map Gradium output_format to AudioMimeType.

--- a/templates/modalities/{modality_slug}/streaming.py.template
+++ b/templates/modalities/{modality_slug}/streaming.py.template
@@ -1,10 +1,8 @@
 """{Modality} streaming primitives."""
 
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Callable
-from typing import Any, Unpack
+from typing import Any
 
-from celeste.client import ModalityClient
 from celeste.streaming import Stream
 
 from .io import (
@@ -19,51 +17,16 @@ from .parameters import {Modality}Parameters
 class {Modality}Stream(Stream[{Modality}Output, {Modality}Parameters, {Modality}Chunk]):
     """Streaming for {modality} modality."""
 
+    _usage_class = {Modality}Usage
+    _finish_reason_class = {Modality}FinishReason
     _chunk_class = {Modality}Chunk
+    _output_class = {Modality}Output
     _empty_content = ""  # TODO: Set appropriate empty content for modality
-
-    def __init__(
-        self,
-        sse_iterator: AsyncIterator[dict[str, Any]],
-        transform_output: Callable[..., {Content}],
-        client: ModalityClient,
-        **parameters: Unpack[{Modality}Parameters],
-    ) -> None:
-        super().__init__(sse_iterator, **parameters)
-        self._transform_output = transform_output
-        self._client = client
 
     @abstractmethod
     def _aggregate_content(self, chunks: list[{Modality}Chunk]) -> Any:
         """Aggregate content from chunks into raw content (modality-specific)."""
         ...
-
-    def _build_stream_metadata(
-        self, raw_events: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Build streaming metadata. Provider API Stream overrides to filter content."""
-        return {
-            "model": self._client.model.id,
-            "provider": self._client.provider,
-            "modality": self._client.modality,
-            "raw_events": raw_events,
-        }
-
-    def _parse_output(  # type: ignore[override]
-        self,
-        chunks: list[{Modality}Chunk],
-        **parameters: Unpack[{Modality}Parameters],
-    ) -> {Modality}Output:
-        """Assemble chunks into final output."""
-        raw_content = self._aggregate_content(chunks)
-        content: {Content} = self._transform_output(raw_content, **parameters)
-        raw_events = self._aggregate_event_data(chunks)
-        return {Modality}Output(
-            content=content,
-            usage=self._aggregate_usage(chunks),
-            finish_reason=self._aggregate_finish_reason(chunks),
-            metadata=self._build_stream_metadata(raw_events),
-        )
 
 
 __all__ = ["{Modality}Stream"]

--- a/tests/unit_tests/test_stream_metadata_from_response_data.py
+++ b/tests/unit_tests/test_stream_metadata_from_response_data.py
@@ -52,7 +52,11 @@ async def test_openai_stream_builds_metadata_from_inner_response_data() -> None:
     stream = OpenAITextStream(
         _async_iter(events),
         transform_output=lambda x, **_: x,
-        client=client,
+        stream_metadata={
+            "model": client.model.id,
+            "provider": client.provider,
+            "modality": client.modality,
+        },
         **{},
     )
 
@@ -95,7 +99,11 @@ async def test_google_stream_builds_metadata_from_event_response_data() -> None:
     stream = GoogleTextStream(
         _async_iter([event]),
         transform_output=lambda x, **_: x,
-        client=client,
+        stream_metadata={
+            "model": client.model.id,
+            "provider": client.provider,
+            "modality": client.modality,
+        },
         **{},
     )
 
@@ -138,7 +146,11 @@ async def test_openai_stream_filters_content_only_events() -> None:
     stream = OpenAITextStream(
         _async_iter(events),
         transform_output=lambda x, **_: x,
-        client=client,
+        stream_metadata={
+            "model": client.model.id,
+            "provider": client.provider,
+            "modality": client.modality,
+        },
         **{},
     )
 
@@ -180,7 +192,11 @@ async def test_openai_stream_aggregates_usage_from_last_event() -> None:
     stream = OpenAITextStream(
         _async_iter(events),
         transform_output=lambda x, **_: x,
-        client=client,
+        stream_metadata={
+            "model": client.model.id,
+            "provider": client.provider,
+            "modality": client.modality,
+        },
         **{},
     )
 


### PR DESCRIPTION
## Summary

Closes #169

- Move `__init__`, `_build_stream_metadata`, and `_parse_output` from `TextStream`, `ImagesStream`, and `AudioStream` into the base `Stream` class
- Replace `client=self` with `stream_metadata={...}` dict — streams no longer hold a client reference
- Add `_output_class` ClassVar and abstract `_aggregate_content` to base `Stream`
- Convert `_map_output_format_to_mime_type` to `@staticmethod` on ElevenLabs/Gradium provider mixins (pure functions that never used `self`)
- Each modality stream reduces to ~10-15 lines (ClassVars + `_aggregate_content`)

**~115 net lines removed across 12 files with zero behavioral changes.**

## Test plan

- [x] `pytest tests/unit_tests/test_streaming.py` — 30 base streaming tests pass
- [x] `pytest tests/unit_tests/test_stream_metadata_from_response_data.py` — 4 metadata tests pass
- [x] `pytest tests/unit_tests/` — full 474 unit tests pass
- [x] All pre-commit hooks pass (ruff lint, ruff format, mypy, bandit)
- [x] All pre-push hooks pass (tests with coverage)
- [x] 3 rounds of exhaustive codebase verification: zero stale `self._client`, `client=`, or `ModalityClient` references in stream contexts