### PR TITLE
fix(anthropic): code-execution replay, max_tokens ceiling; tool kind discriminator

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -246,6 +246,9 @@ class ModalityClient[
             grounding = self._parse_grounding(response_data)
             if grounding is not None:
                 kwargs["grounding"] = grounding
+            container = self._parse_container(response_data)
+            if container is not None:
+                kwargs["container"] = container
             output = self._output_class()(
                 content=content,
                 usage=self._get_usage(response_data),
@@ -266,6 +269,10 @@ class ModalityClient[
     ) -> tuple[str | None, list[dict[str, Any]]]:
         """Parse reasoning from response. Returns (text, signature_blocks)."""
         return None, []
+
+    def _parse_container(self, response_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Parse provider container state. Override in providers that reuse containers."""
+        return None
 
     def _parse_grounding(self, response_data: dict[str, Any]) -> Grounding | None:
         """Parse web-search grounding from response."""

--- a/src/celeste/modalities/text/client.py
+++ b/src/celeste/modalities/text/client.py
@@ -8,7 +8,13 @@ from asgiref.sync import async_to_sync
 from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.messages import media_types
-from celeste.tools import CodeExecution, ToolResult, WebSearch, XSearch
+from celeste.tools import (
+    CodeExecution,
+    ToolResult,
+    WebSearch,
+    XSearch,
+    rehydrate_tools,
+)
 from celeste.types import (
     AudioContent,
     DocumentContent,
@@ -101,10 +107,11 @@ class TextClient(
         streaming: bool = False,
         **parameters: Unpack[TextParameters],
     ) -> dict[str, Any]:
-        """Build request, migrating deprecated boolean tool params first.
-
-        TODO(deprecation): Remove this override on 2026-06-07.
-        """
+        """Build request, rehydrating tools and migrating deprecated boolean tool params."""
+        tools = parameters.get("tools")
+        if isinstance(tools, list):
+            parameters["tools"] = rehydrate_tools(tools)
+        # TODO(deprecation): Remove the boolean-param migration on 2026-06-07.
         for old_param, tool_cls in self._DEPRECATED_TOOL_PARAMS.items():
             value = parameters.pop(old_param, None)  # type: ignore[misc]
             if value:

--- a/src/celeste/modalities/text/io.py
+++ b/src/celeste/modalities/text/io.py
@@ -62,6 +62,7 @@ class TextOutput(Output[TextContent]):
     finish_reason: TextFinishReason | None = None
     reasoning: str | None = None
     signature: list[dict[str, Any]] | None = None
+    container: dict[str, Any] | None = None
 
     @property
     def message(self) -> Message:
@@ -72,6 +73,7 @@ class TextOutput(Output[TextContent]):
             tool_calls=self.tool_calls if self.tool_calls else None,
             reasoning=self.reasoning,
             signature=self.signature,
+            container=self.container,
         )
 
 

--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -80,6 +80,18 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
         blocks = self._aggregate_content_blocks()
         return blocks if needs_native_replay(blocks) else []
 
+    def _aggregate_container(
+        self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Recover the top-level container from message_start / message_delta events."""
+        for event in reversed(raw_events):
+            for holder in (event, event.get("message"), event.get("delta")):
+                if isinstance(holder, dict) and isinstance(
+                    holder.get("container"), dict
+                ):
+                    return holder["container"]
+        return None
+
     def _aggregate_grounding(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
     ) -> Grounding | None:
@@ -126,6 +138,7 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
         system_blocks: list[dict[str, Any]] = []
         messages: list[dict[str, Any]] = []
         pending_tool_results: list[dict[str, Any]] = []
+        container_id: str | None = None
 
         for message in request_messages(
             prompt=inputs.prompt,
@@ -156,6 +169,10 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
             if pending_tool_results:
                 messages.append({"role": "user", "content": pending_tool_results})
                 pending_tool_results = []
+
+            # Last-wins: the pending turn's code-execution container is echoed top-level.
+            if message.container and message.container.get("id"):
+                container_id = message.container["id"]
 
             if role == Role.ASSISTANT and (message.tool_calls or message.signature):
                 sig_blocks = message.signature or []
@@ -192,6 +209,8 @@ class AnthropicTextClient(AnthropicMessagesClient, TextClient):
         request: dict[str, Any] = {"messages": messages}
         if system_blocks:
             request["system"] = system_blocks
+        if container_id:
+            request["container"] = container_id
         return request
 
     def _build_document_source(self, doc: DocumentArtifact) -> dict[str, Any]:

--- a/src/celeste/protocols/chatcompletions/parameters.py
+++ b/src/celeste/protocols/chatcompletions/parameters.py
@@ -104,7 +104,7 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(mapper.map_tool(item))
             elif isinstance(item, dict) and "name" in item:
                 tools.append(self._map_user_tool(item))
-            elif isinstance(item, dict):
+            elif isinstance(item, dict) and "type" in item:
                 tools.append(item)
             else:
                 raise InvalidToolError(item)

--- a/src/celeste/protocols/openresponses/parameters.py
+++ b/src/celeste/protocols/openresponses/parameters.py
@@ -160,7 +160,7 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(mapper.map_tool(item))
             elif isinstance(item, dict) and "name" in item:
                 tools.append(self._map_user_tool(item))
-            elif isinstance(item, dict):
+            elif isinstance(item, dict) and "type" in item:
                 tools.append(item)
             else:
                 raise InvalidToolError(item)

--- a/src/celeste/protocols/openresponses/tools.py
+++ b/src/celeste/protocols/openresponses/tools.py
@@ -27,7 +27,9 @@ class WebSearchMapper(ToolMapper):
         if tool.allowed_domains is not None:
             result.setdefault("filters", {})["allowed_domains"] = tool.allowed_domains
         for field in type(tool).model_fields:
-            if field not in self._supported_fields and getattr(tool, field) is not None:
+            if field == "kind" or field in self._supported_fields:
+                continue
+            if getattr(tool, field) is not None:
                 warnings.warn(
                     f"WebSearch.{field} is not supported by OpenResponses "
                     f"and will be ignored. Workaround: use a raw dict tool instead.",

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -4,7 +4,8 @@ from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
-from celeste.core import UsageField
+from celeste.constraints import Range
+from celeste.core import Parameter, UsageField
 from celeste.io import FinishReason
 from celeste.providers.google.auth import GoogleADC
 
@@ -14,9 +15,15 @@ _NATIVE_REPLAY_BLOCK_TYPES = {"thinking", "redacted_thinking", "server_tool_use"
 
 
 def needs_native_replay(blocks: list[dict[str, Any]]) -> bool:
+    # Programmatic tool_use (non-direct caller) must replay its caller verbatim.
     return any(
         (block_type := block.get("type")) in _NATIVE_REPLAY_BLOCK_TYPES
         or (isinstance(block_type, str) and block_type.endswith("_tool_result"))
+        or (
+            block_type == "tool_use"
+            and isinstance(caller := block.get("caller"), dict)
+            and caller.get("type") != "direct"
+        )
         for block in blocks
     )
 
@@ -101,6 +108,13 @@ class AnthropicMessagesClient(APIMixin):
             request_body["stream"] = True
         return request_body
 
+    def _resolve_max_tokens(self) -> int:
+        """Default max_tokens to the model's output ceiling, not an arbitrary cap."""
+        constraint = self.model.parameter_constraints.get(Parameter.MAX_TOKENS)
+        if isinstance(constraint, Range):
+            return int(constraint.max)
+        return config.DEFAULT_MAX_TOKENS
+
     async def _make_request(
         self,
         request_body: dict[str, Any],
@@ -112,7 +126,7 @@ class AnthropicMessagesClient(APIMixin):
         """Make HTTP request to Anthropic Messages API endpoint."""
         # Apply max_tokens default if not set (Anthropic requires it)
         if "max_tokens" not in request_body:
-            request_body["max_tokens"] = config.DEFAULT_MAX_TOKENS
+            request_body["max_tokens"] = self._resolve_max_tokens()
 
         beta_features: list[str] = request_body.pop("_beta_features", [])
         headers = self._build_headers(
@@ -142,7 +156,7 @@ class AnthropicMessagesClient(APIMixin):
         """Make streaming request to Anthropic Messages API endpoint."""
         # Apply max_tokens default if not set (Anthropic requires it)
         if "max_tokens" not in request_body:
-            request_body["max_tokens"] = config.DEFAULT_MAX_TOKENS
+            request_body["max_tokens"] = self._resolve_max_tokens()
 
         beta_features: list[str] = request_body.pop("_beta_features", [])
         headers = self._build_headers(
@@ -204,6 +218,11 @@ class AnthropicMessagesClient(APIMixin):
         """
         stop_reason = response_data.get("stop_reason")
         return FinishReason(reason=stop_reason)
+
+    def _parse_container(self, response_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Return the code-execution container for reuse in continuation requests."""
+        container = response_data.get("container")
+        return container if isinstance(container, dict) else None
 
 
 __all__ = ["AnthropicMessagesClient"]

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -121,8 +121,6 @@ class ToolsMapper(ParameterMapper[TextContent]):
                 tools.append(item)
             elif isinstance(item, dict) and "name" in item:
                 tools.append(self._map_user_tool(item))
-            elif isinstance(item, dict):
-                tools.append(item)
             else:
                 raise InvalidToolError(item)
 

--- a/src/celeste/providers/anthropic/messages/streaming.py
+++ b/src/celeste/providers/anthropic/messages/streaming.py
@@ -34,13 +34,13 @@ class AnthropicMessagesStream:
             idx = event_data.get("index", len(self._content_blocks))
             if block_type in {"server_tool_use", "tool_use"}:
                 input_value = block.get("input")
-                self._content_blocks[idx] = {
-                    "type": block_type,
-                    "id": block.get("id", ""),
-                    "name": block.get("name", ""),
-                    "input": input_value if isinstance(input_value, dict) else None,
-                    "input_json": "",
-                }
+                # Keep provider fields like `caller`; only input streams via deltas.
+                captured = dict(block)
+                captured["input"] = (
+                    input_value if isinstance(input_value, dict) else None
+                )
+                captured["input_json"] = ""
+                self._content_blocks[idx] = captured
             elif block_type == "redacted_thinking" or (
                 isinstance(block_type, str) and block_type.endswith("_tool_result")
             ):
@@ -88,17 +88,13 @@ class AnthropicMessagesStream:
             block = self._content_blocks[idx]
             if block.get("type") in {"server_tool_use", "tool_use"}:
                 input_data = block.get("input") or {}
-                if block["input_json"]:
+                if block.get("input_json"):
                     with contextlib.suppress(ValueError, TypeError):
                         input_data = json.loads(block["input_json"])
-                blocks.append(
-                    {
-                        "type": block["type"],
-                        "id": block["id"],
-                        "name": block["name"],
-                        "input": input_data,
-                    }
-                )
+                # Keep all captured fields (incl. caller); drop input_json accumulator.
+                emitted = {k: v for k, v in block.items() if k != "input_json"}
+                emitted["input"] = input_data
+                blocks.append(emitted)
             elif block.get("type") == "text" and not block.get("citations"):
                 blocks.append({"type": "text", "text": block.get("text", "")})
             else:

--- a/src/celeste/providers/google/generate_content/tools.py
+++ b/src/celeste/providers/google/generate_content/tools.py
@@ -19,7 +19,9 @@ class WebSearchMapper(ToolMapper):
         if tool.blocked_domains is not None:
             config["exclude_domains"] = tool.blocked_domains
         for field in type(tool).model_fields:
-            if field not in self._supported_fields and getattr(tool, field) is not None:
+            if field == "kind" or field in self._supported_fields:
+                continue
+            if getattr(tool, field) is not None:
                 warnings.warn(
                     f"WebSearch.{field} is not supported by Google "
                     f"and will be ignored. Workaround: use a raw dict tool instead.",

--- a/src/celeste/providers/groq/chat/tools.py
+++ b/src/celeste/providers/groq/chat/tools.py
@@ -16,7 +16,9 @@ class WebSearchMapper(ToolMapper):
     def map_tool(self, tool: Tool) -> dict[str, Any]:
         assert isinstance(tool, WebSearch)
         for field in type(tool).model_fields:
-            if field not in self._supported_fields and getattr(tool, field) is not None:
+            if field == "kind" or field in self._supported_fields:
+                continue
+            if getattr(tool, field) is not None:
                 warnings.warn(
                     f"WebSearch.{field} is not supported by Groq "
                     f"and will be ignored. Workaround: use a raw dict tool instead.",

--- a/src/celeste/providers/moonshot/chat/tools.py
+++ b/src/celeste/providers/moonshot/chat/tools.py
@@ -16,7 +16,9 @@ class WebSearchMapper(ToolMapper):
     def map_tool(self, tool: Tool) -> dict[str, Any]:
         assert isinstance(tool, WebSearch)
         for field in type(tool).model_fields:
-            if field not in self._supported_fields and getattr(tool, field) is not None:
+            if field == "kind" or field in self._supported_fields:
+                continue
+            if getattr(tool, field) is not None:
                 warnings.warn(
                     f"WebSearch.{field} is not supported by Moonshot "
                     f"and will be ignored. Workaround: use a raw dict tool instead.",

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -189,6 +189,9 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         grounding = self._aggregate_grounding(chunks, raw_events)
         if grounding is not None:
             kwargs["grounding"] = grounding
+        container = self._aggregate_container(chunks, raw_events)
+        if container is not None:
+            kwargs["container"] = container
         tool_calls = validate_tool_calls(
             self._aggregate_tool_calls(chunks, raw_events),
             parameters.get("tools"),
@@ -213,6 +216,12 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
     ) -> Grounding | None:
         """Aggregate web-search grounding from stream events."""
+        return None
+
+    def _aggregate_container(
+        self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Aggregate provider container state. Override in provider streams."""
         return None
 
     def _aggregate_reasoning(self, chunks: list[Chunk]) -> str | None:

--- a/src/celeste/tools.py
+++ b/src/celeste/tools.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic import ValidationError as PydanticValidationError
@@ -15,6 +15,8 @@ class Tool(BaseModel):
     """Base for configurable tools. Subclass per tool type.
 
     Provider-specific ToolMappers translate these to wire format.
+    The `kind` discriminator lets serialized tools rehydrate across
+    JSON boundaries (e.g. consumers that relay parameters as JSON).
     """
 
     model_config = ConfigDict(frozen=True)
@@ -29,6 +31,7 @@ class WebSearch(Tool):
     - max_uses → Anthropic: max_uses
     """
 
+    kind: Literal["web_search"] = "web_search"
     allowed_domains: list[str] | None = None
     blocked_domains: list[str] | None = None
     max_uses: int | None = None
@@ -37,9 +40,13 @@ class WebSearch(Tool):
 class XSearch(Tool):
     """X/Twitter search tool (OpenAI/xAI only)."""
 
+    kind: Literal["x_search"] = "x_search"
+
 
 class CodeExecution(Tool):
     """Code execution/interpreter tool."""
+
+    kind: Literal["code_execution"] = "code_execution"
 
 
 class ToolMapper(ABC):
@@ -55,6 +62,22 @@ class ToolMapper(ABC):
 
 
 type ToolDefinition = Tool | dict[str, Any]
+
+_TOOL_KINDS: dict[str, type[Tool]] = {
+    "web_search": WebSearch,
+    "x_search": XSearch,
+    "code_execution": CodeExecution,
+}
+
+
+def rehydrate_tools(tools: list[ToolDefinition]) -> list[ToolDefinition]:
+    """Rebuild Tool instances from kind-tagged dicts (JSON round-trips)."""
+    return [
+        _TOOL_KINDS[item["kind"]].model_validate(item)
+        if isinstance(item, dict) and item.get("kind") in _TOOL_KINDS
+        else item
+        for item in tools
+    ]
 
 
 def _tool_parameter_models(tools: object | None) -> dict[str, type[BaseModel]]:
@@ -163,5 +186,6 @@ __all__ = [
     "ToolResultContent",
     "WebSearch",
     "XSearch",
+    "rehydrate_tools",
     "validate_tool_calls",
 ]

--- a/src/celeste/types.py
+++ b/src/celeste/types.py
@@ -113,6 +113,7 @@ class Message(BaseModel):
     tool_calls: list[ToolCall] | None = None
     reasoning: str | None = None
     signature: list[dict[str, Any]] | None = None
+    container: dict[str, Any] | None = None
 
 
 __all__ = [

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -7,6 +7,31 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 from opentelemetry.trace import Span
+from pydantic import SecretStr
+
+from celeste import Model
+from celeste.auth import AuthHeader
+from celeste.constraints import Constraint
+from celeste.core import Modality, Operation, Provider
+from celeste.modalities.text.providers.anthropic.client import AnthropicTextClient
+
+
+def anthropic_test_client(
+    constraints: dict[str, Constraint] | None = None,
+) -> AnthropicTextClient:
+    """Anthropic text client over a minimal model, for request/stream tests."""
+    model = Model(
+        id="claude-opus-4-8",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Opus 4.8",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+        parameter_constraints=constraints or {},
+    )
+    return AnthropicTextClient(
+        model=model,
+        provider=Provider.ANTHROPIC,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-api-key", prefix=""),
+    )
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_anthropic_max_tokens_default.py
+++ b/tests/unit_tests/test_anthropic_max_tokens_default.py
@@ -1,0 +1,13 @@
+"""Anthropic max_tokens defaults to the model's output ceiling."""
+
+from celeste.constraints import Range
+from celeste.core import Parameter
+from celeste.providers.anthropic.messages import config
+from tests.unit_tests.conftest import anthropic_test_client
+
+
+def test_max_tokens_defaults_to_model_ceiling() -> None:
+    client = anthropic_test_client({Parameter.MAX_TOKENS: Range(min=1, max=128000)})
+
+    assert client._resolve_max_tokens() == 128000
+    assert anthropic_test_client()._resolve_max_tokens() == config.DEFAULT_MAX_TOKENS

--- a/tests/unit_tests/test_anthropic_native_replay.py
+++ b/tests/unit_tests/test_anthropic_native_replay.py
@@ -3,16 +3,9 @@
 from collections.abc import AsyncIterator
 from typing import Any
 
-from pydantic import SecretStr
-
-from celeste import Model
-from celeste.auth import AuthHeader
-from celeste.core import Modality, Operation, Provider
 from celeste.modalities.text.io import TextInput
-from celeste.modalities.text.providers.anthropic.client import (
-    AnthropicTextClient,
-    AnthropicTextStream,
-)
+from celeste.modalities.text.providers.anthropic.client import AnthropicTextStream
+from tests.unit_tests.conftest import anthropic_test_client
 
 
 async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
@@ -21,12 +14,6 @@ async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, An
 
 
 async def test_anthropic_stream_preserves_server_tool_result_for_replay() -> None:
-    model = Model(
-        id="claude-sonnet-5",
-        provider=Provider.ANTHROPIC,
-        display_name="Claude Sonnet 5",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-    )
     events = [
         {
             "type": "content_block_start",
@@ -75,11 +62,112 @@ async def test_anthropic_stream_preserves_server_tool_result_for_replay() -> Non
     ]
     assert output.tool_calls == []
 
-    client = AnthropicTextClient(
-        model=model,
-        provider=Provider.ANTHROPIC,
-        auth=AuthHeader(secret=SecretStr("test"), header="x-api-key", prefix=""),
+    request = anthropic_test_client()._init_request(
+        TextInput(messages=[output.message])
     )
-    request = client._init_request(TextInput(messages=[output.message]))
 
     assert request["messages"][0]["content"] == signature
+
+
+async def test_anthropic_stream_preserves_caller_and_container_for_replay() -> None:
+    caller = {"type": "code_execution_20260120", "tool_id": "srvtoolu_01"}
+    container = {"id": "container_xyz", "expires_at": "2026-07-08T00:00:00Z"}
+    events = [
+        {
+            "type": "message_start",
+            "message": {"id": "msg_01", "container": container},
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_01",
+                "name": "code_execution",
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"code":"rows = await query_database(...)"}',
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_01",
+                "name": "query_database",
+                "caller": caller,
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": '{"sql":"SELECT 1"}'},
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use"},
+            "usage": {"output_tokens": 10},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    output = stream.output
+    signature = output.signature
+    assert signature is not None
+    assert [block["type"] for block in signature] == ["server_tool_use", "tool_use"]
+    assert signature[1]["caller"] == caller
+    assert output.container == container
+    assert [(tc.name, tc.arguments) for tc in output.tool_calls] == [
+        ("query_database", {"sql": "SELECT 1"})
+    ]
+
+    request = anthropic_test_client()._init_request(
+        TextInput(messages=[output.message])
+    )
+
+    assert request["messages"][0]["content"] == signature
+    assert request["container"] == "container_xyz"
+
+
+async def test_anthropic_programmatic_tool_use_alone_triggers_native_replay() -> None:
+    # Continuation responses carry ONLY the next programmatic tool_use (no
+    # server_tool_use/thinking); its caller must still be replayed verbatim.
+    caller = {"type": "code_execution_20260120", "tool_id": "srvtoolu_01"}
+    events = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_02",
+                "name": "query_database",
+                "caller": caller,
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"sql":"SELECT 2"}'},
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use"},
+            "usage": {"output_tokens": 5},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    signature = stream.output.signature
+    assert signature is not None and signature[0]["caller"] == caller

--- a/tests/unit_tests/test_tool_rehydration.py
+++ b/tests/unit_tests/test_tool_rehydration.py
@@ -1,0 +1,27 @@
+"""Tool kind discriminator: JSON round-trips rehydrate; garbage dicts fail hard."""
+
+import pytest
+
+from celeste.exceptions import InvalidToolError
+from celeste.modalities.text.io import TextInput
+from celeste.tools import WebSearch
+from tests.unit_tests.conftest import anthropic_test_client
+
+
+def test_build_request_rehydrates_serialized_tools() -> None:
+    dumped = WebSearch(max_uses=3).model_dump(mode="json")
+
+    request = anthropic_test_client()._build_request(
+        TextInput(prompt="hi"), tools=[dumped]
+    )
+
+    assert request["tools"] == [
+        {"type": "web_search_20260209", "name": "web_search", "max_uses": 3}
+    ]
+
+
+def test_tools_mapper_rejects_unrecognized_dict() -> None:
+    with pytest.raises(InvalidToolError):
+        anthropic_test_client()._build_request(
+            TextInput(prompt="hi"), tools=[{"allowed_domains": None}]
+        )


### PR DESCRIPTION
## What

Four Anthropic-provider fixes plus a serialization feature for native tools, in two commits.

### fix(anthropic) — code-execution replay + max_tokens (`8f6d77c`)

1. **Streamed `server_tool_use`/`tool_use` blocks kept only `{type,id,name,input}`**, dropping provider fields — notably the programmatic `caller` that ties a tool_use to its code-execution run. Capture now preserves the full block and only overlays the incrementally-streamed `input`.
2. **The top-level code-execution `container` was never captured or re-sent.** Anthropic rejects a continuation with pending programmatic tool calls unless the container id is echoed. The container now rides `Message.container` (twin of `signature`) and `_init_request` echoes it top-level — any consumer that replays `output.message` resumes the paused execution with zero extra code.
3. **Mid-run continuations never converged:** those responses carry *only* the next programmatic `tool_use` (no `server_tool_use`/thinking), so `needs_native_replay` didn't fire and the `caller` was rebuilt away — the model re-requested the same call forever. A `tool_use` with a non-direct `caller` now triggers verbatim replay.
4. **Unset `max_tokens` silently fell back to a hardcoded 1024**, truncating long answers mid-sentence. The default now resolves to the model's declared output ceiling (`Range.max` on the `MAX_TOKENS` constraint, e.g. 128000 on current models); 1024 remains only for models without a declared constraint.

### feat(tools) — kind discriminator (`939031f`)

`WebSearch()` serialized to a type-less dict (`XSearch()`/`CodeExecution()` to `{}`), could not be rehydrated after a JSON round-trip, silently bypassed `ToolSupport` validation, and was appended raw to the provider wire by the dict-fallback branch. Now:
- Each built-in `Tool` carries a defaulted `kind` literal; `rehydrate_tools()` rebuilds instances from kind-tagged dicts in `TextClient._build_request` (re-arming `ToolSupport`).
- ToolsMappers with a `type` gate (anthropic, openresponses, chatcompletions) reject unrecognized dicts with `InvalidToolError` instead of shipping garbage; google keeps its keyed-dict passthrough (its raw wire tools have no `type` key).

## Validation

- 688 unit tests, ruff, ruff format, mypy — all green; each commit is standalone-green.
- Live end-to-end against the Anthropic API: a streamed code-execution + programmatic-tool-call run now completes across multiple continuations (caller + container echoed, paused code resumes, correct final answer); a long answer with unset `max_tokens` runs to `end_turn` at 6324 output tokens (previously cut at exactly 1024).
- Live `tools=[WebSearch()]` on gemini + claude: grounded responses, dynamic-filtering upgrade intact, no `DeprecationWarning`.