### PR TITLE
feat(anthropic): stream thinking summaries, fix haiku thinking budget, dynamic-filtering web search

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -94,7 +94,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -217,3 +217,15 @@ MODELS: list[Model] = [
         },
     ),
 ]
+
+# Models that support web_search dynamic filtering (web_search_20260209); others use basic.
+DYNAMIC_FILTERING_MODELS = frozenset(
+    {
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+    }
+)

--- a/src/celeste/modalities/text/providers/anthropic/parameters.py
+++ b/src/celeste/modalities/text/providers/anthropic/parameters.py
@@ -28,6 +28,7 @@ from celeste.providers.anthropic.messages.parameters import (
 from celeste.types import TextContent
 
 from ...parameters import TextParameter
+from .models import DYNAMIC_FILTERING_MODELS
 
 
 class TemperatureMapper(_TemperatureMapper):
@@ -80,9 +81,23 @@ class OutputSchemaMapper(_OutputFormatMapper):
 
 
 class ToolsMapper(_ToolsMapper):
-    """Map tools to Anthropic's tools parameter."""
+    """Map tools to Anthropic's tools parameter (web_search version per model)."""
 
     name = TextParameter.TOOLS
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Upgrade web_search to dynamic filtering (web_search_20260209) where the model supports it."""
+        request = super().map(request, value, model)
+        if model.id in DYNAMIC_FILTERING_MODELS:
+            for tool in request.get("tools", []):
+                if tool.get("name") == "web_search":
+                    tool["type"] = "web_search_20260209"
+        return request
 
 
 class ToolChoiceMapper(_ToolChoiceMapper):

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -74,10 +74,8 @@ class ThinkingMapper(ParameterMapper[TextContent]):
 class ThinkingLevelMapper(ParameterMapper[TextContent]):
     """Map thinking_level to adaptive thinking plus output_config.effort.
 
-    Emits {"thinking": {"type": "adaptive"}, "output_config": {"effort": <value>}}
-    where <value> is one of "low" | "medium" | "high" | "xhigh" | "max" — the
-    Messages API rejects an "effort" key inside the thinking object
-    ("thinking.adaptive.effort: Extra inputs are not permitted").
+    display="summarized" so thinking summaries stream (API default "omitted" is empty).
+    effort goes in output_config, not the thinking object (the API rejects it there).
     """
 
     def map(
@@ -90,7 +88,7 @@ class ThinkingLevelMapper(ParameterMapper[TextContent]):
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
-        request["thinking"] = {"type": "adaptive"}
+        request["thinking"] = {"type": "adaptive", "display": "summarized"}
         request.setdefault("output_config", {})["effort"] = validated_value
         return request
 


### PR DESCRIPTION
## What

Three Anthropic text improvements:

1. **Stream thinking summaries.** `ThinkingLevelMapper` now emits `thinking: {type: "adaptive", display: "summarized"}`. On Opus 4.8 / Sonnet 5 / Opus 4.7 the API defaults `display` to `"omitted"`, which streams thinking blocks with empty text (no `thinking_delta` events) — so adaptive-thinking summaries never surfaced to callers that stream reasoning.

2. **Fix haiku thinking budget.** `claude-haiku-4-5` `THINKING_BUDGET` floor `-1 → 1024`. Haiku 4.5 has no dynamic/adaptive thinking mode (only a fixed `budget_tokens`, min 1024); the `-1 → "auto"` translation was then re-validated against the numeric `Range` and raised `ConstraintViolationError: "Must be numeric, got str"` at request build.

3. **Dynamic-filtering web search.** Select `web_search_20260209` (dynamic filtering) for models that support it (Opus 4.6+ / Sonnet 4.6+ / Fable 5), basic `web_search_20250305` otherwise. The supported-model list lives in the Anthropic text catalog (`DYNAMIC_FILTERING_MODELS`); a plain conditional in the text `ToolsMapper` picks the version. No model IDs in the mapper, nothing added to core.

## Verification

- `ruff` + `mypy` (344 files) clean; unit tests pass.
- Confirmed against the live Anthropic API: adaptive thinking now streams summaries; haiku runs without the constraint error; `web_search_20260209` streams interleaved reasoning with populated grounding on supporting models (note: dynamic filtering runs search inside code execution, so inline `web_search_result_location` citations are not emitted on those turns — an API behavior, not a regression here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
