### PR TITLE
feat(google): add gemini-3.5-flash text model

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -165,4 +165,24 @@ MODELS: list[Model] = [
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
     ),
+    Model(
+        id="gemini-3.5-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.5 Flash",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
 ]


### PR DESCRIPTION
## Summary

- Register `gemini-3.5-flash` in `src/celeste/modalities/text/providers/google/models.py`.
- Constraint set matches `gemini-3.1-pro-preview` in the same file: `THINKING_LEVEL` with `low`, `medium`, and `high` (unlike `gemini-3-flash-preview` / `gemini-3-pro-preview`, which only expose `low` and `high`).
- Same operations, streaming, tools (`WebSearch`, `CodeExecution`), structured output, and multimodal inputs as other Gemini 3.x text entries.

## Test plan

- [ ] `make ci` (or targeted lint/typecheck) passes
- [ ] Smoke test: `celeste.text.generate(..., model="gemini-3.5-flash")` against Google API when credentials are available

Made with [Cursor](https://cursor.com)