### PR TITLE
[codex] Update reasoning effort metadata

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -122,7 +122,9 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "max"]
+            ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),

--- a/src/celeste/modalities/text/providers/mistral/models.py
+++ b/src/celeste/modalities/text/providers/mistral/models.py
@@ -1,6 +1,7 @@
 """Mistral models for text modality."""
 
 from celeste.constraints import (
+    Choice,
     DocumentsConstraint,
     ImagesConstraint,
     Range,
@@ -69,6 +70,9 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "minimal", "low", "medium", "high", "xhigh"]
+            ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -85,6 +89,9 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "minimal", "low", "medium", "high", "xhigh"]
+            ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),

--- a/src/celeste/modalities/text/providers/mistral/parameters.py
+++ b/src/celeste/modalities/text/providers/mistral/parameters.py
@@ -21,7 +21,7 @@ from ...protocols.chatcompletions.parameters import (
 
 
 class ThinkingBudgetMapper(ParameterMapper[TextContent]):
-    """Map thinking_budget to Mistral's prompt_mode parameter."""
+    """Map thinking_budget to Mistral reasoning controls."""
 
     name = TextParameter.THINKING_BUDGET
 
@@ -36,12 +36,11 @@ class ThinkingBudgetMapper(ParameterMapper[TextContent]):
         if validated_value is None:
             return request
 
-        if validated_value == -1:
-            request["prompt_mode"] = "reasoning"
-        elif validated_value == 0:
-            request["prompt_mode"] = None
-        else:
-            request["prompt_mode"] = "reasoning"
+        if isinstance(validated_value, str):
+            request["reasoning_effort"] = validated_value
+            return request
+
+        request["prompt_mode"] = None if validated_value == 0 else "reasoning"
 
         return request
 

--- a/src/celeste/modalities/text/providers/xai/models.py
+++ b/src/celeste/modalities/text/providers/xai/models.py
@@ -24,6 +24,9 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=131072),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "low", "medium", "high"]
+            ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),


### PR DESCRIPTION
## Summary

Updates text model reasoning controls to match provider effort settings:

- Switches `claude-sonnet-4-6` from numeric thinking budget to named thinking levels.
- Adds xAI reasoning effort choices for `grok-4.3`.
- Adds Mistral reasoning effort choices for `mistral-medium-3-5` and `mistral-small-2603`.
- Maps Mistral string reasoning choices to `reasoning_effort` while keeping numeric Magistral budget behavior on `prompt_mode`.

## Validation

Pre-push hooks passed:

- Ruff lint and format
- mypy for source and tests
- Bandit
- unit tests with coverage

Note: the first push attempt exposed a missing optional `google-auth` dependency in the fresh worktree venv; syncing the repo's `gcp` extra fixed the local test environment, with no tracked file changes.