### PR TITLE
fix: enrich streaming HTTP errors with provider-specific messages

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -16,7 +16,7 @@ from celeste.io import Chunk, FinishReason, Input, Output, Usage
 from celeste.mime_types import ApplicationMimeType
 from celeste.models import Model
 from celeste.parameters import ParameterMapper, Parameters
-from celeste.streaming import Stream
+from celeste.streaming import Stream, enrich_stream_errors
 from celeste.types import RawUsage
 
 
@@ -250,6 +250,7 @@ class ModalityClient[In: Input, Out: Output, Params: Parameters, Content](
             extra_headers=extra_headers,
             **parameters,
         )
+        sse_iterator = enrich_stream_errors(sse_iterator, self._handle_error_response)
         return stream_class(
             sse_iterator,
             transform_output=self._transform_output,

--- a/src/celeste/http.py
+++ b/src/celeste/http.py
@@ -185,7 +185,9 @@ class HTTPClient:
             headers=headers,
             timeout=timeout,
         ) as event_source:
-            event_source.response.raise_for_status()
+            if not event_source.response.is_success:
+                await event_source.response.aread()
+                event_source.response.raise_for_status()
             async for sse in event_source.aiter_sse():
                 try:
                     yield json.loads(sse.data)
@@ -221,7 +223,9 @@ class HTTPClient:
             headers=headers,
             timeout=timeout,
         ) as response:
-            response.raise_for_status()
+            if not response.is_success:
+                await response.aread()
+                response.raise_for_status()
             async for line in response.aiter_lines():
                 if line:
                     yield json.loads(line)


### PR DESCRIPTION
## Problem

Streaming and non-streaming HTTP errors produce inconsistent error messages:

```python
# Non-streaming 401
httpx.HTTPStatusError: Anthropic API error: Invalid API Key

# Streaming 401
httpx.HTTPStatusError: Client error '401 Unauthorized' for url 'https://api.anthropic.com/v1/messages'
```

## After this PR

Both paths produce the same enriched message:

```python
# Non-streaming 401
httpx.HTTPStatusError: Anthropic API error: Invalid API Key

# Streaming 401
httpx.HTTPStatusError: Anthropic API error: Invalid API Key
```

## Changes

- **`http.py`**: Read response body before `raise_for_status()` in `stream_post()` and `stream_post_ndjson()` so JSON error details are available downstream
- **`streaming.py`**: Add `enrich_stream_errors()` wrapper that catches `HTTPStatusError` and delegates to the provider's error handler
- **`client.py`**: Wire wrapper into `ModalityClient._stream()` — covers all providers automatically

Closes #194

## Test plan

- [x] Unit tests for `stream_post` / `stream_post_ndjson` HTTP error body readability
- [x] Unit tests for `enrich_stream_errors` (enrichment, passthrough, non-JSON body fallback)
- [x] Full unit test suite passes (502 tests)