### PR TITLE
fix: correct model ID in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import celeste
 text   = await celeste.text.generate("Explain quantum computing", model="claude-opus-4-5")
 image  = await celeste.images.generate("A serene mountain lake at dawn", model="flux-2-pro")
 speech = await celeste.audio.speak("Welcome to the future", model="eleven_v3")
-video  = await celeste.videos.analyze(video_file, prompt="Summarize this clip", model="gemini-3-pro")
+video  = await celeste.videos.analyze(video_file, prompt="Summarize this clip", model="gemini-3-pro-preview")
 embeddings = await celeste.text.embed(["lorep ipsum", "dolor sit amet"], model="gemini-embedding-001")
 ```
 


### PR DESCRIPTION
## Summary
- Fixes `gemini-3-pro` → `gemini-3-pro-preview` in the Quick Start code snippet — `gemini-3-pro` is not a registered model ID and throws `ModelNotFoundError`.

Closes #205