### PR TITLE
feat(telemetry): emit gen_ai.response.model from Output.metadata["model"]

### DIFF
--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -224,6 +224,7 @@ def output_attributes(output: Output[Any]) -> dict[str, Any]:
         attrs[semconv_key or f"celeste.usage.{field_name}"] = value
     if output.finish_reason is not None and output.finish_reason.reason is not None:
         attrs["gen_ai.response.finish_reasons"] = (output.finish_reason.reason,)
+    attrs["gen_ai.response.model"] = output.metadata["model"]
     return attrs
 
 

--- a/tests/unit_tests/_telemetry_helpers.py
+++ b/tests/unit_tests/_telemetry_helpers.py
@@ -1,7 +1,7 @@
 """Shared fixtures and helpers for telemetry-related unit tests."""
 
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Unpack
 
 from celeste.io import Chunk, Output, Usage
 from celeste.parameters import Parameters
@@ -29,6 +29,19 @@ class TelemetryStream(Stream[TelemetryOutput, Parameters, Chunk]):
     _chunk_class: ClassVar[type[Chunk]] = Chunk
     _output_class: ClassVar[type[Output]] = TelemetryOutput
     _empty_content: ClassVar[str] = ""
+
+    def __init__(
+        self,
+        sse_iterator: AsyncIterator[dict[str, Any]],
+        stream_metadata: dict[str, Any] | None = None,
+        **parameters: Unpack[Parameters],
+    ) -> None:
+        """Default `stream_metadata={"model": "test-model"}` to mirror production wiring."""
+        super().__init__(
+            sse_iterator,
+            stream_metadata=stream_metadata or {"model": "test-model"},
+            **parameters,
+        )
 
     def _aggregate_content(self, chunks: list[Chunk]) -> str:
         """Concatenate chunk content."""

--- a/tests/unit_tests/test_telemetry_streaming.py
+++ b/tests/unit_tests/test_telemetry_streaming.py
@@ -16,6 +16,7 @@ from celeste.io import Output, Usage
 from tests.unit_tests._telemetry_helpers import (
     TelemetryOutput,
     TelemetryStream,
+    TelemetryUsage,
     async_iter,
 )
 from tests.unit_tests.conftest import start_test_span
@@ -213,10 +214,24 @@ class TestExtendedUsageAttributes:
     def test_off_spec_usage_emitted_under_celeste_namespace(self) -> None:
         """Modality-specific Usage fields fall through to `celeste.usage.<field>`."""
         usage = _OffSpecUsage(images_generated=4, audio_seconds=1.5)
-        output: Output[Any] = TelemetryOutput(content="", usage=usage)
+        output: Output[Any] = TelemetryOutput(
+            content="", usage=usage, metadata={"model": "test-model"}
+        )
 
         attrs = telemetry.output_attributes(output)
 
         assert attrs["celeste.usage.images_generated"] == 4
         assert attrs["celeste.usage.audio_seconds"] == 1.5
         assert "gen_ai.usage.images_generated" not in attrs
+
+    def test_response_model_emitted_from_metadata(self) -> None:
+        """`gen_ai.response.model` reads from `output.metadata["model"]`."""
+        output: Output[Any] = TelemetryOutput(
+            content="",
+            usage=TelemetryUsage(),
+            metadata={"model": "claude-opus-4-1-20250805"},
+        )
+
+        attrs = telemetry.output_attributes(output)
+
+        assert attrs["gen_ai.response.model"] == "claude-opus-4-1-20250805"


### PR DESCRIPTION
## Summary

`output_attributes` now emits `gen_ai.response.model` set to `output.metadata["model"]` — the model id celeste already populates on every Output. Closes the GenAI semconv `gen_ai.response.model` gap.

## Why

GenAI semconv defines two distinct attributes:

- `gen_ai.request.model` — the id the caller requested
- `gen_ai.response.model` — the id the provider actually served

Pre-PR celeste only emitted the request side. For routing/aliasing providers (Anthropic latest-tag → dated snapshot, OpenAI alias → snapshot) the response side can differ, and dashboards need it to attribute cost/latency/errors to the actually-served variant.

## Mechanism

One-line change in `output_attributes`:

```python
attrs["gen_ai.response.model"] = output.metadata["model"]
```

`metadata["model"]` is universally populated:
- Non-streaming: `ModalityClient._build_metadata` writes it (`client.py:415`).
- Streaming: `client.py:_stream` passes `stream_metadata={"model": self.model.id, ...}` to the Stream constructor; `Stream._build_stream_metadata` spreads it into the Output's metadata.

For providers that don't echo a different served model, the emitted attribute equals `gen_ai.request.model`. That's accurate for the common case where served = requested.

## Why no provider mixin changes

Provider mixins COULD overwrite `metadata["model"]` with the response's served value (Anthropic `response_data["model"]`, Gemini `modelVersion`, etc.) to surface routing differences. They don't today; this PR is intentionally minimal. Aliasing-provider users who want the served snapshot can override `_build_metadata` in their provider mixin in a follow-up — the data flow is already there.

## Tests

- `TelemetryStream` test fixture defaults `stream_metadata={"model": "test-model"}` to mirror production wiring.
- `test_off_spec_usage_emitted_under_celeste_namespace` updated to construct Output with `metadata={"model": ...}`.
- New `test_response_model_emitted_from_metadata` asserts the attribute is read from metadata correctly.

631 tests pass. Real-call validated against running chat-backend (Gemini text streaming + non-streaming + image-gen): every GenAI span carries `gen_ai.response.model`.

## Out of scope

- Provider-side overwrite of `metadata["model"]` with the served snapshot. Easy follow-up; doesn't belong in this minimal landing.
- Adding `Output.model` as a typed field. `metadata["model"]` is the existing surface; promoting it would expand the public Output API for one optional string.

## Test plan

- [x] `make lint`, `make format --check`, `make typecheck` — clean.
- [x] `uv run pytest tests/unit_tests/ -m "not integration" -q` — 631 passed.
- [x] Real-call: Gemini text streaming + non-streaming + image-gen — `gen_ai.response.model` present on every span.