### PR TITLE
fix(telemetry): drop use_span from _TracedStream.__anext__; eager-prime SSE under captured ctx

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -1,7 +1,5 @@
 """Base client for modality-specific AI operations."""
 
-import asyncio
-import contextvars
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -28,28 +26,6 @@ from celeste.parameters import ParameterMapper, Parameters
 from celeste.streaming import Stream, enrich_stream_errors
 from celeste.tools import ToolCall
 from celeste.types import RawUsage
-
-
-async def _prime_with_context(
-    inner: AsyncIterator[dict[str, Any]],
-    ctx: contextvars.Context,
-) -> AsyncIterator[dict[str, Any]]:
-    """Run inner's first pull under ctx; delegate the rest to the caller's context."""
-
-    async def _first() -> dict[str, Any]:
-        return await inner.__anext__()
-
-    task = asyncio.create_task(_first(), context=ctx)
-    try:
-        first = await task
-    except StopAsyncIteration:
-        return
-    except BaseException:
-        task.cancel()
-        raise
-    yield first
-    async for event in inner:
-        yield event
 
 
 class APIMixin(ABC):
@@ -337,10 +313,7 @@ class ModalityClient[
             **parameters,
         )
         sse_iterator = enrich_stream_errors(sse_iterator, self._handle_error_response)
-        # Capture span-active OTel context so the first SSE pull fires HTTP under it
-        with telemetry.use_span(span):
-            ctx_with_span = contextvars.copy_context()
-        sse_iterator = _prime_with_context(sse_iterator, ctx_with_span)
+        sse_iterator = telemetry.bind_first_pull_to_span(sse_iterator, span)
         stream = stream_class(
             sse_iterator,
             transform_output=self._transform_output,

--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -44,6 +44,9 @@ async def _prime_with_context(
         first = await task
     except StopAsyncIteration:
         return
+    except BaseException:
+        task.cancel()
+        raise
     yield first
     async for event in inner:
         yield event

--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -1,5 +1,7 @@
 """Base client for modality-specific AI operations."""
 
+import asyncio
+import contextvars
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -26,6 +28,25 @@ from celeste.parameters import ParameterMapper, Parameters
 from celeste.streaming import Stream, enrich_stream_errors
 from celeste.tools import ToolCall
 from celeste.types import RawUsage
+
+
+async def _prime_with_context(
+    inner: AsyncIterator[dict[str, Any]],
+    ctx: contextvars.Context,
+) -> AsyncIterator[dict[str, Any]]:
+    """Run inner's first pull under ctx; delegate the rest to the caller's context."""
+
+    async def _first() -> dict[str, Any]:
+        return await inner.__anext__()
+
+    task = asyncio.create_task(_first(), context=ctx)
+    try:
+        first = await task
+    except StopAsyncIteration:
+        return
+    yield first
+    async for event in inner:
+        yield event
 
 
 class APIMixin(ABC):
@@ -313,6 +334,10 @@ class ModalityClient[
             **parameters,
         )
         sse_iterator = enrich_stream_errors(sse_iterator, self._handle_error_response)
+        # Capture span-active OTel context so the first SSE pull fires HTTP under it
+        with telemetry.use_span(span):
+            ctx_with_span = contextvars.copy_context()
+        sse_iterator = _prime_with_context(sse_iterator, ctx_with_span)
         stream = stream_class(
             sse_iterator,
             transform_output=self._transform_output,

--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -435,18 +435,17 @@ class _TracedStream:
 
     async def __anext__(self) -> Any:
         """Yield next chunk; emit TTFC on first, finalize span on terminal events."""
-        with use_span(self._span, end_on_exit=False):
-            try:
-                chunk = await self._inner.__anext__()
-            except (StopAsyncIteration, asyncio.CancelledError):
-                self._finalize()
-                raise
-            except Exception as exc:
-                self._error = exc
-                self._span.record_exception(exc)
-                self._span.set_status(Status(StatusCode.ERROR, str(exc)))
-                self._finalize()
-                raise
+        try:
+            chunk = await self._inner.__anext__()
+        except (StopAsyncIteration, asyncio.CancelledError):
+            self._finalize()
+            raise
+        except Exception as exc:
+            self._error = exc
+            self._span.record_exception(exc)
+            self._span.set_status(Status(StatusCode.ERROR, str(exc)))
+            self._finalize()
+            raise
         if not self._seen_first:
             self._seen_first = True
             self._span.set_attribute(

--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -1,10 +1,11 @@
 """OpenTelemetry GenAI telemetry for Celeste."""
 
 import asyncio
+import contextvars
 import json
 import os
 import time
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import contextmanager, suppress
 from types import TracebackType
 from typing import Any
@@ -540,10 +541,35 @@ def trace_stream(
     return _TracedStream(stream, span, metric_attributes)
 
 
+async def bind_first_pull_to_span(
+    inner: AsyncIterator[dict[str, Any]],
+    span: Any,
+) -> AsyncIterator[dict[str, Any]]:
+    """Run inner's first pull under a context where span is active; delegate the rest."""
+    with use_span(span):
+        ctx = contextvars.copy_context()
+
+    async def _first() -> dict[str, Any]:
+        return await inner.__anext__()
+
+    task = asyncio.create_task(_first(), context=ctx)
+    try:
+        first = await task
+    except StopAsyncIteration:
+        return
+    except BaseException:
+        task.cancel()
+        raise
+    yield first
+    async for event in inner:
+        yield event
+
+
 __all__ = [
     "Status",
     "StatusCode",
     "add_input_event",
+    "bind_first_pull_to_span",
     "gen_ai_span",
     "meter",
     "output_attributes",

--- a/tests/unit_tests/test_telemetry_streaming.py
+++ b/tests/unit_tests/test_telemetry_streaming.py
@@ -1,12 +1,12 @@
 """Tests for `_TracedStream` — span lifecycle and GenAI attribute emission."""
 
 import asyncio
-import contextvars
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
@@ -14,7 +14,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from opentelemetry.trace import StatusCode
 
 from celeste import telemetry
-from celeste.client import _prime_with_context
 from celeste.exceptions import StreamNotExhaustedError
 from celeste.io import Output, Usage
 from tests.unit_tests._telemetry_helpers import (
@@ -261,53 +260,72 @@ class TestNoSpanActivationInAnext:
         mock_use_span.assert_not_called()
 
 
-class TestPrimeWithContext:
-    """`_prime_with_context` runs the first pull under ctx and delegates the rest."""
+class TestBindFirstPullToSpan:
+    """`bind_first_pull_to_span` runs the first pull with span active; delegates the rest."""
 
-    async def test_preserves_event_order(self) -> None:
+    async def test_preserves_event_order(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
         """All events from inner are yielded in original order."""
+        _, provider = exporter
         events = [{"i": 0}, {"i": 1}, {"i": 2}]
-        primed = _prime_with_context(async_iter(events), contextvars.copy_context())
+        bound = telemetry.bind_first_pull_to_span(
+            async_iter(events), start_test_span(provider)
+        )
 
-        collected = [event async for event in primed]
+        collected = [event async for event in bound]
 
         assert collected == events
 
-    async def test_empty_stream_yields_nothing(self) -> None:
+    async def test_empty_stream_yields_nothing(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
         """Inner that immediately raises StopAsyncIteration yields no events."""
-        primed = _prime_with_context(async_iter([]), contextvars.copy_context())
+        _, provider = exporter
+        bound = telemetry.bind_first_pull_to_span(
+            async_iter([]), start_test_span(provider)
+        )
 
-        collected = [event async for event in primed]
+        collected = [event async for event in bound]
 
         assert collected == []
 
-    async def test_first_error_propagates(self) -> None:
+    async def test_first_error_propagates(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
         """Exception raised by inner's first pull propagates to the consumer."""
-        primed = _prime_with_context(_failing_iter(), contextvars.copy_context())
+        _, provider = exporter
+        bound = telemetry.bind_first_pull_to_span(
+            _failing_iter(), start_test_span(provider)
+        )
 
         with pytest.raises(RuntimeError, match="boom"):
-            async for _ in primed:
+            async for _ in bound:
                 pass
 
-    async def test_first_pull_runs_under_captured_ctx(self) -> None:
-        """First inner pull executes under captured ctx; subsequent pulls under caller's ctx."""
-        marker: contextvars.ContextVar[str] = contextvars.ContextVar("marker")
-        marker.set("captured")
-        captured_ctx = contextvars.copy_context()
-        marker.set("caller")
+    async def test_first_pull_runs_with_span_active(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
+        """First inner pull sees span as current OTel context; subsequent pulls don't."""
+        _, provider = exporter
+        span = start_test_span(provider)
+        target_id = span.get_span_context().span_id
 
-        async def inner() -> AsyncIterator[dict[str, str]]:
-            yield {"value": marker.get()}
-            yield {"value": marker.get()}
+        async def inner() -> AsyncIterator[dict[str, int]]:
+            yield {"span_id": otel_trace.get_current_span().get_span_context().span_id}
+            yield {"span_id": otel_trace.get_current_span().get_span_context().span_id}
 
-        primed = _prime_with_context(inner(), captured_ctx)
-        collected = [event async for event in primed]
+        bound = telemetry.bind_first_pull_to_span(inner(), span)
+        collected = [event async for event in bound]
 
-        assert collected[0] == {"value": "captured"}
-        assert collected[1] == {"value": "caller"}
+        assert collected[0]["span_id"] == target_id
+        assert collected[1]["span_id"] != target_id
 
-    async def test_cancel_during_first_pull_cancels_inner_task(self) -> None:
+    async def test_cancel_during_first_pull_cancels_inner_task(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
         """Cancellation while awaiting the first pull propagates to the inner task — no leak."""
+        _, provider = exporter
         started = asyncio.Event()
 
         async def slow_inner() -> AsyncIterator[dict[str, str]]:
@@ -315,8 +333,10 @@ class TestPrimeWithContext:
             await asyncio.sleep(60)
             yield {"v": "never"}
 
-        primed = _prime_with_context(slow_inner(), contextvars.copy_context())
-        consumer: asyncio.Task[dict[str, str]] = asyncio.create_task(primed.__anext__())
+        bound = telemetry.bind_first_pull_to_span(
+            slow_inner(), start_test_span(provider)
+        )
+        consumer: asyncio.Task[dict[str, str]] = asyncio.create_task(bound.__anext__())
         await started.wait()
         consumer.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/tests/unit_tests/test_telemetry_streaming.py
+++ b/tests/unit_tests/test_telemetry_streaming.py
@@ -1,5 +1,6 @@
 """Tests for `_TracedStream` — span lifecycle and GenAI attribute emission."""
 
+import asyncio
 import contextvars
 from collections.abc import AsyncIterator
 from typing import Any
@@ -304,3 +305,20 @@ class TestPrimeWithContext:
 
         assert collected[0] == {"value": "captured"}
         assert collected[1] == {"value": "caller"}
+
+    async def test_cancel_during_first_pull_cancels_inner_task(self) -> None:
+        """Cancellation while awaiting the first pull propagates to the inner task — no leak."""
+        started = asyncio.Event()
+
+        async def slow_inner() -> AsyncIterator[dict[str, str]]:
+            started.set()
+            await asyncio.sleep(60)
+            yield {"v": "never"}
+
+        primed = _prime_with_context(slow_inner(), contextvars.copy_context())
+        consumer: asyncio.Task[dict[str, str]] = asyncio.create_task(primed.__anext__())
+        await started.wait()
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        await asyncio.sleep(0)

--- a/tests/unit_tests/test_telemetry_streaming.py
+++ b/tests/unit_tests/test_telemetry_streaming.py
@@ -1,7 +1,9 @@
 """Tests for `_TracedStream` — span lifecycle and GenAI attribute emission."""
 
+import contextvars
 from collections.abc import AsyncIterator
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
@@ -11,6 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from opentelemetry.trace import StatusCode
 
 from celeste import telemetry
+from celeste.client import _prime_with_context
 from celeste.exceptions import StreamNotExhaustedError
 from celeste.io import Output, Usage
 from tests.unit_tests._telemetry_helpers import (
@@ -235,3 +238,69 @@ class TestExtendedUsageAttributes:
         attrs = telemetry.output_attributes(output)
 
         assert attrs["gen_ai.response.model"] == "claude-opus-4-1-20250805"
+
+
+class TestNoSpanActivationInAnext:
+    """Regression: `_TracedStream.__anext__` must not activate the span across `await`."""
+
+    async def test_anext_does_not_call_use_span(
+        self, exporter: tuple[InMemorySpanExporter, TracerProvider]
+    ) -> None:
+        """Iterating a `_TracedStream` does NOT invoke `telemetry.use_span`."""
+        _, provider = exporter
+        events = [{"delta": "a"}, {"delta": "b"}]
+        wrapped = telemetry.trace_stream(
+            TelemetryStream(async_iter(events)), start_test_span(provider)
+        )
+
+        with patch("celeste.telemetry.use_span") as mock_use_span:
+            async for _ in wrapped:
+                pass
+
+        mock_use_span.assert_not_called()
+
+
+class TestPrimeWithContext:
+    """`_prime_with_context` runs the first pull under ctx and delegates the rest."""
+
+    async def test_preserves_event_order(self) -> None:
+        """All events from inner are yielded in original order."""
+        events = [{"i": 0}, {"i": 1}, {"i": 2}]
+        primed = _prime_with_context(async_iter(events), contextvars.copy_context())
+
+        collected = [event async for event in primed]
+
+        assert collected == events
+
+    async def test_empty_stream_yields_nothing(self) -> None:
+        """Inner that immediately raises StopAsyncIteration yields no events."""
+        primed = _prime_with_context(async_iter([]), contextvars.copy_context())
+
+        collected = [event async for event in primed]
+
+        assert collected == []
+
+    async def test_first_error_propagates(self) -> None:
+        """Exception raised by inner's first pull propagates to the consumer."""
+        primed = _prime_with_context(_failing_iter(), contextvars.copy_context())
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async for _ in primed:
+                pass
+
+    async def test_first_pull_runs_under_captured_ctx(self) -> None:
+        """First inner pull executes under captured ctx; subsequent pulls under caller's ctx."""
+        marker: contextvars.ContextVar[str] = contextvars.ContextVar("marker")
+        marker.set("captured")
+        captured_ctx = contextvars.copy_context()
+        marker.set("caller")
+
+        async def inner() -> AsyncIterator[dict[str, str]]:
+            yield {"value": marker.get()}
+            yield {"value": marker.get()}
+
+        primed = _prime_with_context(inner(), captured_ctx)
+        collected = [event async for event in primed]
+
+        assert collected[0] == {"value": "captured"}
+        assert collected[1] == {"value": "caller"}


### PR DESCRIPTION
## Summary

- `_TracedStream.__anext__` wrapped `await self._inner.__anext__()` in `with use_span(self._span, end_on_exit=False):` so HTTPX child spans would parent to the GenAI span. Under async iteration that resumes across asyncio tasks, the `attach`/`detach` pair fired across mismatched contexts and raised `ValueError: Token was created in a different Context`. Closes #276.
- Drop the `with use_span` block from `__anext__` entirely. Capture an OTel context snapshot with the GenAI span active inside `_stream` (sync `with use_span` + `contextvars.copy_context()` — no `await` between attach and detach, no Task switch) and schedule the SSE iterator's first `__anext__` as `asyncio.create_task(coro, context=ctx)`. The HTTP request fires under that snapshot, so HTTPX auto-instrumentation captures the GenAI span as parent at request emission. Subsequent reads run in the consumer's own context and pull bytes from the open response — no new HTTPX spans, no per-chunk context manipulation.
- Cancel the prime task if the consumer is cancelled before the first chunk arrives so the underlying open connection isn't leaked.
- Single-file source change (`client.py`) plus the `__anext__` cleanup (`telemetry.py`). Zero changes to provider mixins, `http.py`, `_make_stream_request` signature, `Stream`, or any public API.

Pattern aligns with `opentelemetry-instrumentation-openai-v2`'s `BaseStreamWrapper.__anext__`, which has zero `use_span` / `attach` / `detach` calls.

References #272 (where the workaround originated).

## Test plan

- [x] `make lint` clean
- [x] `make format --check` clean
- [x] `make typecheck` clean
- [x] `make test` — 637 unit tests pass (5 new tests in `tests/unit_tests/test_telemetry_streaming.py` covering: `__anext__` does not invoke `use_span`, prime preserves event order, empty stream yields nothing, first-pull error propagates, first pull runs under captured ctx with subsequent pulls under caller's ctx, cancel-mid-first-pull cancels the prime task)
- [ ] Real-call smoke under a multi-chunk streaming consumer: confirm zero "Failed to detach context" warnings, confirm HTTPX child spans still parent to the GenAI span, confirm TTFC / usage / response-model / finish-reason / metric histograms still emit