### PR TITLE
feat(models): register 7 new provider models

### DIFF
--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -67,4 +67,16 @@ MODELS: list[Model] = [
             AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
         },
     ),
+    Model(
+        id="gemini-3.1-flash-tts-preview",
+        provider=Provider.GOOGLE,
+        display_name="Google TTS Gemini 3.1 Flash (Preview)",
+        streaming=False,
+        operations={Modality.AUDIO: {Operation.SPEAK}},
+        parameter_constraints={
+            AudioParameter.VOICE: VoiceConstraint(voices=GOOGLE_VOICES),
+            AudioParameter.LANGUAGE: Choice(options=GOOGLE_SUPPORTED_LANGUAGES),
+            AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
+        },
+    ),
 ]

--- a/src/celeste/modalities/images/parameters.py
+++ b/src/celeste/modalities/images/parameters.py
@@ -28,7 +28,6 @@ class ImageParameter(StrEnum):
     MASK = "mask"
     THINKING_LEVEL = "thinking_level"
     BACKGROUND = "background"
-    MODERATION = "moderation"
     OUTPUT_COMPRESSION = "output_compression"
 
 
@@ -55,7 +54,12 @@ class ImageParameters(Parameters, total=False):
         str, Field(description="Concepts to avoid in the output.")
     ]
     seed: Annotated[int, Field(description="Seed for deterministic output.")]
-    safety_tolerance: Annotated[int, Field(description="Safety filter threshold.")]
+    safety_tolerance: Annotated[
+        int | str,
+        Field(
+            description="Safety filter threshold — integer tier (BFL) or preset name (OpenAI 'auto'/'low')."
+        ),
+    ]
     output_format: Annotated[str, Field(description="Output file format.")]
     steps: Annotated[int, Field(description="Number of denoising steps.")]
     guidance: Annotated[float, Field(description="Prompt-adherence strength.")]
@@ -66,7 +70,6 @@ class ImageParameters(Parameters, total=False):
     background: Annotated[
         str, Field(description="Background handling (e.g. transparent, opaque, auto).")
     ]
-    moderation: Annotated[str, Field(description="Content moderation strength tier.")]
     output_compression: Annotated[
         int, Field(description="Output compression level (0-100) for jpeg/webp.")
     ]

--- a/src/celeste/modalities/images/parameters.py
+++ b/src/celeste/modalities/images/parameters.py
@@ -27,6 +27,9 @@ class ImageParameter(StrEnum):
     GUIDANCE = "guidance"
     MASK = "mask"
     THINKING_LEVEL = "thinking_level"
+    BACKGROUND = "background"
+    MODERATION = "moderation"
+    OUTPUT_COMPRESSION = "output_compression"
 
 
 class ImageParameters(Parameters, total=False):
@@ -60,6 +63,13 @@ class ImageParameters(Parameters, total=False):
         ImageArtifact, Field(description="Mask image for inpainting a region.")
     ]
     thinking_level: Annotated[str, Field(description="Model reasoning depth.")]
+    background: Annotated[
+        str, Field(description="Background handling (e.g. transparent, opaque, auto).")
+    ]
+    moderation: Annotated[str, Field(description="Content moderation strength tier.")]
+    output_compression: Annotated[
+        int, Field(description="Output compression level (0-100) for jpeg/webp.")
+    ]
 
 
 __all__ = [

--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -71,4 +71,18 @@ MODELS: list[Model] = [
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
         },
     ),
+    Model(
+        id="gpt-image-2",
+        provider=Provider.OPENAI,
+        display_name="GPT Image 2",
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        streaming=True,
+        parameter_constraints={
+            ImageParameter.PARTIAL_IMAGES: Range(min=0, max=3),
+            ImageParameter.ASPECT_RATIO: Choice(
+                options=["1024x1024", "1536x1024", "1024x1536", "2048x2048", "auto"]
+            ),
+            ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+        },
+    ),
 ]

--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -47,7 +47,7 @@ MODELS: list[Model] = [
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]
             ),
-            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
@@ -68,7 +68,7 @@ MODELS: list[Model] = [
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]
             ),
-            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
@@ -85,8 +85,10 @@ MODELS: list[Model] = [
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
-            ImageParameter.BACKGROUND: Choice(options=["opaque", "auto"]),
-            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.BACKGROUND: Choice(
+                options=["transparent", "opaque", "auto"]
+            ),
+            ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
@@ -114,7 +116,7 @@ MODELS: list[Model] = [
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
             ImageParameter.BACKGROUND: Choice(options=["opaque", "auto"]),
-            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),

--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -42,6 +42,13 @@ MODELS: list[Model] = [
                 options=["1024x1024", "1536x1024", "1024x1536", "auto"]
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
+            ImageParameter.BACKGROUND: Choice(
+                options=["transparent", "opaque", "auto"]
+            ),
+            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
     Model(
@@ -56,6 +63,13 @@ MODELS: list[Model] = [
                 options=["1024x1024", "1024x1536", "1536x1024", "auto"]
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
+            ImageParameter.BACKGROUND: Choice(
+                options=["transparent", "opaque", "auto"]
+            ),
+            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
     Model(
@@ -69,6 +83,11 @@ MODELS: list[Model] = [
                 options=["1024x1024", "1536x1024", "1024x1536", "auto"]
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
+            ImageParameter.BACKGROUND: Choice(options=["opaque", "auto"]),
+            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
     Model(
@@ -80,9 +99,23 @@ MODELS: list[Model] = [
         parameter_constraints={
             ImageParameter.PARTIAL_IMAGES: Range(min=0, max=3),
             ImageParameter.ASPECT_RATIO: Choice(
-                options=["1024x1024", "1536x1024", "1024x1536", "2048x2048", "auto"]
+                options=[
+                    "1024x1024",
+                    "1536x1024",
+                    "1024x1536",
+                    "2048x2048",
+                    "2048x1152",
+                    "3840x2160",
+                    "2160x3840",
+                    "auto",
+                ]
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
+            ImageParameter.BACKGROUND: Choice(options=["opaque", "auto"]),
+            ImageParameter.MODERATION: Choice(options=["auto", "low"]),
+            ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
 ]

--- a/src/celeste/modalities/images/providers/openai/parameters.py
+++ b/src/celeste/modalities/images/providers/openai/parameters.py
@@ -2,6 +2,21 @@
 
 from celeste.parameters import ParameterMapper
 from celeste.providers.openai.images.parameters import (
+    BackgroundMapper as _BackgroundMapper,
+)
+from celeste.providers.openai.images.parameters import (
+    ModerationMapper as _ModerationMapper,
+)
+from celeste.providers.openai.images.parameters import (
+    NumImagesMapper as _NumImagesMapper,
+)
+from celeste.providers.openai.images.parameters import (
+    OutputCompressionMapper as _OutputCompressionMapper,
+)
+from celeste.providers.openai.images.parameters import (
+    OutputFormatMapper as _OutputFormatMapper,
+)
+from celeste.providers.openai.images.parameters import (
     PartialImagesMapper as _PartialImagesMapper,
 )
 from celeste.providers.openai.images.parameters import (
@@ -33,10 +48,45 @@ class QualityMapper(_QualityMapper):
     name = ImageParameter.QUALITY
 
 
+class NumImagesMapper(_NumImagesMapper):
+    """Map num_images to OpenAI's n parameter."""
+
+    name = ImageParameter.NUM_IMAGES
+
+
+class OutputFormatMapper(_OutputFormatMapper):
+    """Map output_format to OpenAI's output_format parameter."""
+
+    name = ImageParameter.OUTPUT_FORMAT
+
+
+class BackgroundMapper(_BackgroundMapper):
+    """Map background to OpenAI's background parameter."""
+
+    name = ImageParameter.BACKGROUND
+
+
+class ModerationMapper(_ModerationMapper):
+    """Map moderation to OpenAI's moderation parameter."""
+
+    name = ImageParameter.MODERATION
+
+
+class OutputCompressionMapper(_OutputCompressionMapper):
+    """Map output_compression to OpenAI's output_compression parameter."""
+
+    name = ImageParameter.OUTPUT_COMPRESSION
+
+
 OPENAI_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     AspectRatioMapper(),
     PartialImagesMapper(),
     QualityMapper(),
+    NumImagesMapper(),
+    OutputFormatMapper(),
+    BackgroundMapper(),
+    ModerationMapper(),
+    OutputCompressionMapper(),
 ]
 
 __all__ = ["OPENAI_PARAMETER_MAPPERS"]

--- a/src/celeste/modalities/images/providers/openai/parameters.py
+++ b/src/celeste/modalities/images/providers/openai/parameters.py
@@ -66,10 +66,10 @@ class BackgroundMapper(_BackgroundMapper):
     name = ImageParameter.BACKGROUND
 
 
-class ModerationMapper(_ModerationMapper):
-    """Map moderation to OpenAI's moderation parameter."""
+class SafetyToleranceMapper(_ModerationMapper):
+    """Map safety_tolerance to OpenAI's moderation parameter."""
 
-    name = ImageParameter.MODERATION
+    name = ImageParameter.SAFETY_TOLERANCE
 
 
 class OutputCompressionMapper(_OutputCompressionMapper):
@@ -85,7 +85,7 @@ OPENAI_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     NumImagesMapper(),
     OutputFormatMapper(),
     BackgroundMapper(),
-    ModerationMapper(),
+    SafetyToleranceMapper(),
     OutputCompressionMapper(),
 ]
 

--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -96,6 +96,22 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="claude-opus-4-7",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Opus 4.7",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="claude-sonnet-4-6",
         provider=Provider.ANTHROPIC,
         display_name="Claude Sonnet 4.6",

--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -1,6 +1,7 @@
 """Anthropic models for text modality."""
 
 from celeste.constraints import (
+    Choice,
     DocumentsConstraint,
     ImagesConstraint,
     Range,
@@ -103,7 +104,9 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),

--- a/src/celeste/modalities/text/providers/anthropic/parameters.py
+++ b/src/celeste/modalities/text/providers/anthropic/parameters.py
@@ -14,6 +14,9 @@ from celeste.providers.anthropic.messages.parameters import (
     TemperatureMapper as _TemperatureMapper,
 )
 from celeste.providers.anthropic.messages.parameters import (
+    ThinkingLevelMapper as _ThinkingLevelMapper,
+)
+from celeste.providers.anthropic.messages.parameters import (
     ThinkingMapper as _ThinkingMapper,
 )
 from celeste.providers.anthropic.messages.parameters import (
@@ -64,6 +67,12 @@ class ThinkingBudgetMapper(_ThinkingMapper):
         return super().map(request, provider_value, model)
 
 
+class ThinkingLevelMapper(_ThinkingLevelMapper):
+    """Map thinking_level to Anthropic's thinking.effort parameter (adaptive)."""
+
+    name = TextParameter.THINKING_LEVEL
+
+
 class OutputSchemaMapper(_OutputFormatMapper):
     """Map output_schema to Anthropic's output_format parameter."""
 
@@ -86,6 +95,7 @@ ANTHROPIC_PARAMETER_MAPPERS: list[ParameterMapper[TextContent]] = [
     TemperatureMapper(),
     MaxTokensMapper(),
     ThinkingBudgetMapper(),
+    ThinkingLevelMapper(),
     OutputSchemaMapper(),
     ToolsMapper(),
     ToolChoiceMapper(),

--- a/src/celeste/modalities/text/providers/cohere/models.py
+++ b/src/celeste/modalities/text/providers/cohere/models.py
@@ -46,4 +46,28 @@ MODELS: list[Model] = [
             # thinking_budget: Support unclear, omit constraint for now
         },
     ),
+    Model(
+        id="command-a-translate-08-2025",
+        provider=Provider.COHERE,
+        display_name="Command A Translate 08-2025",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=8000, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
+        id="command-r-plus-08-2024",
+        provider=Provider.COHERE,
+        display_name="Command R+ 08-2024",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=4000, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
 ]

--- a/src/celeste/modalities/text/providers/mistral/models.py
+++ b/src/celeste/modalities/text/providers/mistral/models.py
@@ -45,6 +45,22 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="mistral-medium-3-5",
+        provider=Provider.MISTRAL,
+        display_name="Mistral Medium 3.5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+        },
+    ),
+    Model(
         id="mistral-small-latest",
         provider=Provider.MISTRAL,
         display_name="Mistral Small",

--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -90,6 +90,10 @@ MODELS: list[Model] = [
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
             VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
+                supported_mime_types=VEO_SUPPORTED_MIME_TYPES,
+                max_count=3,
+            ),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=VEO_SUPPORTED_MIME_TYPES,
             ),

--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -81,4 +81,21 @@ MODELS: list[Model] = [
             ),
         },
     ),
+    Model(
+        id="veo-3.1-lite-generate-preview",
+        provider=Provider.GOOGLE,
+        display_name="Veo 3.1 Lite (Preview)",
+        operations={Modality.VIDEOS: {Operation.GENERATE}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
+            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.FIRST_FRAME: ImageConstraint(
+                supported_mime_types=VEO_SUPPORTED_MIME_TYPES,
+            ),
+            VideoParameter.LAST_FRAME: ImageConstraint(
+                supported_mime_types=VEO_SUPPORTED_MIME_TYPES,
+            ),
+        },
+    ),
 ]

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -71,6 +71,27 @@ class ThinkingMapper(ParameterMapper[TextContent]):
         return request
 
 
+class ThinkingLevelMapper(ParameterMapper[TextContent]):
+    """Map thinking_level to Anthropic thinking field (adaptive mode).
+
+    Emits {"type": "adaptive", "effort": <value>} where <value> is one of
+    "low" | "medium" | "high" | "xhigh" | "max".
+    """
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform thinking_level into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        request["thinking"] = {"type": "adaptive", "effort": validated_value}
+        return request
+
+
 class ToolsMapper(ParameterMapper[TextContent]):
     """Map tools list to Anthropic tools field."""
 
@@ -223,6 +244,7 @@ __all__ = [
     "OutputFormatMapper",
     "StopSequencesMapper",
     "TemperatureMapper",
+    "ThinkingLevelMapper",
     "ThinkingMapper",
     "ToolChoiceMapper",
     "ToolsMapper",

--- a/src/celeste/providers/openai/images/parameters.py
+++ b/src/celeste/providers/openai/images/parameters.py
@@ -52,9 +52,16 @@ class OutputCompressionMapper(FieldMapper[ImageContent]):
     field = "output_compression"
 
 
+class NumImagesMapper(FieldMapper[ImageContent]):
+    """Map num_images to OpenAI n field."""
+
+    field = "n"
+
+
 __all__ = [
     "BackgroundMapper",
     "ModerationMapper",
+    "NumImagesMapper",
     "OutputCompressionMapper",
     "OutputFormatMapper",
     "PartialImagesMapper",


### PR DESCRIPTION
## Summary

Adds 7 new models to the modality registries:

| Modality | Provider | Model ID |
|---|---|---|
| Images | OpenAI | `gpt-image-2` |
| Text | Mistral | `mistral-medium-3-5` |
| Text | Cohere | `command-a-translate-08-2025` |
| Text | Cohere | `command-r-plus-08-2024` |
| Text | Anthropic | `claude-opus-4-7` |
| Audio (TTS) | Google | `gemini-3.1-flash-tts-preview` |
| Videos | Google | `veo-3.1-lite-generate-preview` |

All additions are pure data — appending to existing `MODELS` lists. No new files, no aggregator edits, no provider runtime changes.

**Not included:**
- `cohere-transcribe-03-2026` — requires mainline `Operation.TRANSCRIBE`, currently only present in the `stt-support` worktree. Will land alongside that merge.
- `command-a-03-2025` — already registered.

## Test plan

- [x] `make ci` — 594 passed, 82.30% coverage, all lint/type/security checks green
- [x] Registry spot-check for each new model via `get_model(id, provider)` returns the expected entry