### PR TITLE
refactor(telemetry): collapse 6 OpenTelemetry no-op stubs into one proxy

### DIFF
--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -48,75 +48,39 @@ _MODALITY_OPERATION: dict[Modality, str] = {
 }
 
 
-class _NoOpSpan:
-    """Span stand-in used when ``opentelemetry-api`` is not installed."""
+class _NoOp:
+    """No-op stand-in for opentelemetry-api objects when it is not installed.
 
-    def set_attribute(self, key: str, value: Any) -> None:
-        """Discard the attribute."""
+    Returns itself for every attribute access and call, so spans, tracers, meters,
+    histograms, Status and StatusCode all degrade to silent no-ops.
+    """
 
-    def set_attributes(self, attributes: dict[str, Any]) -> None:
-        """Discard the attribute mapping."""
+    ERROR = "ERROR"  # satisfies StatusCode.ERROR
 
-    def set_status(self, *args: Any, **kwargs: Any) -> None:
-        """Discard the status update."""
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Accept and discard any construction arguments."""
 
-    def record_exception(self, *args: Any, **kwargs: Any) -> None:
-        """Discard the exception."""
+    def __call__(self, *args: Any, **kwargs: Any) -> "_NoOp":
+        """Return self for any call (e.g. start_as_current_span, create_histogram)."""
+        return self
 
-    def add_event(self, *args: Any, **kwargs: Any) -> None:
-        """Discard the span event."""
+    def __getattr__(self, name: str) -> "_NoOp":
+        """Return self for any attribute (span/meter/histogram methods)."""
+        return self
 
-    def end(self) -> None:
-        """Discard the end signal."""
+    def __enter__(self) -> "_NoOp":
+        """Enter the no-op span context."""
+        return self
 
-
-class _NoOpTracer:
-    """Tracer stand-in used when ``opentelemetry-api`` is not installed."""
-
-    @contextmanager
-    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[_NoOpSpan]:
-        """Yield a no-op span as a context manager."""
-        yield _NoOpSpan()
-
-    def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
-        """Return a detached no-op span."""
-        return _NoOpSpan()
+    def __exit__(self, *args: Any) -> None:
+        """Exit the no-op span context."""
+        return None
 
 
 @contextmanager
 def _noop_use_span(span: Any, end_on_exit: bool = False) -> Iterator[Any]:
     """No-op stand-in for ``opentelemetry.trace.use_span``."""
     yield span
-
-
-class _NoOpStatus:
-    """Status stand-in used when ``opentelemetry-api`` is not installed."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Discard the status arguments."""
-
-
-class _NoOpStatusCode:
-    """StatusCode stand-in used when ``opentelemetry-api`` is not installed."""
-
-    ERROR = "ERROR"
-
-
-class _NoOpHistogram:
-    """Histogram stand-in used when ``opentelemetry-api`` is not installed."""
-
-    def record(self, value: float, attributes: dict[str, Any] | None = None) -> None:
-        """Discard the metric record."""
-
-
-class _NoOpMeter:
-    """Meter stand-in used when ``opentelemetry-api`` is not installed."""
-
-    def create_histogram(
-        self, name: str, unit: str = "", description: str = ""
-    ) -> _NoOpHistogram:
-        """Return a no-op histogram."""
-        return _NoOpHistogram()
 
 
 try:
@@ -131,11 +95,11 @@ try:
     StatusCode: Any = _OtelStatusCode
     meter: Any = _otel_metrics.get_meter("celeste")
 except ImportError:
-    tracer = _NoOpTracer()
+    tracer = _NoOp()
     use_span = _noop_use_span
-    Status = _NoOpStatus
-    StatusCode = _NoOpStatusCode
-    meter = _NoOpMeter()
+    Status = _NoOp
+    StatusCode = _NoOp
+    meter = _NoOp()
 
 
 _token_usage_histogram: Any = meter.create_histogram(

--- a/tests/unit_tests/test_telemetry_noop.py
+++ b/tests/unit_tests/test_telemetry_noop.py
@@ -1,0 +1,31 @@
+"""Tests for the no-op telemetry proxy used when opentelemetry-api is absent."""
+
+from celeste.telemetry import _NoOp, _noop_use_span
+
+
+def test_noop_proxy_supports_all_call_shapes() -> None:
+    """The _NoOp proxy must satisfy every span/meter/Status call site used in telemetry."""
+    noop = _NoOp()
+
+    # tracer.start_as_current_span(...) used as a context manager yielding a span
+    with noop.start_as_current_span("op") as span:
+        span.set_attribute("k", "v")
+        span.set_attributes({"k": "v"})
+        span.add_event("e", {"a": 1})
+        span.record_exception(Exception("boom"))
+        span.set_status(_NoOp(_NoOp.ERROR, "msg"))  # Status(StatusCode.ERROR, msg)
+        span.end()
+
+    # StatusCode.ERROR is read as a real class attribute
+    assert _NoOp.ERROR == "ERROR"
+
+    # meter.create_histogram(...).record(...) chains through the proxy
+    histogram = noop.create_histogram(name="n", unit="{token}", description="d")
+    histogram.record(1.0, {"gen_ai.token.type": "input"})
+
+
+def test_noop_use_span_yields_the_passed_span() -> None:
+    """_noop_use_span must yield the span it was given, not a no-op stand-in."""
+    sentinel = object()
+    with _noop_use_span(sentinel) as span:
+        assert span is sentinel


### PR DESCRIPTION
## What

When `opentelemetry-api` is not installed, `telemetry.py` falls back to six hand-written no-op stand-ins — `_NoOpSpan`, `_NoOpTracer`, `_NoOpStatus`, `_NoOpStatusCode`, `_NoOpHistogram`, `_NoOpMeter`. They're near-identical discard-everything boilerplate.

This replaces all six with a single `_NoOp` proxy that returns itself for every attribute access and call:

```python
class _NoOp:
    ERROR = "ERROR"  # satisfies StatusCode.ERROR
    def __init__(self, *a, **k): ...
    def __call__(self, *a, **k): return self
    def __getattr__(self, name): return self
    def __enter__(self): return self
    def __exit__(self, *a): return None
```

Net **−36 lines** (`telemetry.py`: +24 / −60).

## Why it's safe

Every call site the telemetry module makes against these objects is covered by the proxy, and all of them discard return values:

- `with tracer.start_as_current_span(...) as span:` → `__getattr__` → `__call__` → `__enter__` all return self; `span.set_attribute / set_attributes / add_event / record_exception / set_status / end(...)` resolve through `__getattr__`/`__call__`.
- `Status(StatusCode.ERROR, str(exc))` → `StatusCode.ERROR` is the real class attr `"ERROR"`; `Status(...)` instantiates `_NoOp` and discards args.
- `meter.create_histogram(...).record(...)` chains through the proxy.
- Special methods (`__enter__`, `__call__`) are looked up on the type, so `__getattr__` never shadows them. No `==`/identity checks are made on `Status` objects.

`_noop_use_span` is **kept as a separate function** — it must yield the *passed-in* span, which a self-returning proxy would not. The real-OpenTelemetry path is untouched. No behavior change.

## Tests

Adds `tests/unit_tests/test_telemetry_noop.py` driving the `_NoOp` proxy through every call shape the module uses. The import-fallback path previously had **no** coverage (the suite always runs with `opentelemetry` installed).

`make ci` green: 676 passed, coverage 81.76%, ruff + format + mypy + bandit clean.

## Context

This is the single surviving cleanup from a repo-wide over-engineering audit. The audit's other candidates — including a "protocol client dedup" — were investigated and **deliberately not done**: the `chatcompletions`/`openresponses` protocols are a template-driven extension point and only ~14% identical, so merging them would fight the design.