### PR TITLE
[codex] fix anthropic native replay

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -1,8 +1,6 @@
 """Anthropic text client (modality)."""
 
 import base64
-import contextlib
-import json
 from typing import Any
 
 from celeste.artifacts import DocumentArtifact, ImageArtifact
@@ -15,7 +13,10 @@ from celeste.messages import (
 )
 from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
-from celeste.providers.anthropic.messages.client import AnthropicMessagesClient
+from celeste.providers.anthropic.messages.client import (
+    AnthropicMessagesClient,
+    needs_native_replay,
+)
 from celeste.providers.anthropic.messages.streaming import (
     AnthropicMessagesStream as _AnthropicMessagesStream,
 )
@@ -39,31 +40,15 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._message_start: dict[str, Any] | None = None
-        self._tool_calls: dict[int, dict[str, Any]] = {}
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
-        """Parse one SSE event into a typed chunk (captures message_start and tool_use)."""
+        """Parse one SSE event into a typed chunk (captures message_start)."""
         event_type = event_data.get("type")
         if event_type == "message_start":
             message = event_data.get("message")
             if isinstance(message, dict):
                 self._message_start = message
             return None
-        if event_type == "content_block_start":
-            block = event_data.get("content_block", {})
-            if block.get("type") == "tool_use":
-                idx = event_data.get("index", len(self._tool_calls))
-                self._tool_calls[idx] = {
-                    "id": block.get("id", ""),
-                    "name": block.get("name", ""),
-                    "input_json": "",
-                }
-        elif event_type == "content_block_delta":
-            delta = event_data.get("delta", {})
-            if delta.get("type") == "input_json_delta":
-                idx = event_data.get("index", -1)
-                if idx in self._tool_calls:
-                    self._tool_calls[idx]["input_json"] += delta.get("partial_json", "")
         return super()._parse_chunk(event_data)
 
     def _aggregate_event_data(self, chunks: list[TextChunk]) -> list[dict[str, Any]]:
@@ -78,24 +63,22 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
     ) -> list[ToolCall]:
         """Reconstruct tool calls from accumulated content_block events."""
-        result: list[ToolCall] = []
-        for tc in self._tool_calls.values():
-            arguments = {}
-            if tc["input_json"]:
-                with contextlib.suppress(ValueError, TypeError):
-                    arguments = json.loads(tc["input_json"])
-            result.append(ToolCall(id=tc["id"], name=tc["name"], arguments=arguments))
-        return result
+        return [
+            ToolCall(
+                id=block["id"],
+                name=block["name"],
+                arguments=block.get("input", {}),
+            )
+            for block in self._aggregate_content_blocks()
+            if block.get("type") == "tool_use"
+        ]
 
     def _aggregate_signature(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Return the full native content array when the turn carries thinking blocks."""
+        """Return native content when Anthropic requires exact assistant replay."""
         blocks = self._aggregate_content_blocks()
-        has_thinking = any(
-            b.get("type") in {"thinking", "redacted_thinking"} for b in blocks
-        )
-        return blocks if has_thinking else []
+        return blocks if needs_native_replay(blocks) else []
 
     def _aggregate_grounding(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
@@ -278,11 +261,8 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
             for b in blocks
             if b.get("type") == "thinking" and b.get("thinking")
         ]
-        has_thinking = any(
-            b.get("type") in {"thinking", "redacted_thinking"} for b in blocks
-        )
         text = "\n".join(reasoning_parts) if reasoning_parts else None
-        return text, list(blocks) if has_thinking else []
+        return text, list(blocks) if needs_native_replay(blocks) else []
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Anthropic response."""

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -10,6 +10,16 @@ from celeste.providers.google.auth import GoogleADC
 
 from . import config
 
+_NATIVE_REPLAY_BLOCK_TYPES = {"thinking", "redacted_thinking", "server_tool_use"}
+
+
+def needs_native_replay(blocks: list[dict[str, Any]]) -> bool:
+    return any(
+        (block_type := block.get("type")) in _NATIVE_REPLAY_BLOCK_TYPES
+        or (isinstance(block_type, str) and block_type.endswith("_tool_result"))
+        for block in blocks
+    )
+
 
 class AnthropicMessagesClient(APIMixin):
     """Mixin for Anthropic Messages API capabilities.

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -117,6 +117,8 @@ class ToolsMapper(ParameterMapper[TextContent]):
                     msg = f"Tool '{type(item).__name__}' is not supported by Anthropic"
                     raise ValueError(msg)
                 tools.append(mapper.map_tool(item))
+            elif isinstance(item, dict) and "type" in item:
+                tools.append(item)
             elif isinstance(item, dict) and "name" in item:
                 tools.append(self._map_user_tool(item))
             elif isinstance(item, dict):

--- a/src/celeste/providers/anthropic/messages/streaming.py
+++ b/src/celeste/providers/anthropic/messages/streaming.py
@@ -33,13 +33,17 @@ class AnthropicMessagesStream:
             block_type = block.get("type")
             idx = event_data.get("index", len(self._content_blocks))
             if block_type in {"server_tool_use", "tool_use"}:
+                input_value = block.get("input")
                 self._content_blocks[idx] = {
                     "type": block_type,
                     "id": block.get("id", ""),
                     "name": block.get("name", ""),
+                    "input": input_value if isinstance(input_value, dict) else None,
                     "input_json": "",
                 }
-            elif block_type in {"web_search_tool_result", "redacted_thinking"}:
+            elif block_type == "redacted_thinking" or (
+                isinstance(block_type, str) and block_type.endswith("_tool_result")
+            ):
                 self._content_blocks[idx] = block
             elif block_type == "thinking":
                 self._content_blocks[idx] = {
@@ -83,7 +87,7 @@ class AnthropicMessagesStream:
         for idx in sorted(self._content_blocks):
             block = self._content_blocks[idx]
             if block.get("type") in {"server_tool_use", "tool_use"}:
-                input_data: dict[str, Any] = {}
+                input_data = block.get("input") or {}
                 if block["input_json"]:
                     with contextlib.suppress(ValueError, TypeError):
                         input_data = json.loads(block["input_json"])

--- a/tests/unit_tests/test_anthropic_native_replay.py
+++ b/tests/unit_tests/test_anthropic_native_replay.py
@@ -1,0 +1,85 @@
+"""Regression test for Anthropic native assistant transcript replay."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pydantic import SecretStr
+
+from celeste import Model
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.modalities.text.io import TextInput
+from celeste.modalities.text.providers.anthropic.client import (
+    AnthropicTextClient,
+    AnthropicTextStream,
+)
+
+
+async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+async def test_anthropic_stream_preserves_server_tool_result_for_replay() -> None:
+    model = Model(
+        id="claude-sonnet-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Sonnet 5",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+    )
+    events = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_01",
+                "name": "bash_code_execution",
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"code":"print(1)"}',
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "bash_code_execution_tool_result",
+                "tool_use_id": "srvtoolu_01",
+                "content": [{"type": "text", "text": "1\n"}],
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 2,
+            "delta": {"type": "text_delta", "text": "done"},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    output = stream.output
+    signature = output.signature
+    assert signature is not None
+    assert [block["type"] for block in signature] == [
+        "server_tool_use",
+        "bash_code_execution_tool_result",
+        "text",
+    ]
+    assert output.tool_calls == []
+
+    client = AnthropicTextClient(
+        model=model,
+        provider=Provider.ANTHROPIC,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-api-key", prefix=""),
+    )
+    request = client._init_request(TextInput(messages=[output.message]))
+
+    assert request["messages"][0]["content"] == signature


### PR DESCRIPTION
## Summary
- Preserve Anthropic native server-tool transcripts for replay when responses include `server_tool_use` or `*_tool_result` blocks.
- Reuse reconstructed native content blocks as the streaming tool-call source so server tools are not returned as client tool calls.
- Allow raw Anthropic provider tool dicts with `type` to pass through before user-function mapping.

## Root Cause
Anthropic assistant content was only saved as replay `signature` when thinking blocks were present. Code execution server-tool turns can include `server_tool_use` and `bash_code_execution_tool_result` without thinking, so Celeste dropped the native result block and a later Anthropic request could fail with a missing tool result error.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit_tests/test_anthropic_native_replay.py -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 uv run ruff check src/celeste tests/unit_tests/test_anthropic_native_replay.py`
- `PYTHONDONTWRITEBYTECODE=1 uv run mypy src/celeste`
- pre-push hooks passed, including Ruff, mypy, Bandit, and full tests with coverage

Note: the local pre-push full test run required installing the existing `gcp` extra so `google.auth` imports used by Vertex routing tests were available.