### PR TITLE
fix: add ToolSupport to legacy OpenAI/xAI models

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -51,6 +51,7 @@ MODELS: list[Model] = [
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=4096),
             TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
             TextParameter.IMAGE: ImagesConstraint(),
         },
     ),
@@ -63,6 +64,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=8192),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
         },
     ),
     Model(
@@ -74,6 +76,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=4096),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
         },
     ),
     Model(

--- a/src/celeste/modalities/text/providers/xai/models.py
+++ b/src/celeste/modalities/text/providers/xai/models.py
@@ -128,6 +128,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=32768),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
             TextParameter.IMAGE: ImagesConstraint(),
         },
     ),


### PR DESCRIPTION
## Summary

- Added `TextParameter.TOOLS: ToolSupport(tools=[])` to 4 legacy models that support tool calling but were missing the declaration:
  - `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo` (OpenAI)
  - `grok-2-vision-1212` (xAI)
- These models support function calling via their APIs but didn't advertise it in model metadata
- `ToolSupport(tools=[])` means "no built-in server tools, user-defined function tools are fine" — this is correct for legacy models that don't have native web search

## Test plan

- [x] 513 unit tests pass
- [x] All pre-commit/pre-push hooks pass

Fixes #225