### PR TITLE
fix(google): send tool schemas via parametersJsonSchema

### DIFF
--- a/src/celeste/providers/google/generate_content/parameters.py
+++ b/src/celeste/providers/google/generate_content/parameters.py
@@ -210,8 +210,6 @@ class ToolsMapper[Content](ParameterMapper[Content]):
         params = tool.get("parameters", {})
         if isinstance(params, type) and issubclass(params, BaseModel):
             schema = params.model_json_schema()
-            # Remove unsupported 'title' fields
-            schema = ToolsMapper._remove_titles(schema)
         else:
             schema = params
 
@@ -219,25 +217,7 @@ class ToolsMapper[Content](ParameterMapper[Content]):
         if "description" in tool:
             result["description"] = tool["description"]
         if schema:
-            result["parameters"] = schema
-        return result
-
-    @staticmethod
-    def _remove_titles(schema: dict[str, Any]) -> dict[str, Any]:
-        """Remove unsupported 'title' fields from schema for Google."""
-        result: dict[str, Any] = {}
-        for key, value in schema.items():
-            if key == "title":
-                continue
-            if isinstance(value, dict):
-                result[key] = ToolsMapper._remove_titles(value)
-            elif isinstance(value, list):
-                result[key] = [
-                    ToolsMapper._remove_titles(item) if isinstance(item, dict) else item
-                    for item in value
-                ]
-            else:
-                result[key] = value
+            result["parametersJsonSchema"] = schema
         return result
 
 

--- a/tests/unit_tests/test_google_tools_mapper.py
+++ b/tests/unit_tests/test_google_tools_mapper.py
@@ -1,0 +1,65 @@
+"""Regression coverage for Gemini ToolsMapper — emits `parametersJsonSchema`."""
+
+from __future__ import annotations
+
+from celeste.providers.google.generate_content.parameters import ToolsMapper
+
+
+def _map(tool: dict) -> dict:
+    return ToolsMapper._map_user_tool(tool)
+
+
+def test_maps_to_parameters_json_schema_not_legacy_parameters() -> None:
+    fn = _map(
+        {
+            "name": "example",
+            "description": "example tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"prompt": {"type": "string"}},
+                "required": ["prompt"],
+            },
+        },
+    )
+    assert "parametersJsonSchema" in fn
+    assert "parameters" not in fn
+    assert fn["parametersJsonSchema"]["properties"]["prompt"]["type"] == "string"
+
+
+def test_preserves_integer_enum_on_non_string_type() -> None:
+    fn = _map(
+        {
+            "name": "example",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "duration": {"type": "integer", "enum": [4, 6, 8]},
+                },
+            },
+        },
+    )
+    duration = fn["parametersJsonSchema"]["properties"]["duration"]
+    assert duration["type"] == "integer"
+    assert duration["enum"] == [4, 6, 8]
+
+
+def test_preserves_title_fields() -> None:
+    fn = _map(
+        {
+            "name": "example",
+            "parameters": {
+                "title": "ExampleInput",
+                "type": "object",
+                "properties": {"x": {"type": "string", "title": "X"}},
+            },
+        },
+    )
+    assert fn["parametersJsonSchema"]["title"] == "ExampleInput"
+    assert fn["parametersJsonSchema"]["properties"]["x"]["title"] == "X"
+
+
+def test_tool_with_no_parameters_emits_no_schema_field() -> None:
+    fn = _map({"name": "example", "description": "no-args"})
+    assert "parameters" not in fn
+    assert "parametersJsonSchema" not in fn
+    assert fn["description"] == "no-args"


### PR DESCRIPTION
## Summary

Closes #262.

The legacy `functionDeclarations[].parameters` field restricts `enum` to `TYPE_STRING` properties. Any integer `Choice` constraint (e.g. `veo-3.0-generate-001`'s `duration = Choice([4, 6, 8])` or `gemini-embedding-001`'s `dimensions = Choice([768, 1536, 3072])`) produced a 400 at tool-registration time.

Gemini's November 2025 update introduced `parametersJsonSchema`, which accepts raw JSON Schema — integer enums, `$defs`, `$ref`, `anyOf`, `additionalProperties`, and `title` — with no sanitization ([Google announcement](https://blog.google/technology/developers/gemini-api-structured-outputs/)). `parametersJsonSchema` is mutually exclusive with `parameters` per the [API reference](https://ai.google.dev/api/caching).

## Change

`ToolsMapper._map_user_tool` now emits the schema under `parametersJsonSchema` instead of `parameters`. The `_remove_titles` helper is deleted — `title` is natively supported by the JSON Schema field.

## Ecosystem precedent

- **pydantic-ai** uses `parametersJsonSchema` unconditionally in its Gemini provider.
- **Google's `python-genai` SDK** emits deprecation warnings on its legacy `Schema.from_json_schema` sanitizer, steering callers toward `parametersJsonSchema`.
- celeste-python's text-model catalog is entirely 2.5 / 3.x — all within Google's "all actively supported Gemini models" set.

## Test plan

- [x] New `tests/unit_tests/test_google_tools_mapper.py` covering:
  - Schema emitted under `parametersJsonSchema`, not `parameters`.
  - Integer `enum` on a non-string property preserved.
  - `title` fields preserved.
  - Tool with no parameters emits no schema field.
- [x] Full unit test suite passes (598 tests).
- [x] ruff + mypy clean.