### PR TITLE
fix: warn when WebSearch config fields are dropped by provider

### DIFF
--- a/src/celeste/protocols/openresponses/tools.py
+++ b/src/celeste/protocols/openresponses/tools.py
@@ -1,8 +1,10 @@
 """OpenResponses protocol tool mappers and shared parsing helpers."""
 
 import json
-from typing import Any
+import warnings
+from typing import Any, ClassVar
 
+from celeste.exceptions import UnsupportedParameterWarning
 from celeste.tools import (
     CodeExecution,
     Tool,
@@ -19,12 +21,21 @@ class WebSearchMapper(ToolMapper):
     """Map WebSearch to OpenResponses web_search wire format."""
 
     tool_type = WebSearch
+    _supported_fields: ClassVar[set[str]] = {"allowed_domains"}
 
     def map_tool(self, tool: Tool) -> dict[str, Any]:
         assert isinstance(tool, WebSearch)
         result: dict[str, Any] = {"type": "web_search"}
         if tool.allowed_domains is not None:
             result.setdefault("filters", {})["allowed_domains"] = tool.allowed_domains
+        for field in tool.model_fields:
+            if field not in self._supported_fields and getattr(tool, field) is not None:
+                warnings.warn(
+                    f"WebSearch.{field} is not supported by OpenResponses "
+                    f"and will be ignored. Workaround: use a raw dict tool instead.",
+                    UnsupportedParameterWarning,
+                    stacklevel=2,
+                )
         return result
 
 

--- a/src/celeste/providers/google/generate_content/tools.py
+++ b/src/celeste/providers/google/generate_content/tools.py
@@ -1,7 +1,9 @@
 """Google GenerateContent API tool mappers."""
 
-from typing import Any
+import warnings
+from typing import Any, ClassVar
 
+from celeste.exceptions import UnsupportedParameterWarning
 from celeste.tools import CodeExecution, Tool, ToolMapper, WebSearch
 
 
@@ -9,12 +11,21 @@ class WebSearchMapper(ToolMapper):
     """Map WebSearch to Google google_search wire format."""
 
     tool_type = WebSearch
+    _supported_fields: ClassVar[set[str]] = {"blocked_domains"}
 
     def map_tool(self, tool: Tool) -> dict[str, Any]:
         assert isinstance(tool, WebSearch)
         config: dict[str, Any] = {}
         if tool.blocked_domains is not None:
             config["exclude_domains"] = tool.blocked_domains
+        for field in tool.model_fields:
+            if field not in self._supported_fields and getattr(tool, field) is not None:
+                warnings.warn(
+                    f"WebSearch.{field} is not supported by Google "
+                    f"and will be ignored. Workaround: use a raw dict tool instead.",
+                    UnsupportedParameterWarning,
+                    stacklevel=2,
+                )
         return {"google_search": config}
 
 

--- a/src/celeste/providers/groq/chat/tools.py
+++ b/src/celeste/providers/groq/chat/tools.py
@@ -1,7 +1,9 @@
 """Groq Chat Completions tool mappers."""
 
-from typing import Any
+import warnings
+from typing import Any, ClassVar
 
+from celeste.exceptions import UnsupportedParameterWarning
 from celeste.tools import CodeExecution, Tool, ToolMapper, WebSearch
 
 
@@ -9,8 +11,18 @@ class WebSearchMapper(ToolMapper):
     """Map WebSearch to Groq browser_search wire format."""
 
     tool_type = WebSearch
+    _supported_fields: ClassVar[set[str]] = set()
 
     def map_tool(self, tool: Tool) -> dict[str, Any]:
+        assert isinstance(tool, WebSearch)
+        for field in tool.model_fields:
+            if field not in self._supported_fields and getattr(tool, field) is not None:
+                warnings.warn(
+                    f"WebSearch.{field} is not supported by Groq "
+                    f"and will be ignored. Workaround: use a raw dict tool instead.",
+                    UnsupportedParameterWarning,
+                    stacklevel=2,
+                )
         return {"type": "browser_search"}
 
 

--- a/src/celeste/providers/moonshot/chat/tools.py
+++ b/src/celeste/providers/moonshot/chat/tools.py
@@ -1,7 +1,9 @@
 """Moonshot Chat Completions tool mappers."""
 
-from typing import Any
+import warnings
+from typing import Any, ClassVar
 
+from celeste.exceptions import UnsupportedParameterWarning
 from celeste.tools import Tool, ToolMapper, WebSearch
 
 
@@ -9,8 +11,18 @@ class WebSearchMapper(ToolMapper):
     """Map WebSearch to Moonshot builtin_function wire format."""
 
     tool_type = WebSearch
+    _supported_fields: ClassVar[set[str]] = set()
 
     def map_tool(self, tool: Tool) -> dict[str, Any]:
+        assert isinstance(tool, WebSearch)
+        for field in tool.model_fields:
+            if field not in self._supported_fields and getattr(tool, field) is not None:
+                warnings.warn(
+                    f"WebSearch.{field} is not supported by Moonshot "
+                    f"and will be ignored. Workaround: use a raw dict tool instead.",
+                    UnsupportedParameterWarning,
+                    stacklevel=2,
+                )
         return {"type": "builtin_function", "function": {"name": "$web_search"}}
 
 


### PR DESCRIPTION
## Summary

- Tool mappers now emit `UnsupportedParameterWarning` when a non-None `WebSearch` field is not supported by the target provider
- Each mapper declares `_supported_fields` so new `WebSearch` fields automatically trigger warnings without code changes
- Follows celeste's existing warn-and-drop pattern from PR #212

Closes #231

## Test plan

- [x] 474 unit tests pass
- [x] ruff, mypy, bandit all clean
- [ ] Manual: `WebSearch(blocked_domains=["reddit.com"])` on OpenAI emits warning
- [ ] Manual: `WebSearch()` with no config fields emits no warning