### PR TITLE
feat(telemetry): GenAI OpenTelemetry spans on `_predict` and `_stream`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ inputs.python-version || '3.12' }}
+      - run: uv sync --extra otel
       - run: uv run mypy -p celeste && uv run mypy tests/
 
   security:

--- a/README.md
+++ b/README.md
@@ -218,6 +218,38 @@ Catch errors **before** production.
 
 ---
 
+## 🔭 Tracing with OpenTelemetry
+
+Celeste emits [GenAI semantic-convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) spans on every modality call when a `TracerProvider` is configured. Spans are zero-cost when no provider is set.
+
+```bash
+uv add 'celeste-ai[otel]'
+```
+
+Configure a provider once at startup (SDK setup is the consumer's responsibility):
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
+```
+
+Every `celeste.text.generate(...)` and `celeste.text.stream.generate(...)` call (and the equivalents on other modalities) emits a span named `chat <model>` (or `embeddings <model>` for embeddings; `celeste.<modality> <model>` for image/video/audio operations the spec doesn't yet cover). Attributes follow GenAI v1.41.0: `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, plus `gen_ai.request.stream` and `gen_ai.response.time_to_first_chunk` on streaming spans.
+
+The GenAI semconv is currently `Status: Development`. Pin attribute shapes via the standard opt-in:
+
+```bash
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
+
+Attribute names may drift between celeste-ai minor versions until the spec stabilizes.
+
+---
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -218,38 +218,6 @@ Catch errors **before** production.
 
 ---
 
-## 🔭 Tracing with OpenTelemetry
-
-Celeste emits [GenAI semantic-convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) spans on every modality call when a `TracerProvider` is configured. Spans are zero-cost when no provider is set.
-
-```bash
-uv add 'celeste-ai[otel]'
-```
-
-Configure a provider once at startup (SDK setup is the consumer's responsibility):
-
-```python
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-
-provider = TracerProvider()
-provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-trace.set_tracer_provider(provider)
-```
-
-Every `celeste.text.generate(...)` and `celeste.text.stream.generate(...)` call (and the equivalents on other modalities) emits a span named `chat <model>` (or `embeddings <model>` for embeddings; `celeste.<modality> <model>` for image/video/audio operations the spec doesn't yet cover). Attributes follow GenAI v1.41.0: `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, plus `gen_ai.request.stream` and `gen_ai.response.time_to_first_chunk` on streaming spans.
-
-The GenAI semconv is currently `Status: Development`. Pin attribute shapes via the standard opt-in:
-
-```bash
-export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-```
-
-Attribute names may drift between celeste-ai minor versions until the spec stabilizes.
-
----
-
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gcp = ["google-auth[requests]>=2.0.0"]
+otel = ["opentelemetry-api>=1.30"]
 
 [project.urls]
 Homepage = "https://withceleste.ai"
@@ -121,6 +122,7 @@ known-first-party = ["celeste"]
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]  # No docstrings required in tests
 "**/client.py" = ["ANN401"]  # Allow Any return types in mixin client classes
+"**/telemetry.py" = ["ANN401"]  # Allow Any: mirrors OTel API surface for forwarding
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dev = [
     "bandit[toml]>=1.7.5",
     "pre-commit>=3.5.0",
     "pytest-rerunfailures>=16.1",
-    "opentelemetry-api>=1.30",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "bandit[toml]>=1.7.5",
     "pre-commit>=3.5.0",
     "pytest-rerunfailures>=16.1",
+    "opentelemetry-api>=1.30",
 ]
 
 [build-system]
@@ -163,10 +164,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "google.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "opentelemetry.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,10 @@ module = "google.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "opentelemetry.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = [
     "celeste.modalities.text.client",
     "celeste.modalities.text.streaming",

--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Unpack
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from celeste import telemetry
 from celeste.auth import Authentication
 from celeste.core import Modality, Protocol, Provider
 from celeste.exceptions import (
@@ -212,29 +213,44 @@ class ModalityClient[
         Returns:
             Output of the parameterized type.
         """
-        inputs, parameters = self._validate_artifacts(inputs, **parameters)
-        request_body = self._build_request(inputs, extra_body=extra_body, **parameters)
-        response_data = await self._make_request(
-            request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
-        )
-        content = self._parse_content(response_data)
-        content = self._transform_output(content, **parameters)
-        tool_calls = self._parse_tool_calls(response_data)
-        reasoning, signature = self._parse_reasoning(response_data)
-        kwargs: dict[str, Any] = {}
-        if reasoning is not None:
-            kwargs["reasoning"] = reasoning
-        if signature:
-            kwargs["signature"] = signature
-        output = self._output_class()(
-            content=content,
-            usage=self._get_usage(response_data),
-            finish_reason=self._get_finish_reason(response_data),
-            metadata=self._build_metadata(response_data),
-            tool_calls=tool_calls,
-            **kwargs,
-        )
-        return output
+        with telemetry.tracer.start_as_current_span(
+            telemetry.span_name(self.modality, self.model),
+            attributes=telemetry.request_attributes(
+                model=self.model,
+                provider=self.provider,
+                protocol=self.protocol,
+                modality=self.modality,
+            ),
+        ) as span:
+            inputs, parameters = self._validate_artifacts(inputs, **parameters)
+            request_body = self._build_request(
+                inputs, extra_body=extra_body, **parameters
+            )
+            response_data = await self._make_request(
+                request_body,
+                endpoint=endpoint,
+                extra_headers=extra_headers,
+                **parameters,
+            )
+            content = self._parse_content(response_data)
+            content = self._transform_output(content, **parameters)
+            tool_calls = self._parse_tool_calls(response_data)
+            reasoning, signature = self._parse_reasoning(response_data)
+            kwargs: dict[str, Any] = {}
+            if reasoning is not None:
+                kwargs["reasoning"] = reasoning
+            if signature:
+                kwargs["signature"] = signature
+            output = self._output_class()(
+                content=content,
+                usage=self._get_usage(response_data),
+                finish_reason=self._get_finish_reason(response_data),
+                metadata=self._build_metadata(response_data),
+                tool_calls=tool_calls,
+                **kwargs,
+            )
+            span.set_attributes(telemetry.output_attributes(output))
+            return output
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from response. Override in providers that support tools."""
@@ -281,6 +297,18 @@ class ModalityClient[
         request_body = self._build_request(
             inputs, extra_body=extra_body, streaming=True, **parameters
         )
+        span = telemetry.tracer.start_span(
+            telemetry.span_name(self.modality, self.model),
+            attributes={
+                **telemetry.request_attributes(
+                    model=self.model,
+                    provider=self.provider,
+                    protocol=self.protocol,
+                    modality=self.modality,
+                ),
+                "gen_ai.request.stream": True,
+            },
+        )
         sse_iterator = self._make_stream_request(
             request_body,
             endpoint=endpoint,
@@ -288,6 +316,7 @@ class ModalityClient[
             **parameters,
         )
         sse_iterator = enrich_stream_errors(sse_iterator, self._handle_error_response)
+        sse_iterator = telemetry.trace_stream(sse_iterator, span)
         return stream_class(
             sse_iterator,
             transform_output=self._transform_output,

--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -1,0 +1,170 @@
+"""OpenTelemetry GenAI telemetry for Celeste."""
+
+import time
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from celeste.core import Modality, Protocol, Provider
+from celeste.io import Output
+from celeste.models import Model
+
+_PROVIDER_NAME_MAP: dict[Provider, str] = {
+    Provider.OPENAI: "openai",
+    Provider.ANTHROPIC: "anthropic",
+    Provider.GOOGLE: "gcp.gemini",
+    Provider.MISTRAL: "mistral_ai",
+    Provider.XAI: "x_ai",
+    Provider.GROQ: "groq",
+    Provider.DEEPSEEK: "deepseek",
+    Provider.PERPLEXITY: "perplexity",
+    Provider.COHERE: "cohere",
+}
+
+_MODALITY_OPERATION: dict[Modality, str] = {
+    Modality.TEXT: "chat",
+    Modality.EMBEDDINGS: "embeddings",
+}
+
+
+class _NoOpSpan:
+    """Span stand-in used when ``opentelemetry-api`` is not installed."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Discard the attribute."""
+
+    def set_attributes(self, attributes: dict[str, Any]) -> None:
+        """Discard the attribute mapping."""
+
+    def set_status(self, *args: Any, **kwargs: Any) -> None:
+        """Discard the status update."""
+
+    def record_exception(self, *args: Any, **kwargs: Any) -> None:
+        """Discard the exception."""
+
+    def end(self) -> None:
+        """Discard the end signal."""
+
+
+class _NoOpTracer:
+    """Tracer stand-in used when ``opentelemetry-api`` is not installed."""
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[_NoOpSpan]:
+        """Yield a no-op span as a context manager."""
+        yield _NoOpSpan()
+
+    def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        """Return a detached no-op span."""
+        return _NoOpSpan()
+
+
+@contextmanager
+def _noop_use_span(span: Any, end_on_exit: bool = False) -> Iterator[Any]:
+    """No-op stand-in for ``opentelemetry.trace.use_span``."""
+    yield span
+
+
+try:
+    from opentelemetry import trace as _otel_trace
+
+    tracer: Any = _otel_trace.get_tracer("celeste")
+    use_span: Any = _otel_trace.use_span
+except ImportError:
+    tracer = _NoOpTracer()
+    use_span = _noop_use_span
+
+
+def request_attributes(
+    *,
+    model: Model,
+    provider: Provider | None,
+    protocol: Protocol | None,
+    modality: Modality,
+) -> dict[str, Any]:
+    """Build GenAI request attributes for a span.
+
+    Off-spec providers/modalities get ``celeste.*`` keys so the data is
+    queryable without polluting the ``gen_ai.*`` namespace.
+
+    Args:
+        model: Resolved model.
+        provider: Resolved provider, if any.
+        protocol: Resolved protocol, if any.
+        modality: Operation modality.
+
+    Returns:
+        Attribute dict suitable for passing to ``start_as_current_span``.
+    """
+    attrs: dict[str, Any] = {"gen_ai.request.model": model.id}
+    provider_name = _PROVIDER_NAME_MAP.get(provider) if provider is not None else None
+    if provider_name is not None:
+        attrs["gen_ai.provider.name"] = provider_name
+    elif protocol is not None:
+        attrs["gen_ai.provider.name"] = protocol.value
+    operation = _MODALITY_OPERATION.get(modality)
+    if operation is not None:
+        attrs["gen_ai.operation.name"] = operation
+    else:
+        attrs["celeste.modality"] = modality.value
+    return attrs
+
+
+def span_name(modality: Modality, model: Model) -> str:
+    """Build the span name per GenAI semconv ``"{operation} {model}"``.
+
+    Falls back to ``"celeste.{modality} {model}"`` for modalities the spec
+    does not yet cover.
+    """
+    operation = _MODALITY_OPERATION.get(modality)
+    if operation is not None:
+        return f"{operation} {model.id}"
+    return f"celeste.{modality.value} {model.id}"
+
+
+def output_attributes(output: Output[Any]) -> dict[str, Any]:
+    """Extract GenAI response attributes from a typed Output."""
+    attrs: dict[str, Any] = {}
+    input_tokens = getattr(output.usage, "input_tokens", None)
+    output_tokens = getattr(output.usage, "output_tokens", None)
+    if isinstance(input_tokens, int):
+        attrs["gen_ai.usage.input_tokens"] = input_tokens
+    if isinstance(output_tokens, int):
+        attrs["gen_ai.usage.output_tokens"] = output_tokens
+    if output.finish_reason is not None and output.finish_reason.reason is not None:
+        attrs["gen_ai.response.finish_reasons"] = (output.finish_reason.reason,)
+    return attrs
+
+
+async def trace_stream(
+    sse_iterator: AsyncIterator[dict[str, Any]],
+    span: Any,
+) -> AsyncIterator[dict[str, Any]]:
+    """Wrap an SSE iterator to record TTFC and end the span at iteration's end.
+
+    OTel's ``use_span(span, end_on_exit=True)`` context manager makes the
+    span current, auto-records exceptions, sets ERROR status on exception,
+    and ends the span on exit (including ``GeneratorExit`` from consumer
+    abandonment). No try/except needed.
+    """
+    with use_span(span, end_on_exit=True):
+        started = time.monotonic()
+        seen_first = False
+        async for event in sse_iterator:
+            if not seen_first:
+                seen_first = True
+                span.set_attribute(
+                    "gen_ai.response.time_to_first_chunk",
+                    time.monotonic() - started,
+                )
+            yield event
+
+
+__all__ = [
+    "output_attributes",
+    "request_attributes",
+    "span_name",
+    "trace_stream",
+    "tracer",
+    "use_span",
+]


### PR DESCRIPTION
## Summary

Native OpenTelemetry GenAI v1.41.0 spans on every `ModalityClient._predict` and `_stream` call. Provider-SDK instrumentation packages (OpenInference, openllmetry, opentelemetry-instrumentation-openai-v2) cannot reach Celeste calls because Celeste bypasses provider SDKs; the right home for native LLM-semantic spans is celeste-python itself.

Closes #206.

## What changed

- New `src/celeste/telemetry.py` (~170 LOC) with lazy OTel import + private no-op fallback, GenAI provider/modality enum maps, and four pure helpers (`request_attributes`, `span_name`, `output_attributes`, `trace_stream`).
- `src/celeste/client.py:ModalityClient._predict` — body wrapped in `with telemetry.tracer.start_as_current_span(...) as span:`. OTel's context manager auto-handles exception recording, status, and span end. Output attributes set on success before return.
- `src/celeste/client.py:ModalityClient._stream` — detached span via `tracer.start_span(...)`, then `telemetry.trace_stream(sse_iterator, span)` wraps the SSE iterator with `use_span(span, end_on_exit=True)` for clean lifecycle (completion / exception / `GeneratorExit` abandonment, no try/except in our code).
- `pyproject.toml` — optional `[otel]` extra (`opentelemetry-api>=1.30`); per-file `ANN401` ignore for `**/telemetry.py` mirroring the existing `**/client.py` ignore (forwarding shims need `Any`).
- `.github/workflows/ci.yml` — type-check job installs `[otel]` extra so mypy sees the real OTel types (mirrors the existing `[gcp]` install in the test job).

## Verified — real Gemini call

```json
{
    "name": "chat gemini-3.1-flash-lite-preview",
    "attributes": {
        "gen_ai.request.model": "gemini-3.1-flash-lite-preview",
        "gen_ai.provider.name": "gcp.gemini",
        "gen_ai.operation.name": "chat",
        "gen_ai.usage.input_tokens": 13,
        "gen_ai.usage.output_tokens": 1,
        "gen_ai.response.finish_reasons": ["STOP"]
    }
}
```

## Out of scope (future)

- Content events (`gen_ai.input.messages`/`output.messages`, env-var gated).
- Metrics histograms (`gen_ai.client.token.usage`, `gen_ai.client.operation.duration`).
- `operation: Operation` kwarg on `_predict`/`_stream` for off-spec span fidelity (image edit vs generate, audio speak, video edit).

## Behavior matrix

| Install | TracerProvider | Result |
|---|---|---|
| `celeste-ai` (no extra) | n/a | helpers route to private no-op classes. Zero overhead. |
| `celeste-ai[otel]` | no | OTel's `ProxyTracer` returns `NonRecordingSpan`. Zero overhead. |
| `celeste-ai[otel]` | yes | Spans emitted with `gen_ai.*` attributes per spec. |

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy -p celeste` clean (333 source files)
- [x] `uv run ruff check src/celeste` clean
- [x] `uv run pytest tests/unit_tests/ -m "not integration"` — 604 passed
- [x] Manual smoke against Gemini with `ConsoleSpanExporter` (output above)
