### PR TITLE
feat(deepseek): register V4-Flash and V4-Pro models

### DIFF
--- a/src/celeste/modalities/text/providers/deepseek/models.py
+++ b/src/celeste/modalities/text/providers/deepseek/models.py
@@ -1,6 +1,6 @@
 """DeepSeek models for text modality."""
 
-from celeste.constraints import Range, Schema, ToolChoiceSupport, ToolSupport
+from celeste.constraints import Choice, Range, Schema, ToolChoiceSupport, ToolSupport
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
 
@@ -31,6 +31,36 @@ MODELS: list[Model] = [
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
+        },
+    ),
+    Model(
+        id="deepseek-v4-flash",
+        provider=Provider.DEEPSEEK,
+        display_name="DeepSeek V4 Flash",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=384_000, step=1),
+            TextParameter.THINKING_LEVEL: Choice(options=["disabled", "high", "max"]),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+        },
+    ),
+    Model(
+        id="deepseek-v4-pro",
+        provider=Provider.DEEPSEEK,
+        display_name="DeepSeek V4 Pro",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=384_000, step=1),
+            TextParameter.THINKING_LEVEL: Choice(options=["disabled", "high", "max"]),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
         },
     ),
 ]

--- a/src/celeste/modalities/text/providers/deepseek/parameters.py
+++ b/src/celeste/modalities/text/providers/deepseek/parameters.py
@@ -1,7 +1,24 @@
 """DeepSeek parameter mappers for text."""
 
+from celeste.parameters import ParameterMapper
+from celeste.providers.deepseek.chat.parameters import (
+    ThinkingLevelMapper as _ThinkingLevelMapper,
+)
+from celeste.types import TextContent
+
+from ...parameters import TextParameter
 from ...protocols.chatcompletions.parameters import CHATCOMPLETIONS_PARAMETER_MAPPERS
 
-DEEPSEEK_PARAMETER_MAPPERS = CHATCOMPLETIONS_PARAMETER_MAPPERS
+
+class ThinkingLevelMapper(_ThinkingLevelMapper):
+    """Map thinking_level to DeepSeek's thinking/reasoning_effort fields."""
+
+    name = TextParameter.THINKING_LEVEL
+
+
+DEEPSEEK_PARAMETER_MAPPERS: list[ParameterMapper[TextContent]] = [
+    *CHATCOMPLETIONS_PARAMETER_MAPPERS,
+    ThinkingLevelMapper(),
+]
 
 __all__ = ["DEEPSEEK_PARAMETER_MAPPERS"]

--- a/src/celeste/providers/deepseek/chat/parameters.py
+++ b/src/celeste/providers/deepseek/chat/parameters.py
@@ -1,0 +1,35 @@
+"""DeepSeek Chat API parameter mappers."""
+
+from typing import Any
+
+from celeste.models import Model
+from celeste.parameters import ParameterMapper
+from celeste.types import TextContent
+
+
+class ThinkingLevelMapper(ParameterMapper[TextContent]):
+    """Map thinking_level to DeepSeek's thinking + reasoning_effort fields.
+
+    - "disabled" → thinking={"type": "disabled"}
+    - "high"     → thinking={"type": "enabled"}, reasoning_effort="high"
+    - "max"      → thinking={"type": "enabled"}, reasoning_effort="max"
+    """
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        if validated_value == "disabled":
+            request["thinking"] = {"type": "disabled"}
+        else:
+            request["thinking"] = {"type": "enabled"}
+            request["reasoning_effort"] = validated_value
+        return request
+
+
+__all__ = ["ThinkingLevelMapper"]


### PR DESCRIPTION
## Summary
- Register `deepseek-v4-flash` and `deepseek-v4-pro` (released early March 2026): 1M context, 384K max output, thinking + non-thinking modes, 128-function tool calling.
- Add `TextParameter.THINKING_LEVEL` as `Choice(["disabled", "high", "max"])` and a DeepSeek `ThinkingLevelMapper` that emits the proprietary dual-field wire shape: `thinking.type` (enabled/disabled) plus top-level `reasoning_effort` (high/max). Pattern mirrors xai/openai — spread the protocol mappers and append the provider-specific one.
- Legacy `deepseek-chat` / `deepseek-reasoner` entries are untouched; DeepSeek aliases them to V4-Flash modes server-side.

Pricing for context (per 1M tokens, from official docs):
| Model | Input | Cached | Output |
|---|---:|---:|---:|
| V4-Flash | \$0.14 | \$0.028 | \$0.28 |
| V4-Pro | \$1.74 | \$0.145 | \$3.48 |

## Test plan
- [x] `make ci` green (598 unit tests pass, 82.3% coverage, lint/mypy/bandit clean)
- [x] Manual smoke via `celeste.text.generate`:
  - V4-Flash + V4-Pro generate with `thinking_level` in `{disabled, high, max}`
  - `tool_choice="required"` works with `thinking_level="disabled"`
  - Tool calls returned when tools provided
- [x] `ThinkingLevelMapper` emits exact wire format:
  - `"disabled"` → `{"thinking": {"type": "disabled"}}`
  - `"high"` → `{"thinking": {"type": "enabled"}, "reasoning_effort": "high"}`
  - `"max"` → `{"thinking": {"type": "enabled"}, "reasoning_effort": "max"}`
- [ ] ⚠️ Integration test `test_tool_choice_required_forces_tool_call` fails for V4 models due to an **undocumented DeepSeek server bug**: `tool_choice="required"` is rejected with HTTP 400 `"deepseek-reasoner does not support this tool_choice"` when thinking mode is enabled (V4's default). Works fine with `thinking_level="disabled"`. The official API reference lists `required` as a valid `tool_choice` value with no thinking-mode caveat. Keeping `ToolChoiceSupport()` permissive to match the documented contract.

## Docs
- https://api-docs.deepseek.com/quick_start/pricing
- https://api-docs.deepseek.com/guides/thinking_mode