### PR TITLE
fix(google): add minimal thinking level to gemini-3.5-flash

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -156,7 +156,9 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
-            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),


### PR DESCRIPTION
Gemini 3.5 Flash supports `thinking_level` values `minimal`, `low`, `medium` (default), and `high`, but only `low`/`medium`/`high` were registered. This adds `minimal`.

Source: https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5