### PR TITLE
fix: improve tool error messages

### DIFF
--- a/src/celeste/constraints.py
+++ b/src/celeste/constraints.py
@@ -382,8 +382,11 @@ class ToolSupport(Constraint):
         """Validate tools list against supported tools."""
         for item in value:
             if isinstance(item, Tool) and type(item) not in self.tools:
-                supported = [t.__name__ for t in self.tools]
-                msg = f"Tool '{type(item).__name__}' not supported. Supported: {supported}"
+                if self.tools:
+                    supported = [t.__name__ for t in self.tools]
+                    msg = f"Tool '{type(item).__name__}' not supported. Supported: {supported}"
+                else:
+                    msg = f"Tool '{type(item).__name__}' is not supported by this model"
                 raise ConstraintViolationError(msg)
         return value
 

--- a/src/celeste/protocols/chatcompletions/parameters.py
+++ b/src/celeste/protocols/chatcompletions/parameters.py
@@ -99,7 +99,7 @@ class ToolsMapper(ParameterMapper[TextContent]):
             if isinstance(item, Tool):
                 mapper = dispatch.get(type(item))
                 if mapper is None:
-                    msg = f"Tool '{type(item).__name__}' is not supported by this provider"
+                    msg = f"Tool '{type(item).__name__}' is not supported by Chat Completions"
                     raise ValueError(msg)
                 tools.append(mapper.map_tool(item))
             elif isinstance(item, dict) and "name" in item:


### PR DESCRIPTION
Closes #226

## Summary
- ChatCompletions error now says "not supported by Chat Completions" instead of vague "this provider"
- ToolSupport with empty tools list says "not supported by this model" instead of "Supported: []"

## Files changed
- `src/celeste/protocols/chatcompletions/parameters.py` — named the protocol
- `src/celeste/constraints.py` — better empty-list message

## Test plan
- [x] 474 unit tests pass
- [x] All hooks pass (ruff, mypy, bandit, coverage)