### PR TITLE
fix: drop call-arg exclusion from internal modality/provider mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ module = [
     "celeste.providers.*.*",
     "celeste.namespaces.domains",
 ]
-disable_error_code = ["override", "return-value", "arg-type", "call-arg", "assignment", "no-any-return", "attr-defined"]
+disable_error_code = ["override", "return-value", "arg-type", "assignment", "no-any-return", "attr-defined"]
 
 [tool.bandit]
 exclude_dirs = [".venv", "__pycache__"]

--- a/src/celeste/modalities/images/providers/google/client.py
+++ b/src/celeste/modalities/images/providers/google/client.py
@@ -39,6 +39,7 @@ class GoogleImagesClient(ImagesClient):
             model=self.model,
             provider=self.provider,
             auth=self.auth,
+            base_url=self.base_url,
         )
         object.__setattr__(self, "_strategy", strategy)
 


### PR DESCRIPTION
## Summary

Removes `call-arg` from the big internal `[[tool.mypy.overrides]]` block (the one covering `modalities.*.client / streaming / providers`, `providers.*`, `namespaces.domains`). After [#256](https://github.com/withceleste/celeste-python/pull/256) fixed the missing `total=False` on modality `Parameters` TypedDicts, this exclusion was no longer needed for the `Unpack[*Parameters]` pattern that originally motivated it.

Closes #257.

## What removing the exclusion exposed

Exactly **one** previously-hidden real bug, and zero noise:

```
src/celeste/modalities/images/providers/google/client.py:37: error: Missing named argument "base_url" for "GeminiImagesClient"  [call-arg]
src/celeste/modalities/images/providers/google/client.py:37: error: Missing named argument "base_url" for "ImagenImagesClient"  [call-arg]
```

`GoogleImagesClient.model_post_init()` constructs the strategy client (`GeminiImagesClient` or `ImagenImagesClient`) but did not forward `self.base_url`. The wrapper would honor a custom `base_url` from its caller, but the strategy would silently default to `None` — a real propagation bug. Fixed by passing `base_url=self.base_url` at the call site.

## What is NOT in scope

- **`tests.*` override** — keeping `call-arg` disabled. Removing it surfaces 39 errors in test files that construct provider clients (`GoogleTextClient`, etc.) without `base_url=`. Test ergonomics over strict construction kwargs is a deliberate choice; this PR leaves it alone.
- **Other disabled codes** — `override`, `return-value`, `arg-type`, `assignment`, `no-any-return`, `attr-defined` are kept on the internal block. They cover unrelated provider-mixin / multiple-inheritance typing patterns and predate #256.

## Test plan

- [x] `make lint` — clean
- [x] `make format` — clean
- [x] `make typecheck` — `Success: no issues found in 331 source files` + `63 source files`
- [x] `make security` — bandit clean
- [x] `make test` — **586 passed**, 82.29% coverage (≥80% threshold)
- [x] `make ci` — full pipeline green
- [x] pre-commit + pre-push hooks all passed