### PR TITLE
feat(google): promote Gemini 3.1 Flash Lite to GA

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -126,15 +126,17 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="gemini-3.1-flash-lite-preview",
+        id="gemini-3.1-flash-lite",
         provider=Provider.GOOGLE,
-        display_name="Gemini 3.1 Flash Lite Preview",
+        display_name="Gemini 3.1 Flash Lite",
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
-            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),


### PR DESCRIPTION
## Summary

- Replace preview model id `gemini-3.1-flash-lite-preview` with stable GA id `gemini-3.1-flash-lite` ([Google model card](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite), GA May 2026).
- Update display name to **Gemini 3.1 Flash Lite** (drop Preview).
- Expand `thinking_level` options to `minimal`, `low`, `medium`, `high` per Gemini 3 thinking docs (Flash-Lite defaults to `minimal`).

## Breaking change

Callers using the preview slug must switch to `gemini-3.1-flash-lite`.

## Test plan

- [x] `make ci` passed locally (648 tests)

Made with [Cursor](https://cursor.com)