### PR TITLE
fix(anthropic): move thinking effort to output_config

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/parameters.py
+++ b/src/celeste/modalities/text/providers/anthropic/parameters.py
@@ -68,7 +68,7 @@ class ThinkingBudgetMapper(_ThinkingMapper):
 
 
 class ThinkingLevelMapper(_ThinkingLevelMapper):
-    """Map thinking_level to Anthropic's thinking.effort parameter (adaptive)."""
+    """Map thinking_level to Anthropic's adaptive thinking + output_config.effort."""
 
     name = TextParameter.THINKING_LEVEL
 

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -72,10 +72,12 @@ class ThinkingMapper(ParameterMapper[TextContent]):
 
 
 class ThinkingLevelMapper(ParameterMapper[TextContent]):
-    """Map thinking_level to Anthropic thinking field (adaptive mode).
+    """Map thinking_level to adaptive thinking plus output_config.effort.
 
-    Emits {"type": "adaptive", "effort": <value>} where <value> is one of
-    "low" | "medium" | "high" | "xhigh" | "max".
+    Emits {"thinking": {"type": "adaptive"}, "output_config": {"effort": <value>}}
+    where <value> is one of "low" | "medium" | "high" | "xhigh" | "max" — the
+    Messages API rejects an "effort" key inside the thinking object
+    ("thinking.adaptive.effort: Extra inputs are not permitted").
     """
 
     def map(
@@ -88,7 +90,8 @@ class ThinkingLevelMapper(ParameterMapper[TextContent]):
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
-        request["thinking"] = {"type": "adaptive", "effort": validated_value}
+        request["thinking"] = {"type": "adaptive"}
+        request.setdefault("output_config", {})["effort"] = validated_value
         return request
 
 


### PR DESCRIPTION
## What

Setting `thinking_level` on an Anthropic model produces a request the Messages API rejects:

```
anthropic API error: thinking.adaptive.effort: Extra inputs are not permitted
```

`ThinkingLevelMapper` embeds the effort level inside the thinking object — `{"thinking": {"type": "adaptive", "effort": "high"}}` — but the finalized API only accepts `type` and `display` there. Effort belongs in the top-level `output_config` parameter.

## Fix

The mapper now emits:

```json
{"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}
```

`output_config` is written via `setdefault` so future fields (e.g. `format`) compose. Docstrings updated in both the provider mapper and its text-modality subclass.

## Verification

- `make lint` clean; pre-push mypy/ruff/bandit hooks pass.
- `make test`: 682 passed (with `--all-extras`; the vertex-routing tests need the google extra installed).