### PR TITLE
fix: move _transform_output to base _predict pipeline

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -164,7 +164,7 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
                 text_content = content_block.get("text") or ""
                 break
 
-        return self._transform_output(text_content, **parameters)
+        return text_content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/cohere/client.py
+++ b/src/celeste/modalities/text/providers/cohere/client.py
@@ -86,7 +86,7 @@ class CohereTextClient(CohereChatClient, TextClient):
         content_array = super()._parse_content(response_data)
         first_content = content_array[0]
         text = first_content.get("text") or ""
-        return self._transform_output(text, **parameters)
+        return text
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/deepseek/client.py
+++ b/src/celeste/modalities/text/providers/deepseek/client.py
@@ -66,7 +66,7 @@ class DeepSeekTextClient(DeepSeekChatClient, TextClient):
         choices = super()._parse_content(response_data)
         message = choices[0].get("message", {})
         content = message.get("content") or ""
-        return self._transform_output(content, **parameters)
+        return content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -178,7 +178,7 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
         candidates = super()._parse_content(response_data)
         parts = candidates[0].get("content", {}).get("parts", [])
         text = parts[0].get("text") if parts else ""
-        return self._transform_output(text or "", **parameters)
+        return text or ""
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/groq/client.py
+++ b/src/celeste/modalities/text/providers/groq/client.py
@@ -84,7 +84,7 @@ class GroqTextClient(GroqChatClient, TextClient):
         choices = super()._parse_content(response_data)
         message = choices[0].get("message", {})
         content = message.get("content") or ""
-        return self._transform_output(content, **parameters)
+        return content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/huggingface/client.py
+++ b/src/celeste/modalities/text/providers/huggingface/client.py
@@ -86,7 +86,7 @@ class HuggingFaceTextClient(HuggingFaceChatClient, TextClient):
         choices = super()._parse_content(response_data)
         message = choices[0].get("message", {})
         content = message.get("content") or ""
-        return self._transform_output(content, **parameters)
+        return content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/mistral/client.py
+++ b/src/celeste/modalities/text/providers/mistral/client.py
@@ -93,7 +93,7 @@ class MistralTextClient(MistralChatClient, TextClient):
                     text_parts.append(block.get("text", ""))
             content = "".join(text_parts)
 
-        return self._transform_output(content, **parameters)
+        return content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/moonshot/client.py
+++ b/src/celeste/modalities/text/providers/moonshot/client.py
@@ -83,7 +83,7 @@ class MoonshotTextClient(MoonshotChatClient, TextClient):
         choices = super()._parse_content(response_data)
         message = choices[0].get("message", {})
         content = message.get("content") or ""
-        return self._transform_output(content, **parameters)
+        return content
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/openai/client.py
+++ b/src/celeste/modalities/text/providers/openai/client.py
@@ -89,9 +89,9 @@ class OpenAITextClient(OpenAIResponsesMixin, TextClient):
                 for part in item.get("content", []):
                     if part.get("type") == "output_text":
                         text = part.get("text") or ""
-                        return self._transform_output(text, **parameters)
+                        return text
 
-        return self._transform_output("", **parameters)
+        return ""
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/openresponses/client.py
+++ b/src/celeste/modalities/text/providers/openresponses/client.py
@@ -115,9 +115,9 @@ class OpenResponsesTextClient(OpenResponsesMixin, TextClient):
                 for part in item.get("content", []):
                     if part.get("type") == "output_text":
                         text = part.get("text") or ""
-                        return self._transform_output(text, **parameters)
+                        return text
 
-        return self._transform_output("", **parameters)
+        return ""
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/xai/client.py
+++ b/src/celeste/modalities/text/providers/xai/client.py
@@ -87,9 +87,9 @@ class XAITextClient(XAIResponsesClient, TextClient):
                 for part in item.get("content", []):
                     if part.get("type") == "output_text":
                         text = part.get("text") or ""
-                        return self._transform_output(text, **parameters)
+                        return text
 
-        return self._transform_output("", **parameters)
+        return ""
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/parameters.py
+++ b/src/celeste/parameters.py
@@ -5,7 +5,6 @@ from enum import StrEnum
 from typing import Any, ClassVar, TypedDict
 
 from celeste.models import Model
-from celeste.types import TextContent
 
 
 class Parameters(TypedDict, total=False):
@@ -32,7 +31,7 @@ class ParameterMapper(ABC):
         """
         ...
 
-    def parse_output(self, content: TextContent, value: object | None) -> TextContent:
+    def parse_output(self, content: Any, value: object | None) -> Any:  # noqa: ANN401
         """Optionally transform parsed content based on parameter value (default: return unchanged)."""
         return content
 

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -32,7 +32,7 @@ class AnthropicMessagesClient(APIMixin):
                 content = super()._parse_content(response_data)  # Raw content array
                 for block in content:
                     if block.get("type") == "text":
-                        return self._transform_output(block.get("text") or "", **parameters)
+                        return block.get("text") or ""
                 return ""
     """
 

--- a/src/celeste/providers/cohere/chat/client.py
+++ b/src/celeste/providers/cohere/chat/client.py
@@ -26,7 +26,7 @@ class CohereChatClient(APIMixin):
             def _parse_content(self, response_data, **parameters):
                 content_array = super()._parse_content(response_data)
                 text = content_array[0].get("text") or ""
-                return self._transform_output(text, **parameters)
+                return text
     """
 
     _content_fields: ClassVar[set[str]] = {"message"}

--- a/src/celeste/providers/google/generate_content/client.py
+++ b/src/celeste/providers/google/generate_content/client.py
@@ -33,7 +33,7 @@ class GoogleGenerateContentClient(APIMixin):
             def _parse_content(self, response_data, **parameters):
                 parts = super()._parse_content(response_data)
                 text = parts[0].get("text") or ""
-                return self._transform_output(text, **parameters)
+                return text
     """
 
     _content_fields: ClassVar[set[str]] = {"candidates"}

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -33,7 +33,7 @@ class GoogleInteractionsClient(APIMixin):
             def _parse_content(self, response_data, **parameters):
                 outputs = super()._parse_content(response_data)
                 text = "".join(o.get("text", "") for o in outputs if o.get("type") == "text")
-                return self._transform_output(text, **parameters)
+                return text
     """
 
     _content_fields: ClassVar[set[str]] = {"outputs"}


### PR DESCRIPTION
## Summary

Closes #142

- Moves `_transform_output()` call from each provider's `_parse_content()` to the base `_predict()` pipeline in `ModalityClient`, preventing silent structured output failures when new providers forget the call
- Removes redundant `_transform_output()` from all 11 text provider `_parse_content()` methods
- Updates 4 provider mixin docstrings that showed the old pattern in usage examples
- Makes `_transform_output` signature generic (`Content` instead of `TextContent`) to work at the base pipeline level
- Changes `ParameterMapper.parse_output` base signature to `Any` as a pragmatic bridge — tracked for proper generic fix in #186

## Test plan

- [x] Added `TestPredictTransformOutput` with 2 integration tests verifying `_predict()` applies `_transform_output` correctly
- [x] All 478 unit tests pass
- [x] mypy passes clean (no type: ignore needed at call sites)
- [x] All pre-commit hooks pass (ruff, mypy, bandit, tests)