### PR TITLE
fix: add total=False to modality Parameters TypedDicts

### DIFF
--- a/src/celeste/modalities/audio/parameters.py
+++ b/src/celeste/modalities/audio/parameters.py
@@ -15,7 +15,7 @@ class AudioParameter(StrEnum):
     LANGUAGE = "language"
 
 
-class AudioParameters(Parameters):
+class AudioParameters(Parameters, total=False):
     """Parameters for audio operations."""
 
     voice: str

--- a/src/celeste/modalities/embeddings/parameters.py
+++ b/src/celeste/modalities/embeddings/parameters.py
@@ -14,7 +14,7 @@ class EmbeddingsParameter(StrEnum):
     AUDIO = "audio"
 
 
-class EmbeddingsParameters(Parameters):
+class EmbeddingsParameters(Parameters, total=False):
     """Parameters for embeddings operations."""
 
     dimensions: int | None

--- a/src/celeste/modalities/images/parameters.py
+++ b/src/celeste/modalities/images/parameters.py
@@ -26,7 +26,7 @@ class ImageParameter(StrEnum):
     THINKING_LEVEL = "thinking_level"
 
 
-class ImageParameters(Parameters):
+class ImageParameters(Parameters, total=False):
     """Parameters for images operations."""
 
     aspect_ratio: str

--- a/src/celeste/modalities/text/parameters.py
+++ b/src/celeste/modalities/text/parameters.py
@@ -41,7 +41,7 @@ class TextParameter(StrEnum):
     DOCUMENT = "document"
 
 
-class TextParameters(Parameters):
+class TextParameters(Parameters, total=False):
     """Parameters for text operations."""
 
     # Common parameters

--- a/src/celeste/modalities/videos/parameters.py
+++ b/src/celeste/modalities/videos/parameters.py
@@ -17,7 +17,7 @@ class VideoParameter(StrEnum):
     LAST_FRAME = "last_frame"
 
 
-class VideoParameters(Parameters):
+class VideoParameters(Parameters, total=False):
     """Parameters for video generation operations."""
 
     aspect_ratio: str

--- a/templates/modalities/{modality_slug}/parameters.py.template
+++ b/templates/modalities/{modality_slug}/parameters.py.template
@@ -32,7 +32,7 @@ class {Modality}Parameter(StrEnum):
     # AUDIO = "audio"
 
 
-class {Modality}Parameters(Parameters):
+class {Modality}Parameters(Parameters, total=False):
     """Parameters for {modality} operations."""
 
     # Common parameters


### PR DESCRIPTION
## Summary

- Add `total=False` to the five modality `Parameters` TypedDict subclasses (`TextParameters`, `ImageParameters`, `VideoParameters`, `AudioParameters`, `EmbeddingsParameters`) and to the modality scaffolding template.
- Root cause per [PEP 589](https://peps.python.org/pep-0589/): *"The totality flag only applies to items defined in the body of the TypedDict definition. Inherited items won't be affected, and instead use totality of the TypedDict type where they were defined."*
- Every field declared in a subclass body needs its own `total=False` (or PEP 655 `NotRequired[...]` per field) — it is not inherited from the `Parameters` base.

Six files changed, six lines changed.

## Why PEP 589 `total=False` and not PEP 655 `NotRequired`

Equivalent under the spec. Chose `total=False` for consistency with the existing `Parameters` base and because ecosystem precedent (pydantic `ConfigDict`, openai-python `CompletionCreateParamsBase`, anthropic-sdk-python `MessageCreateParamsBase`, google-genai, typeshed stubs) uses `TypedDict, total=False` for all-optional param bags consumed via `Unpack[...]`. Zero `NotRequired` hits in openai-python or anthropic-sdk-python types folders.

## Impact

Downstream consumers using strict mypy (e.g. `celeste-tools`) were hitting 10+ `Missing named argument` errors per `celeste.text.generate` call, one per `TextParameters` field. This fix makes strict-mypy downstream packages type-check cleanly against `celeste-ai` without needing to disable `call-arg`.

Internally the problem was masked by `[[tool.mypy.overrides]] disable_error_code = ["call-arg"]` on `celeste.modalities.*.client` and `celeste.providers.*.*` in `pyproject.toml`. Those overrides may become tightenable in a follow-up PR now that the root cause is fixed.

## Test plan

- [x] `make lint` — ruff clean
- [x] `make format` — 394 files unchanged
- [x] `make typecheck` — 331 source + 63 test files clean under strict mypy
- [x] `make security` — bandit clean (0 issues, 18940 LOC)
- [x] `make test` — 586 passed, 0 failed (after `uv sync --extra gcp`)
- [x] pre-commit hooks — all passed on commit and pre-push

Closes #255