### PR TITLE
fix: raise InvalidToolError for non-dict/non-Tool items in tools list

### DIFF
--- a/src/celeste/exceptions.py
+++ b/src/celeste/exceptions.py
@@ -233,6 +233,15 @@ class UnsupportedProviderError(CredentialsError):
         )
 
 
+class InvalidToolError(ValidationError):
+    """Raised when a tool item is not a Tool instance or dict."""
+
+    def __init__(self, item: object) -> None:
+        """Initialize with the invalid item."""
+        self.item = item
+        super().__init__(f"Expected Tool instance or dict, got {type(item).__name__}")
+
+
 class UnsupportedParameterError(ValidationError):
     """Raised when a parameter is not supported by a model."""
 
@@ -253,6 +262,7 @@ __all__ = [
     "ClientNotFoundError",
     "ConstraintViolationError",
     "Error",
+    "InvalidToolError",
     "MissingCredentialsError",
     "MissingDependencyError",
     "ModalityNotFoundError",

--- a/src/celeste/protocols/chatcompletions/parameters.py
+++ b/src/celeste/protocols/chatcompletions/parameters.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, get_origin
 
 from pydantic import BaseModel, TypeAdapter
 
+from celeste.exceptions import InvalidToolError
 from celeste.models import Model
 from celeste.parameters import FieldMapper, ParameterMapper
 from celeste.structured_outputs import StrictJsonSchemaGenerator
@@ -105,6 +106,8 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(self._map_user_tool(item))
             elif isinstance(item, dict):
                 tools.append(item)
+            else:
+                raise InvalidToolError(item)
 
         return request
 

--- a/src/celeste/protocols/openresponses/parameters.py
+++ b/src/celeste/protocols/openresponses/parameters.py
@@ -5,6 +5,7 @@ from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
 
+from celeste.exceptions import InvalidToolError
 from celeste.models import Model
 from celeste.parameters import FieldMapper, ParameterMapper
 from celeste.structured_outputs import StrictJsonSchemaGenerator
@@ -159,6 +160,8 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(self._map_user_tool(item))
             elif isinstance(item, dict):
                 tools.append(item)
+            else:
+                raise InvalidToolError(item)
 
         return request
 

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -5,6 +5,7 @@ from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
 
+from celeste.exceptions import InvalidToolError
 from celeste.models import Model
 from celeste.parameters import FieldMapper, ParameterMapper
 from celeste.structured_outputs import StrictJsonSchemaGenerator
@@ -98,6 +99,8 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(self._map_user_tool(item))
             elif isinstance(item, dict):
                 tools.append(item)
+            else:
+                raise InvalidToolError(item)
 
         return request
 

--- a/src/celeste/providers/google/generate_content/parameters.py
+++ b/src/celeste/providers/google/generate_content/parameters.py
@@ -7,6 +7,7 @@ from typing import Any, get_args, get_origin
 from pydantic import BaseModel, TypeAdapter
 
 from celeste.artifacts import ImageArtifact
+from celeste.exceptions import InvalidToolError
 from celeste.mime_types import ApplicationMimeType
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
@@ -213,6 +214,8 @@ class ToolsMapper[Content](ParameterMapper[Content]):
                 fn_declarations.append(self._map_user_tool(item))
             elif isinstance(item, dict):
                 tools.append(item)
+            else:
+                raise InvalidToolError(item)
 
         if fn_declarations:
             tools.append({"functionDeclarations": fn_declarations})

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -7,6 +7,7 @@ from celeste.exceptions import (
     ClientNotFoundError,
     ConstraintViolationError,
     Error,
+    InvalidToolError,
     MissingCredentialsError,
     ModalityNotFoundError,
     ModelNotFoundError,
@@ -16,6 +17,7 @@ from celeste.exceptions import (
     UnsupportedCapabilityError,
     UnsupportedParameterError,
     UnsupportedProviderError,
+    ValidationError,
 )
 from celeste.models import Model
 
@@ -367,4 +369,25 @@ class TestUnsupportedProviderError:
 
         exc = UnsupportedProviderError("test_provider")
         assert isinstance(exc, CredentialsError)
+        assert isinstance(exc, Error)
+
+
+class TestInvalidToolError:
+    """Test InvalidToolError exception."""
+
+    def test_creates_with_item(self) -> None:
+        """Test exception stores the invalid item."""
+        exc = InvalidToolError(42)
+        assert exc.item == 42
+        assert "int" in str(exc)
+
+    def test_message_includes_type_name(self) -> None:
+        """Test exception message shows the actual type passed."""
+        exc = InvalidToolError("web_search")
+        assert str(exc) == "Expected Tool instance or dict, got str"
+
+    def test_inherits_from_validation_error(self) -> None:
+        """Test InvalidToolError inherits from ValidationError."""
+        exc = InvalidToolError(42)
+        assert isinstance(exc, ValidationError)
         assert isinstance(exc, Error)


### PR DESCRIPTION
Closes #218

## Summary
- Add `InvalidToolError(ValidationError)` to `celeste.exceptions`
- Add `else: raise InvalidToolError(item)` to all 4 `ToolsMapper.map()` implementations
- `tools=[WebSearch]` (forgot `()`), `tools=["web_search"]`, or any non-dict/non-Tool item now raises immediately instead of being silently dropped

## Files changed
- `src/celeste/exceptions.py` — new `InvalidToolError`
- `src/celeste/protocols/chatcompletions/parameters.py` — else clause
- `src/celeste/protocols/openresponses/parameters.py` — else clause
- `src/celeste/providers/anthropic/messages/parameters.py` — else clause
- `src/celeste/providers/google/generate_content/parameters.py` — else clause
- `tests/unit_tests/test_exceptions.py` — 3 tests for `InvalidToolError`

## Test plan
- [x] 513 unit tests pass
- [x] All pre-commit/pre-push hooks pass (ruff, mypy, bandit, coverage)