### PR TITLE
feat(models): add Gemini 3.1 Pro and Claude Sonnet 4.6

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -78,6 +78,20 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="claude-sonnet-4-6",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Sonnet 4.6",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=64000),
+            TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.WEB_SEARCH: Bool(),
+            TextParameter.IMAGE: ImagesConstraint(),
+        },
+    ),
+    Model(
         id="claude-sonnet-4-20250514",
         provider=Provider.ANTHROPIC,
         display_name="Claude Sonnet 4",

--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -112,4 +112,22 @@ MODELS: list[Model] = [
             TextParameter.AUDIO: AudioConstraint(),
         },
     ),
+    Model(
+        id="gemini-3.1-pro-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.1 Pro",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.WEB_SEARCH: Bool(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+        },
+    ),
 ]


### PR DESCRIPTION
## Summary
- Add `gemini-3.1-pro-preview` with `low`/`medium`/`high` thinking levels (medium is new in 3.1)
- Add `claude-sonnet-4-6` with 64K max tokens and extended thinking support

## Test plan
- [ ] Verify model registration loads correctly
- [ ] Integration test with `gemini-3.1-pro-preview`
- [ ] Integration test with `claude-sonnet-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)