### PR TITLE
feat(google): add gemini-3.1-flash-lite-image and fix Gemini image catalog errors

### DIFF
--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -125,6 +125,31 @@ GEMINI_MODELS: list[Model] = [
             ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "High"]),
         },
     ),
+    Model(
+        id="gemini-3.1-flash-lite-image",
+        provider=Provider.GOOGLE,
+        display_name="Nano Banana 2 Lite",
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Choice(
+                options=[
+                    "1:1",
+                    "2:3",
+                    "3:2",
+                    "3:4",
+                    "4:3",
+                    "4:5",
+                    "5:4",
+                    "9:16",
+                    "16:9",
+                    "21:9",
+                ]
+            ),
+            ImageParameter.QUALITY: Choice(options=["1K"]),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
+            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "high"]),
+        },
+    ),
 ]
 
 # Unified model list for registration

--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -32,7 +32,6 @@ IMAGEN_MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Choice(
                 options=["1:1", "3:4", "4:3", "9:16", "16:9"]
             ),
-            ImageParameter.QUALITY: Choice(options=["1K"]),
         },
     ),
     Model(
@@ -76,9 +75,9 @@ GEMINI_MODELS: list[Model] = [
         },
     ),
     Model(
-        id="gemini-3-pro-image-preview",
+        id="gemini-3-pro-image",
         provider=Provider.GOOGLE,
-        display_name="Gemini 3 Pro Image (Preview)",
+        display_name="Nano Banana Pro",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
             ImageParameter.ASPECT_RATIO: Choice(
@@ -97,11 +96,11 @@ GEMINI_MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
-            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "High"]),
+            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "high"]),
         },
     ),
     Model(
-        id="gemini-3.1-flash-image-preview",
+        id="gemini-3.1-flash-image",
         provider=Provider.GOOGLE,
         display_name="Nano Banana 2",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
@@ -120,9 +119,9 @@ GEMINI_MODELS: list[Model] = [
                     "21:9",
                 ]
             ),
-            ImageParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
+            ImageParameter.QUALITY: Choice(options=["512px", "1K", "2K", "4K"]),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
-            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "High"]),
+            ImageParameter.THINKING_LEVEL: Choice(options=["minimal", "high"]),
         },
     ),
     Model(


### PR DESCRIPTION
## Summary
- Adds `gemini-3.1-flash-lite-image` (Nano Banana 2 Lite) to the Google image catalog: 1K-only resolution, 14 object reference images, generate+edit, `minimal`/`high` thinking levels.
- Auditing the sibling entries while verifying this one turned up real, pre-existing errors, fixed here:
  - `gemini-3-pro-image-preview` and `gemini-3.1-flash-image-preview` are deprecated and shut down June 25, 2026 — renamed to their GA replacement IDs `gemini-3-pro-image` and `gemini-3.1-flash-image`.
  - `THINKING_LEVEL` was `["minimal", "High"]` everywhere in the Gemini 3.x image family; the API expects lowercase `"high"` (confirmed against an actual code sample in Google's docs). Fixed on all three Gemini 3.x entries.
  - `gemini-3.1-flash-image` (GA) gained a `512px` quality tier over the preview version — added.
  - `imagen-4.0-fast-generate-001` had a `QUALITY: ["1K"]` constraint, but Google's docs state the `imageSize` parameter is only supported on the Standard and Ultra Imagen 4 variants, not Fast — removed.
- Grepped the repo for the old preview IDs — no other code/tests referenced them, so the rename is safe.
- `gemini-2.5-flash-image`'s aspect ratio list and reference-image count could not be independently confirmed against official docs and were left unchanged.

## Test plan
- [x] `make ci` passes (lint, format, mypy, bandit, tests with coverage)
- [x] Manually loaded each changed/new `Model` entry and confirmed it validates
- [x] Verified every changed value against Google's official Gemini API docs (model pages, image-generation guide, changelog/deprecations)