### PR TITLE
feat(anthropic): add Claude Sonnet 5, Opus 4.8, and Fable 5 to catalog

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -17,6 +17,60 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="claude-fable-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Fable 5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-opus-4-8",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Opus 4.8",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-sonnet-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Sonnet 5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="claude-sonnet-4-5",
         provider=Provider.ANTHROPIC,
         display_name="Claude Sonnet 4.5",


### PR DESCRIPTION
## Summary
- Adds `claude-sonnet-5`, `claude-opus-4-8`, and `claude-fable-5` to the Anthropic text model catalog — the three current-gen models that were missing.
- All three drop manual extended thinking (`budget_tokens` returns a 400) in favor of adaptive thinking controlled via the `effort` parameter, so they reuse the same constraint shape already established by `claude-opus-4-7`: `MAX_TOKENS` up to 128k, `THINKING_LEVEL` with `low/medium/high/xhigh/max`, plus `OUTPUT_SCHEMA`, `TOOLS` (web search), `TOOL_CHOICE`, `IMAGE`, and `DOCUMENT` support.
- Verified against Anthropic's official docs (models overview, per-model "what's new" pages, effort parameter, structured outputs, web search tool support) for each model.
- Skipped `claude-mythos-5`/`claude-mythos-preview` — invitation-only (Project Glasswing), not generally available.

## Test plan
- [x] `make ci` passes (lint, format, mypy, bandit, tests with coverage)
- [x] Manually loaded each new `Model` entry and confirmed it validates