### PR TITLE
fix(streaming): assemble raw_response so streamed usage is complete

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -72,6 +72,7 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
         return None
 
     def _usage_from_raw_response(self, raw_response: dict[str, Any]) -> TextUsage:
+        """Derive typed usage from the assembled response (usage is split across events)."""
         return self._usage_class(
             **AnthropicMessagesClient.map_usage_fields(raw_response.get("usage") or {})
         )

--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -28,6 +28,7 @@ from ...client import TextClient
 from ...io import (
     TextChunk,
     TextInput,
+    TextUsage,
 )
 from ...streaming import TextStream
 from .grounding import parse_grounding
@@ -36,28 +37,6 @@ from .parameters import ANTHROPIC_PARAMETER_MAPPERS
 
 class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
     """Anthropic streaming for text modality."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._message_start: dict[str, Any] | None = None
-
-    def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
-        """Parse one SSE event into a typed chunk (captures message_start)."""
-        event_type = event_data.get("type")
-        if event_type == "message_start":
-            message = event_data.get("message")
-            if isinstance(message, dict):
-                self._message_start = message
-            return None
-        return super()._parse_chunk(event_data)
-
-    def _aggregate_event_data(self, chunks: list[TextChunk]) -> list[dict[str, Any]]:
-        """Prepend message_start, then delegate to base."""
-        events: list[dict[str, Any]] = []
-        if self._message_start is not None:
-            events.append({"type": "message_start", "message": self._message_start})
-        events.extend(super()._aggregate_event_data(chunks))
-        return events
 
     def _aggregate_tool_calls(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
@@ -91,6 +70,11 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
                 ):
                     return holder["container"]
         return None
+
+    def _usage_from_raw_response(self, raw_response: dict[str, Any]) -> TextUsage:
+        return self._usage_class(
+            **AnthropicMessagesClient.map_usage_fields(raw_response.get("usage") or {})
+        )
 
     def _aggregate_grounding(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]

--- a/src/celeste/protocols/openresponses/streaming.py
+++ b/src/celeste/protocols/openresponses/streaming.py
@@ -75,6 +75,16 @@ class OpenResponsesStream:
                 return OpenResponsesClient.map_usage_fields(usage_data)
         return None
 
+    def _aggregate_raw_response(
+        self, chunks: list[Any], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Unwrap the final Response object from the response.completed event."""
+        for event in reversed(raw_events):
+            if event.get("type") == "response.completed":
+                response = event.get("response")
+                return response if isinstance(response, dict) else None
+        return None
+
     def _parse_chunk_finish_reason(
         self, event_data: dict[str, Any]
     ) -> FinishReason | None:

--- a/src/celeste/providers/anthropic/messages/streaming.py
+++ b/src/celeste/providers/anthropic/messages/streaming.py
@@ -24,10 +24,16 @@ class AnthropicMessagesStream:
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         super().__init__(*args, **kwargs)
         self._content_blocks: dict[int, dict[str, Any]] = {}
+        self._message_start: dict[str, Any] | None = None
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> Any:  # noqa: ANN401
         """Capture native content blocks before delegating to the modality stream."""
         event_type = event_data.get("type")
+        if event_type == "message_start":
+            message = event_data.get("message")
+            if isinstance(message, dict):
+                self._message_start = message
+            return None
         if event_type == "content_block_start":
             block = event_data.get("content_block", {})
             block_type = block.get("type")
@@ -80,6 +86,31 @@ class AnthropicMessagesStream:
                     if isinstance(citation, dict):
                         block["citations"].append(citation)
         return super()._parse_chunk(event_data)  # type: ignore[misc]
+
+    def _aggregate_event_data(self, chunks: list[Any]) -> list[dict[str, Any]]:
+        """Prepend the captured message_start, then delegate to the modality stream."""
+        events: list[dict[str, Any]] = []
+        if self._message_start is not None:
+            events.append({"type": "message_start", "message": self._message_start})
+        events.extend(super()._aggregate_event_data(chunks))  # type: ignore[misc]
+        return events
+
+    def _aggregate_raw_response(
+        self, chunks: list[Any], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Assemble the final Messages response: message_start merged with message_delta."""
+        if self._message_start is None:
+            return None
+        response = dict(self._message_start)
+        for event in reversed(raw_events):
+            if event.get("type") == "message_delta":
+                response.update(event.get("delta") or {})
+                response["usage"] = {
+                    **(response.get("usage") or {}),
+                    **(event.get("usage") or {}),
+                }
+                break
+        return response
 
     def _aggregate_content_blocks(self) -> list[dict[str, Any]]:
         """Return reconstructed native Anthropic content blocks."""

--- a/src/celeste/providers/google/generate_content/streaming.py
+++ b/src/celeste/providers/google/generate_content/streaming.py
@@ -73,6 +73,15 @@ class GoogleGenerateContentStream:
 
         return None
 
+    def _aggregate_raw_response(
+        self, chunks: list[Any], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """The last chunk carrying cumulative usageMetadata is response-shaped."""
+        for event in reversed(raw_events):
+            if isinstance(event.get("usageMetadata"), dict):
+                return event
+        return None
+
     def _parse_chunk_finish_reason(
         self, event_data: dict[str, Any]
     ) -> FinishReason | None:

--- a/src/celeste/providers/google/interactions/streaming.py
+++ b/src/celeste/providers/google/interactions/streaming.py
@@ -81,6 +81,17 @@ class GoogleInteractionsStream:
 
         return None
 
+    def _aggregate_raw_response(
+        self, chunks: list[Any], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Unwrap the final Interaction object from the interaction.complete event."""
+        for event in reversed(raw_events):
+            event_type = event.get("event_type") or event.get("type")
+            if event_type == "interaction.complete":
+                interaction = event.get("interaction")
+                return interaction if isinstance(interaction, dict) else None
+        return None
+
     def _parse_chunk_finish_reason(
         self, event_data: dict[str, Any]
     ) -> FinishReason | None:

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -233,11 +233,7 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
     def _aggregate_raw_response(
         self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
     ) -> dict[str, Any] | None:
-        """Reconstructed final response dict (streaming counterpart of raw_response).
-
-        Default covers wires whose terminal event is response-shaped (top-level
-        usage). Providers override where the wire wraps or splits the response.
-        """
+        """Reconstruct the final response dict; providers override for wrapped/split wires."""
         for event in reversed(raw_events):
             if isinstance(event.get("usage"), dict):
                 return event

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -196,11 +196,17 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
             self._aggregate_tool_calls(chunks, raw_events),
             parameters.get("tools"),
         )
+        metadata = self._build_stream_metadata(raw_events)
+        raw_response = self._aggregate_raw_response(chunks, raw_events)
+        usage: Usage | None = None
+        if raw_response is not None:
+            metadata["raw_response"] = raw_response
+            usage = self._usage_from_raw_response(raw_response)
         output = self._output_class(
             content=content,
-            usage=self._aggregate_usage(chunks),
+            usage=usage or self._aggregate_usage(chunks),
             finish_reason=self._aggregate_finish_reason(chunks),
-            metadata=self._build_stream_metadata(raw_events),
+            metadata=metadata,
             tool_calls=tool_calls,
             **kwargs,
         )
@@ -222,6 +228,23 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
     ) -> dict[str, Any] | None:
         """Aggregate provider container state. Override in provider streams."""
+        return None
+
+    def _aggregate_raw_response(
+        self, chunks: list[Chunk], raw_events: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Reconstructed final response dict (streaming counterpart of raw_response).
+
+        Default covers wires whose terminal event is response-shaped (top-level
+        usage). Providers override where the wire wraps or splits the response.
+        """
+        for event in reversed(raw_events):
+            if isinstance(event.get("usage"), dict):
+                return event
+        return None
+
+    def _usage_from_raw_response(self, raw_response: dict[str, Any]) -> Usage | None:
+        """Typed usage from the assembled response. Providers with split usage override."""
         return None
 
     def _aggregate_reasoning(self, chunks: list[Chunk]) -> str | None:

--- a/tests/unit_tests/test_stream_raw_response.py
+++ b/tests/unit_tests/test_stream_raw_response.py
@@ -1,0 +1,110 @@
+"""Streaming reconstructs metadata["raw_response"] so billing reads complete usage."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from celeste.modalities.text.protocols.chatcompletions import ChatCompletionsTextStream
+from celeste.modalities.text.protocols.openresponses import OpenResponsesTextStream
+from celeste.modalities.text.providers.anthropic.client import AnthropicTextStream
+
+
+async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+async def test_anthropic_stream_assembles_raw_response_with_complete_usage() -> None:
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_01",
+                "model": "claude-sonnet-5",
+                "usage": {
+                    "input_tokens": 6000,
+                    "cache_creation": {"ephemeral_5m_input_tokens": 1200},
+                    "cache_read_input_tokens": 40,
+                    "server_tool_use": {"web_search_requests": 4},
+                },
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "done"},
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 305},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    output = stream.output
+    raw_response = output.metadata["raw_response"]
+    assert raw_response["id"] == "msg_01"
+    assert raw_response["stop_reason"] == "end_turn"
+    assert raw_response["usage"] == {
+        "input_tokens": 6000,
+        "output_tokens": 305,
+        "cache_creation": {"ephemeral_5m_input_tokens": 1200},
+        "cache_read_input_tokens": 40,
+        "server_tool_use": {"web_search_requests": 4},
+    }
+    # Typed usage is derived from the assembled response, not last-chunk-wins.
+    assert output.usage.input_tokens == 6000
+    assert output.usage.output_tokens == 305
+    assert output.usage.cached_tokens == 40
+
+
+async def test_openresponses_stream_unwraps_completed_response() -> None:
+    response = {
+        "id": "resp_01",
+        "status": "completed",
+        "usage": {"input_tokens": 100, "output_tokens": 20},
+        "output": [],
+    }
+    events = [
+        {
+            "type": "response.output_text.delta",
+            "delta": "done",
+            "content_index": 0,
+        },
+        {"type": "response.completed", "response": response},
+    ]
+    stream = OpenResponsesTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    assert stream.output.metadata["raw_response"] == response
+    assert stream.output.usage.input_tokens == 100
+
+
+async def test_chatcompletions_stream_keeps_terminal_usage_event() -> None:
+    final_chunk = {
+        "id": "chatcmpl-01",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {"prompt_tokens": 50, "completion_tokens": 10, "total_tokens": 60},
+    }
+    events = [
+        {
+            "object": "chat.completion.chunk",
+            "choices": [{"delta": {"content": "done"}}],
+        },
+        final_chunk,
+    ]
+    stream = ChatCompletionsTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    assert stream.output.metadata["raw_response"] == final_chunk
+    # Typed usage unchanged for single-terminal-event protocols.
+    assert stream.output.usage.input_tokens == 50
+    assert stream.output.usage.output_tokens == 10


### PR DESCRIPTION
## What

Streamed outputs never carried a complete usage object. Non-streaming sets `metadata["raw_response"]` (full final response, top-level `usage`), but streaming left consumers to re-derive usage from `raw_events` — impossible without knowing each wire's event nesting:

- **anthropic** splits usage across `message_start.message.usage` (input, cache_creation, server_tool_use) and `message_delta.usage` (output) — so typed usage lost input/cache entirely (last-chunk-wins kept only the delta), and nested billable fields (`server_tool_use.web_search_requests`, `cache_creation`) were unreachable.
- **openresponses** wraps the final response under `response.completed → {"response": …}` — its usage never surfaced at the top level of any event.
- **google interactions** wraps under `interaction.complete → {"interaction": …}`.

## Fix (one contract, generic seam)

Streaming now assembles `metadata["raw_response"]` — the reconstructed final response object — so both transports honor the same metadata contract:

- New base hook `Stream._aggregate_raw_response(chunks, raw_events)` (default: the last response-shaped event, covering chatcompletions / google generate_content out of the box), with wire-shape overrides where the response is wrapped or split: anthropic (deep-merge `message_start.message` with the terminal `message_delta`'s `delta` + `usage`), openresponses (unwrap `response`), google interactions (unwrap `interaction`), google generate_content (last `usageMetadata` chunk).
- Typed `Output.usage` derives from the assembled response where the wire splits it (`_usage_from_raw_response`, Anthropic override) instead of last-chunk-wins — streamed Anthropic outputs now carry real `input_tokens`/`cached_tokens`.
- The Anthropic `message_start` capture machinery moved from the text modality class into the `AnthropicMessagesStream` mixin where the rest of the Messages wire parsing lives; the modality class keeps only the typed-usage binding.

## Validation

- 691 unit tests, ruff, ruff format, mypy — green. New `test_stream_raw_response.py`: one fixture per protocol family (anthropic split-merge incl. `server_tool_use` + cache; openresponses unwrap; chatcompletions terminal event passthrough with typed usage unchanged).
- Live streamed anthropic web-search run: `raw_response.usage` complete (`input_tokens`, `cache_creation`, `server_tool_use.web_search_requests`), typed usage populated (`input=19795, output=294`) where it was previously output-only.