### PR TITLE
fix: empty/whitespace credentials should raise MissingCredentialsError

### DIFF
--- a/src/celeste/credentials.py
+++ b/src/celeste/credentials.py
@@ -99,7 +99,7 @@ class Credentials(BaseSettings):
             MissingCredentialsError: If provider requires credentials but none are configured,
                 or the configured value is empty/whitespace-only.
         """
-        if override_key:
+        if override_key is not None:
             raw = (
                 override_key
                 if isinstance(override_key, str)


### PR DESCRIPTION
## Summary

Closes #184

- `get_credentials()` now rejects empty/whitespace `SecretStr` values with `MissingCredentialsError` instead of passing them through to produce invalid HTTP headers
- `has_credential()` now returns `False` for empty/whitespace credentials, which also fixes `list_available_providers()`
- Inverted `test_whitespace_credentials` to assert the new behavior

## Test plan

- [x] `test_whitespace_credentials_are_treated_as_missing` passes for `""`, `"   "`, `"\t\n"`
- [x] All 478 unit tests pass
- [x] All pre-commit hooks pass (ruff, mypy, bandit)