### PR TITLE
feat: add reasoning output support for text generation

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -220,17 +220,31 @@ class ModalityClient[
         content = self._parse_content(response_data)
         content = self._transform_output(content, **parameters)
         tool_calls = self._parse_tool_calls(response_data)
-        return self._output_class()(
+        reasoning, signature = self._parse_reasoning(response_data)
+        kwargs: dict[str, Any] = {}
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
+        if signature:
+            kwargs["signature"] = signature
+        output = self._output_class()(
             content=content,
             usage=self._get_usage(response_data),
             finish_reason=self._get_finish_reason(response_data),
             metadata=self._build_metadata(response_data),
             tool_calls=tool_calls,
+            **kwargs,
         )
+        return output
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from response. Override in providers that support tools."""
         return []
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse reasoning from response. Returns (text, signature_blocks)."""
+        return None, []
 
     def _stream(
         self,

--- a/src/celeste/modalities/images/parameters.py
+++ b/src/celeste/modalities/images/parameters.py
@@ -23,6 +23,7 @@ class ImageParameter(StrEnum):
     STEPS = "steps"
     GUIDANCE = "guidance"
     MASK = "mask"
+    THINKING_LEVEL = "thinking_level"
 
 
 class ImageParameters(Parameters):
@@ -42,6 +43,7 @@ class ImageParameters(Parameters):
     steps: int
     guidance: float
     mask: ImageArtifact
+    thinking_level: str
 
 
 __all__ = [

--- a/src/celeste/modalities/images/providers/google/gemini.py
+++ b/src/celeste/modalities/images/providers/google/gemini.py
@@ -63,6 +63,8 @@ class GeminiImagesClient(GoogleGenerateContentClient, ImagesClient):
             content = candidate.get("content", {})
             parts = content.get("parts", [])
             for part in parts:
+                if part.get("thought"):
+                    continue
                 inline_data = part.get("inlineData", {})
                 base64_data = inline_data.get("data")
                 if not base64_data:

--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -97,6 +97,7 @@ GEMINI_MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
+            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "High"]),
         },
     ),
     Model(
@@ -121,6 +122,7 @@ GEMINI_MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
+            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "High"]),
         },
     ),
 ]

--- a/src/celeste/modalities/images/providers/google/parameters.py
+++ b/src/celeste/modalities/images/providers/google/parameters.py
@@ -10,6 +10,9 @@ from celeste.providers.google.generate_content.parameters import (
 from celeste.providers.google.generate_content.parameters import (
     MediaContentMapper as _GeminiMediaContentMapper,
 )
+from celeste.providers.google.generate_content.parameters import (
+    ThinkingLevelMapper as _GeminiThinkingLevelMapper,
+)
 from celeste.providers.google.imagen.parameters import (
     AspectRatioMapper as _ImagenAspectRatioMapper,
 )
@@ -67,10 +70,17 @@ class GeminiReferenceImagesMapper(_GeminiMediaContentMapper[ImageContent]):
     name = ImageParameter.REFERENCE_IMAGES
 
 
+class GeminiThinkingLevelMapper(_GeminiThinkingLevelMapper[ImageContent]):
+    """Map thinking_level to Gemini generationConfig.thinkingConfig.thinkingLevel."""
+
+    name = ImageParameter.THINKING_LEVEL
+
+
 GEMINI_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     GeminiAspectRatioMapper(),
     GeminiQualityMapper(),
     GeminiReferenceImagesMapper(),
+    GeminiThinkingLevelMapper(),
 ]
 
 

--- a/src/celeste/modalities/text/io.py
+++ b/src/celeste/modalities/text/io.py
@@ -7,6 +7,8 @@ Text modality handles:
 Types are unified per-modality since generate and analyze produce identical outputs.
 """
 
+from typing import Any
+
 from pydantic import Field
 
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
@@ -55,6 +57,8 @@ class TextOutput(Output[TextContent]):
 
     usage: TextUsage = Field(default_factory=TextUsage)
     finish_reason: TextFinishReason | None = None
+    reasoning: str | None = None
+    signature: list[dict[str, Any]] | None = None
 
     @property
     def message(self) -> Message:
@@ -63,12 +67,15 @@ class TextOutput(Output[TextContent]):
             role=Role.ASSISTANT,
             content=self.content,
             tool_calls=self.tool_calls if self.tool_calls else None,
+            reasoning=self.reasoning,
+            signature=self.signature,
         )
 
 
 class TextChunk(Chunk[str]):
     """Chunk for text streaming."""
 
+    reasoning: str | None = None
     finish_reason: TextFinishReason | None = None
     usage: TextUsage | None = None
 

--- a/src/celeste/modalities/text/protocols/chatcompletions/client.py
+++ b/src/celeste/modalities/text/protocols/chatcompletions/client.py
@@ -83,6 +83,16 @@ class ChatCompletionsTextClient(ChatCompletionsMixin, TextClient):
         content = message.get("content") or ""
         return content
 
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse reasoning_content from Chat Completions response."""
+        choices = response_data.get("choices", [])
+        if not choices:
+            return None, []
+        reasoning = choices[0].get("message", {}).get("reasoning_content")
+        return reasoning, []  # empty signature — must NOT send back
+
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Chat Completions response."""
         return parse_tool_calls(response_data)

--- a/src/celeste/modalities/text/protocols/openresponses/client.py
+++ b/src/celeste/modalities/text/protocols/openresponses/client.py
@@ -11,6 +11,7 @@ from celeste.protocols.openresponses.streaming import (
 )
 from celeste.protocols.openresponses.tools import (
     parse_content,
+    parse_reasoning,
     parse_tool_calls,
     serialize_messages,
 )
@@ -58,6 +59,15 @@ class OpenResponsesTextStream(_OpenResponsesStream, TextStream):
         if self._response_data is None:
             return []
         return parse_tool_calls(self._response_data)
+
+    def _aggregate_signature(
+        self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Extract reasoning items from response.completed data."""
+        if self._response_data is None:
+            return []
+        _, signature_blocks = parse_reasoning(self._response_data.get("output", []))
+        return signature_blocks
 
 
 class OpenResponsesTextClient(OpenResponsesMixin, TextClient):
@@ -110,6 +120,13 @@ class OpenResponsesTextClient(OpenResponsesMixin, TextClient):
         """Parse text content from response."""
         output = super()._parse_content(response_data)
         return parse_content(output)
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse reasoning from Responses API output."""
+        output = response_data.get("output", [])
+        return parse_reasoning(output)
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from OpenResponses response."""

--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -31,9 +31,11 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
         super().__init__(*args, **kwargs)
         self._message_start: dict[str, Any] | None = None
         self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._thinking_blocks: list[dict[str, Any]] = []
+        self._current_thinking: dict[str, Any] | None = None
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
-        """Parse one SSE event into a typed chunk (captures message_start and tool_use)."""
+        """Parse one SSE event into a typed chunk (captures message_start, tool_use, thinking)."""
         event_type = event_data.get("type")
         if event_type == "message_start":
             message = event_data.get("message")
@@ -42,19 +44,37 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
             return None
         if event_type == "content_block_start":
             block = event_data.get("content_block", {})
-            if block.get("type") == "tool_use":
+            block_type = block.get("type")
+            if block_type == "tool_use":
                 idx = event_data.get("index", len(self._tool_calls))
                 self._tool_calls[idx] = {
                     "id": block.get("id", ""),
                     "name": block.get("name", ""),
                     "input_json": "",
                 }
+            elif block_type == "thinking":
+                self._current_thinking = {
+                    "type": "thinking",
+                    "thinking": "",
+                    "signature": "",
+                }
+            elif block_type == "redacted_thinking":
+                self._thinking_blocks.append(block)
         elif event_type == "content_block_delta":
             delta = event_data.get("delta", {})
-            if delta.get("type") == "input_json_delta":
+            delta_type = delta.get("type")
+            if delta_type == "input_json_delta":
                 idx = event_data.get("index", -1)
                 if idx in self._tool_calls:
                     self._tool_calls[idx]["input_json"] += delta.get("partial_json", "")
+            elif delta_type == "thinking_delta" and self._current_thinking is not None:
+                self._current_thinking["thinking"] += delta.get("thinking", "")
+            elif delta_type == "signature_delta" and self._current_thinking is not None:
+                self._current_thinking["signature"] += delta.get("signature", "")
+        elif event_type == "content_block_stop":
+            if self._current_thinking is not None:
+                self._thinking_blocks.append(self._current_thinking)
+                self._current_thinking = None
         return super()._parse_chunk(event_data)
 
     def _aggregate_event_data(self, chunks: list[TextChunk]) -> list[dict[str, Any]]:
@@ -79,6 +99,12 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
                     arguments = _json.loads(tc["input_json"])
             result.append(ToolCall(id=tc["id"], name=tc["name"], arguments=arguments))
         return result
+
+    def _aggregate_signature(
+        self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Return accumulated thinking blocks for round-trip signature."""
+        return self._thinking_blocks
 
 
 class AnthropicTextClient(AnthropicMessagesClient, TextClient):
@@ -129,19 +155,23 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
                     messages.append({"role": "user", "content": pending_tool_results})
                     pending_tool_results = []
 
-                if role == "assistant" and message.tool_calls:
+                if role == "assistant" and (message.tool_calls or message.signature):
                     content_blocks: list[dict[str, Any]] = []
+                    sig_blocks = message.signature
+                    if sig_blocks:
+                        content_blocks.extend(sig_blocks)
                     if content:
                         content_blocks.append({"type": "text", "text": str(content)})
-                    for tc in message.tool_calls:
-                        content_blocks.append(
-                            {
-                                "type": "tool_use",
-                                "id": tc.id,
-                                "name": tc.name,
-                                "input": tc.arguments,
-                            }
-                        )
+                    if message.tool_calls:
+                        for tc in message.tool_calls:
+                            content_blocks.append(
+                                {
+                                    "type": "tool_use",
+                                    "id": tc.id,
+                                    "name": tc.name,
+                                    "input": tc.arguments,
+                                }
+                            )
                     messages.append({"role": "assistant", "content": content_blocks})
                 else:
                     messages.append({"role": role, "content": content})
@@ -235,6 +265,25 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
                 break
 
         return text_content
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse thinking blocks from Anthropic response."""
+        blocks = response_data.get("content", [])
+        reasoning_parts: list[str] = []
+        signature_blocks: list[dict[str, Any]] = []
+        for block in blocks:
+            block_type = block.get("type")
+            if block_type == "thinking":
+                thinking_text = block.get("thinking", "")
+                if thinking_text:
+                    reasoning_parts.append(thinking_text)
+                signature_blocks.append(block)
+            elif block_type == "redacted_thinking":
+                signature_blocks.append(block)
+        text = "\n".join(reasoning_parts) if reasoning_parts else None
+        return text, signature_blocks
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Anthropic response."""

--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -43,6 +43,18 @@ class GoogleTextStream(_GoogleGenerateContentStream, TextStream):
                         )
         return tool_calls
 
+    def _aggregate_signature(
+        self, chunks: list, raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Extract thought parts with signatures from Google streaming events."""
+        thought_parts: list[dict[str, Any]] = []
+        for event in raw_events:
+            for candidate in event.get("candidates", []):
+                for part in candidate.get("content", {}).get("parts", []):
+                    if part.get("thought") and "thoughtSignature" in part:
+                        thought_parts.append(part)
+        return thought_parts
+
 
 class GoogleTextClient(GoogleGenerateContentClient, TextClient):
     """Google text client."""
@@ -94,7 +106,9 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
                     )
                 else:
                     role = "model" if msg.role == "assistant" else msg.role
-                    msg_parts = content_to_parts(msg.content)
+                    sig_blocks = msg.signature
+                    msg_parts = list(sig_blocks) if sig_blocks else []
+                    msg_parts.extend(content_to_parts(msg.content))
                     if msg.tool_calls:
                         for tc in msg.tool_calls:
                             part: dict[str, Any] = {
@@ -159,6 +173,25 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
             if text is not None:
                 return text
         return ""
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse thought parts from Google response."""
+        candidates = response_data.get("candidates", [])
+        if not candidates:
+            return None, []
+        parts = candidates[0].get("content", {}).get("parts", [])
+        reasoning_parts: list[str] = []
+        signature_blocks: list[dict[str, Any]] = []
+        for p in parts:
+            if p.get("thought"):
+                text = p.get("text", "")
+                if text:
+                    reasoning_parts.append(text)
+                signature_blocks.append(p)
+        text = "\n".join(reasoning_parts) if reasoning_parts else None
+        return text, signature_blocks
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Google response."""

--- a/src/celeste/modalities/text/providers/mistral/client.py
+++ b/src/celeste/modalities/text/providers/mistral/client.py
@@ -7,6 +7,9 @@ from celeste.providers.mistral.chat.client import MistralChatClient
 from celeste.providers.mistral.chat.streaming import (
     MistralChatStream as _MistralChatStream,
 )
+from celeste.providers.mistral.chat.streaming import (
+    _extract_thinking_text,
+)
 from celeste.types import TextContent
 
 from ...protocols.chatcompletions.client import (
@@ -46,6 +49,21 @@ class MistralTextClient(MistralChatClient, ChatCompletionsTextClient):
             content = "".join(text_parts)
 
         return content
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse thinking blocks from Mistral Magistral response."""
+        choices = response_data.get("choices", [])
+        if not choices:
+            return None, []
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if not isinstance(content, list):
+            return None, []
+        reasoning_parts = _extract_thinking_text(content)
+        text = "\n".join(reasoning_parts) if reasoning_parts else None
+        return text, []  # Mistral has no signature for round-trip
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/streaming.py
+++ b/src/celeste/modalities/text/streaming.py
@@ -19,5 +19,10 @@ class TextStream(Stream[TextOutput, TextParameters, TextChunk]):
         """Aggregate content from chunks into raw text."""
         return "".join(chunk.content for chunk in chunks)
 
+    def _aggregate_reasoning(self, chunks: list[TextChunk]) -> str | None:
+        """Aggregate reasoning from chunks into text."""
+        parts = [c.reasoning for c in chunks if c.reasoning]
+        return "".join(parts) if parts else None
+
 
 __all__ = ["TextStream"]

--- a/src/celeste/protocols/chatcompletions/streaming.py
+++ b/src/celeste/protocols/chatcompletions/streaming.py
@@ -31,25 +31,29 @@ class ChatCompletionsStream:
         super().__init__(*args, **kwargs)
         self._tool_call_deltas: dict[int, dict[str, Any]] = {}
 
+    def _get_chunk_delta(self, event_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Extract delta dict from a chat.completion.chunk event."""
+        if event_data.get("object") != "chat.completion.chunk":
+            return None
+        choices = event_data.get("choices", [])
+        if not choices or not isinstance(choices[0], dict):
+            return None
+        delta = choices[0].get("delta", {})
+        return delta if isinstance(delta, dict) else None
+
     def _parse_chunk_content(self, event_data: dict[str, Any]) -> str | None:
         """Extract content from SSE event."""
-        object_type = event_data.get("object")
-        if object_type != "chat.completion.chunk":
+        delta = self._get_chunk_delta(event_data)
+        if delta is None:
             return None
-
-        choices = event_data.get("choices", [])
-        if not choices:
-            return None
-
-        first_choice = choices[0]
-        if not isinstance(first_choice, dict):
-            return None
-
-        delta = first_choice.get("delta", {})
-        if not isinstance(delta, dict):
-            return None
-
         return delta.get("content") or None
+
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract reasoning_content from SSE event (DeepSeek R1, etc.)."""
+        delta = self._get_chunk_delta(event_data)
+        if delta is None:
+            return None
+        return delta.get("reasoning_content") or None
 
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]

--- a/src/celeste/protocols/chatcompletions/tools.py
+++ b/src/celeste/protocols/chatcompletions/tools.py
@@ -58,6 +58,8 @@ def serialize_messages(
             )
         elif msg.role == "assistant" and msg.tool_calls:
             msg_dict = msg.model_dump(exclude_none=True)
+            msg_dict.pop("reasoning", None)
+            msg_dict.pop("signature", None)
             msg_dict["tool_calls"] = [
                 {
                     "id": tc.id,
@@ -73,6 +75,8 @@ def serialize_messages(
         else:
             msg_dict = msg.model_dump(exclude_none=True)
             msg_dict.pop("tool_calls", None)
+            msg_dict.pop("reasoning", None)
+            msg_dict.pop("signature", None)
             items.append(msg_dict)
     return items
 

--- a/src/celeste/protocols/openresponses/parameters.py
+++ b/src/celeste/protocols/openresponses/parameters.py
@@ -110,7 +110,9 @@ class ReasoningEffortMapper(ParameterMapper[TextContent]):
         if validated_value is None:
             return request
 
-        request.setdefault("reasoning", {})["effort"] = validated_value
+        reasoning = request.setdefault("reasoning", {})
+        reasoning["effort"] = validated_value
+        reasoning.setdefault("summary", "auto")
         return request
 
 

--- a/src/celeste/protocols/openresponses/streaming.py
+++ b/src/celeste/protocols/openresponses/streaming.py
@@ -37,6 +37,16 @@ class OpenResponsesStream:
             return event_data.get("delta") or None
         return None
 
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract reasoning delta from SSE event."""
+        event_type = event_data.get("type")
+        if event_type in (
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ):
+            return event_data.get("delta") or None
+        return None
+
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]
     ) -> dict[str, int | float | None] | None:

--- a/src/celeste/protocols/openresponses/tools.py
+++ b/src/celeste/protocols/openresponses/tools.py
@@ -98,6 +98,29 @@ def parse_content(output: list[dict[str, Any]]) -> str:
     return ""
 
 
+def parse_reasoning(
+    output: list[dict[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Extract reasoning from Responses API output items."""
+    reasoning_parts: list[str] = []
+    signature_blocks: list[dict[str, Any]] = []
+    for item in output:
+        if item.get("type") == "reasoning":
+            signature_blocks.append(item)
+            for s in item.get("summary", []):
+                if s.get("type") == "summary_text":
+                    text = s.get("text", "")
+                    if text:
+                        reasoning_parts.append(text)
+            for c in item.get("content", []):
+                if c.get("type") == "reasoning_text":
+                    text = c.get("text", "")
+                    if text:
+                        reasoning_parts.append(text)
+    text = "\n".join(reasoning_parts) if reasoning_parts else None
+    return text, signature_blocks
+
+
 def serialize_messages(messages: list[Message]) -> list[dict[str, Any]]:
     """Serialize messages to Responses API input format."""
     items: list[dict[str, Any]] = []
@@ -110,19 +133,25 @@ def serialize_messages(messages: list[Message]) -> list[dict[str, Any]]:
                     "output": str(msg.content),
                 }
             )
-        elif msg.role == "assistant" and msg.tool_calls:
-            for tc in msg.tool_calls:
-                items.append(
-                    {
-                        "type": "function_call",
-                        "name": tc.name,
-                        "arguments": json.dumps(tc.arguments),
-                        "call_id": tc.id,
-                    }
-                )
+        elif msg.role == "assistant" and (msg.tool_calls or msg.signature):
+            sig_blocks = msg.signature
+            if sig_blocks:
+                items.extend(sig_blocks)
+            if msg.tool_calls:
+                for tc in msg.tool_calls:
+                    items.append(
+                        {
+                            "type": "function_call",
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.arguments),
+                            "call_id": tc.id,
+                        }
+                    )
         else:
             msg_dict = msg.model_dump(exclude_none=True)
             msg_dict.pop("tool_calls", None)
+            msg_dict.pop("reasoning", None)
+            msg_dict.pop("signature", None)
             items.append(msg_dict)
     return items
 
@@ -133,6 +162,7 @@ __all__ = [
     "WebSearchMapper",
     "XSearchMapper",
     "parse_content",
+    "parse_reasoning",
     "parse_tool_calls",
     "serialize_messages",
 ]

--- a/src/celeste/providers/anthropic/messages/streaming.py
+++ b/src/celeste/providers/anthropic/messages/streaming.py
@@ -32,6 +32,14 @@ class AnthropicMessagesStream:
 
         return None
 
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract thinking content from SSE event."""
+        if event_data.get("type") == "content_block_delta":
+            delta = event_data.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                return delta.get("thinking") or None
+        return None
+
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]
     ) -> dict[str, int | float | None] | None:

--- a/src/celeste/providers/google/generate_content/parameters.py
+++ b/src/celeste/providers/google/generate_content/parameters.py
@@ -66,9 +66,11 @@ class ThinkingBudgetMapper[Content](ParameterMapper[Content]):
         if validated_value is None:
             return request
 
-        request.setdefault("generationConfig", {}).setdefault("thinkingConfig", {})[
-            "thinkingBudget"
-        ] = validated_value
+        thinking_config = request.setdefault("generationConfig", {}).setdefault(
+            "thinkingConfig", {}
+        )
+        thinking_config["thinkingBudget"] = validated_value
+        thinking_config.setdefault("includeThoughts", True)
         return request
 
 
@@ -86,9 +88,11 @@ class ThinkingLevelMapper[Content](ParameterMapper[Content]):
         if validated_value is None:
             return request
 
-        request.setdefault("generationConfig", {}).setdefault("thinkingConfig", {})[
-            "thinkingLevel"
-        ] = validated_value
+        thinking_config = request.setdefault("generationConfig", {}).setdefault(
+            "thinkingConfig", {}
+        )
+        thinking_config["thinkingLevel"] = validated_value
+        thinking_config.setdefault("includeThoughts", True)
         return request
 
 

--- a/src/celeste/providers/google/generate_content/streaming.py
+++ b/src/celeste/providers/google/generate_content/streaming.py
@@ -39,6 +39,19 @@ class GoogleGenerateContentStream:
 
         return None
 
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract thought content from SSE event."""
+        candidates = event_data.get("candidates", [])
+        if not candidates:
+            return None
+
+        parts = candidates[0].get("content", {}).get("parts", [])
+        for p in parts:
+            if p.get("thought") and "text" in p:
+                return p["text"]
+
+        return None
+
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]
     ) -> dict[str, int | float | None] | None:

--- a/src/celeste/providers/mistral/chat/streaming.py
+++ b/src/celeste/providers/mistral/chat/streaming.py
@@ -6,6 +6,19 @@ from celeste.io import FinishReason
 from celeste.protocols.chatcompletions import ChatCompletionsStream
 
 
+def _extract_thinking_text(content_blocks: list[Any]) -> list[str]:
+    """Extract thinking text from Mistral Magistral list content."""
+    parts: list[str] = []
+    for block in content_blocks:
+        if isinstance(block, dict) and block.get("type") == "thinking":
+            for part in block.get("thinking", []):
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("text", "")
+                    if text:
+                        parts.append(text)
+    return parts
+
+
 class MistralChatStream(ChatCompletionsStream):
     """Mixin for Chat API SSE parsing.
 
@@ -39,6 +52,23 @@ class MistralChatStream(ChatCompletionsStream):
             return "".join(text_parts) if text_parts else None
 
         return content_delta or None
+
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract thinking content from Mistral SSE event."""
+        choices = event_data.get("choices", [])
+        if not choices or not isinstance(choices[0], dict):
+            return None
+
+        delta = choices[0].get("delta", {})
+        if not isinstance(delta, dict):
+            return None
+
+        content_delta = delta.get("content")
+        if not isinstance(content_delta, list):
+            return None
+
+        parts = _extract_thinking_text(content_delta)
+        return "".join(parts) if parts else None
 
     def _parse_chunk_finish_reason(
         self, event_data: dict[str, Any]

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -109,6 +109,10 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         """Parse content from chunk event. Override in provider mixin."""
         return None
 
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Parse reasoning delta from chunk event. Override in providers with reasoning."""
+        return None
+
     def _wrap_chunk_content(self, raw_content: Any) -> Any:  # noqa: ANN401
         """Wrap raw content into chunk content type. Override for type transformation."""
         return raw_content
@@ -124,19 +128,30 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
                 provider=self._stream_metadata.get("provider"),
             )
         content = self._parse_chunk_content(event)
+        reasoning = self._parse_chunk_reasoning(event)
         usage = self._get_chunk_usage(event)
         finish_reason = self._get_chunk_finish_reason(event)
-        if content is None:
-            if usage is None and finish_reason is None:
-                return None
-            content = self._empty_content
-        else:
-            content = self._wrap_chunk_content(content)
+        if (
+            content is None
+            and reasoning is None
+            and usage is None
+            and finish_reason is None
+        ):
+            return None
+        content = (
+            self._wrap_chunk_content(content)
+            if content is not None
+            else self._empty_content
+        )
+        kwargs: dict[str, Any] = {}
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
         return self._chunk_class(  # type: ignore[return-value]
             content=content,
             finish_reason=finish_reason,
             usage=usage,
             metadata={"event_data": event},
+            **kwargs,
         )
 
     @abstractmethod
@@ -153,18 +168,37 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
             else raw_content
         )
         raw_events = self._aggregate_event_data(chunks)
-        return self._output_class(  # type: ignore[return-value]
+        reasoning = self._aggregate_reasoning(chunks)
+        signature = self._aggregate_signature(chunks, raw_events)
+        kwargs: dict[str, Any] = {}
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
+        if signature:
+            kwargs["signature"] = signature
+        output = self._output_class(
             content=content,
             usage=self._aggregate_usage(chunks),
             finish_reason=self._aggregate_finish_reason(chunks),
             metadata=self._build_stream_metadata(raw_events),
             tool_calls=self._aggregate_tool_calls(chunks, raw_events),
+            **kwargs,
         )
+        return output  # type: ignore[return-value]
 
     def _aggregate_tool_calls(
         self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
     ) -> list[ToolCall]:
         """Aggregate tool calls from stream events. Override in providers that support tools."""
+        return []
+
+    def _aggregate_reasoning(self, chunks: list[Chunk]) -> str | None:
+        """Aggregate reasoning from chunks. Override in modality streams."""
+        return None
+
+    def _aggregate_signature(
+        self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Aggregate signature blocks from stream. Override in provider streams."""
         return []
 
     def _parse_chunk_usage(self, event_data: dict[str, Any]) -> RawUsage | None:

--- a/src/celeste/types.py
+++ b/src/celeste/types.py
@@ -57,6 +57,8 @@ class Message(BaseModel):
     role: Role
     content: Content
     tool_calls: list[ToolCall] | None = None
+    reasoning: str | None = None
+    signature: list[dict[str, Any]] | None = None
 
 
 __all__ = [

--- a/tests/integration_tests/text/test_reasoning.py
+++ b/tests/integration_tests/text/test_reasoning.py
@@ -1,0 +1,122 @@
+"""Integration tests for reasoning/thinking content in text generation."""
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*capability parameter is deprecated.*",
+    category=DeprecationWarning,
+)
+
+import pytest  # noqa: E402
+
+from celeste import Modality, Model, Operation, create_client, list_models  # noqa: E402
+from celeste.constraints import Choice, Range  # noqa: E402
+from celeste.modalities.text import TextChunk, TextOutput  # noqa: E402
+from celeste.modalities.text.parameters import TextParameter  # noqa: E402
+
+# Models that support thinking_budget — one per provider for fast feedback
+REASONING_MODELS = [
+    m
+    for m in list_models(modality=Modality.TEXT, operation=Operation.GENERATE)
+    if TextParameter.THINKING_BUDGET in (m.parameter_constraints or {})
+]
+
+# Pick one model per provider to avoid slow test matrix
+_seen_providers: set[str] = set()
+REASONING_MODELS_ONE_PER_PROVIDER = []
+for m in REASONING_MODELS:
+    if m.provider not in _seen_providers:
+        _seen_providers.add(m.provider)
+        REASONING_MODELS_ONE_PER_PROVIDER.append(m)
+
+
+def _get_thinking_budget(model: Model) -> int | str:
+    """Get an appropriate thinking_budget value based on the model's constraint type."""
+    constraint = (model.parameter_constraints or {}).get(TextParameter.THINKING_BUDGET)
+    if isinstance(constraint, Range):
+        return 1024
+    if isinstance(constraint, Choice):
+        return "high" if "high" in constraint.options else constraint.options[-1]
+    return 1024
+
+
+@pytest.mark.parametrize(
+    "model",
+    REASONING_MODELS_ONE_PER_PROVIDER,
+    ids=lambda m: f"{m.provider}-{m.id}",
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reasoning_generate(model: Model) -> None:
+    """Test that reasoning text is returned when thinking_budget is set."""
+    client = create_client(modality=Modality.TEXT, model=model)
+
+    response = await client.generate(
+        prompt="What is 15 * 37? Think step by step.",
+        max_tokens=2000,
+        thinking_budget=_get_thinking_budget(model),
+    )
+
+    assert isinstance(response, TextOutput)
+    assert response.reasoning is not None, (
+        f"Model {model.provider}/{model.id} returned no reasoning"
+    )
+    assert len(response.reasoning) > 0, (
+        f"Model {model.provider}/{model.id} returned empty reasoning"
+    )
+    assert response.content, (
+        f"Model {model.provider}/{model.id} returned no content alongside reasoning"
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [m for m in REASONING_MODELS_ONE_PER_PROVIDER if m.streaming],
+    ids=lambda m: f"{m.provider}-{m.id}",
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reasoning_stream(model: Model) -> None:
+    """Test that reasoning chunks are streamed when thinking_budget is set."""
+    client = create_client(modality=Modality.TEXT, model=model)
+
+    chunks: list[TextChunk] = []
+    async for chunk in client.stream.generate(
+        prompt="What is 15 * 37? Think step by step.",
+        max_tokens=2000,
+        thinking_budget=_get_thinking_budget(model),
+    ):
+        chunks.append(chunk)
+
+    reasoning_chunks = [c for c in chunks if c.reasoning]
+    assert len(reasoning_chunks) > 0, (
+        f"Model {model.provider}/{model.id} streamed no reasoning chunks"
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    REASONING_MODELS_ONE_PER_PROVIDER,
+    ids=lambda m: f"{m.provider}-{m.id}",
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reasoning_message_roundtrip(model: Model) -> None:
+    """Test that output.message preserves reasoning for multi-turn."""
+    client = create_client(modality=Modality.TEXT, model=model)
+
+    response = await client.generate(
+        prompt="What is 15 * 37? Think step by step.",
+        max_tokens=2000,
+        thinking_budget=_get_thinking_budget(model),
+    )
+
+    msg = response.message
+    assert msg.reasoning is not None, "Message should carry reasoning text"
+
+    # Verify signature data is attached (for providers that need it)
+    if response.reasoning and response.signature:
+        assert msg.signature is not None, (
+            "Message should carry signature for round-trip"
+        )


### PR DESCRIPTION
## Summary

- Surfaces reasoning/thinking content from models as first-class `reasoning` and `signature` fields on `TextOutput`, `TextChunk`, and `Message`
- `signature` is a public serializable field (survives `model_dump()`, JSON, FastAPI boundaries) for multi-turn round-trips
- Providers: Anthropic (thinking blocks), Google (thought parts), Mistral (magistral thinking), OpenAI/xAI (reasoning items), ChatCompletions (reasoning_content)
- Adds `thinking_level` support for Gemini image models

Closes #208

## Test plan

- [x] `make ci` — 586 passed, 82% coverage
- [x] Integration tests: `test_reasoning_generate`, `test_reasoning_stream`, `test_reasoning_message_roundtrip` across 5 providers
- [x] Serialization round-trip verified: `TextOutput.model_dump()` → JSON → `Message(**data)` preserves `signature`
- [x] Verified `signature` stripped from serialized messages sent to providers