### PR TITLE
feat(xai): add grok-4.5 text model

### DIFF
--- a/src/celeste/modalities/text/providers/xai/models.py
+++ b/src/celeste/modalities/text/providers/xai/models.py
@@ -16,6 +16,22 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="grok-4.5",
+        provider=Provider.XAI,
+        display_name="Grok 4.5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=131072),
+            TextParameter.THINKING_BUDGET: Choice(options=["low", "medium", "high"]),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+        },
+    ),
+    Model(
         id="grok-4.3",
         provider=Provider.XAI,
         display_name="Grok 4.3",


### PR DESCRIPTION
Registers **Grok 4.5** as an xAI text model. xAI is already fully wired (auth, OpenResponses client, `Provider.XAI`), so this is a one-file addition — appending a single `Model(...)` to the xAI text `MODELS` list.

### Model
- `id="grok-4.5"`, 500k context, input text+image / output text
- Capabilities: streaming, function calling (`TOOL_CHOICE`), structured outputs, vision (`IMAGE`), server tools `web_search` / `x_search` / `code_execution`

### Two spec-driven values (per [docs.x.ai](https://docs.x.ai/developers/models/grok-4.5))
- `THINKING_BUDGET` omits `"none"` → `["low", "medium", "high"]`: Grok 4.5 reasoning is always-on and cannot be disabled (mirrors the existing `grok-3-mini` precedent).
- `MAX_TOKENS` max `131072`: the docs publish no separate output cap for grok-4.5 (only the 500k context), so this mirrors the Grok family's declared value.

### Verification
- `make ci` passes: ruff format+lint, mypy strict, bandit, 691 unit tests, 82.54% coverage.
- Registry check: `grok-4.5` resolves via `list_models(modality=TEXT)` for `Provider.XAI`.
- Auto-covered by the registry-driven text integration tests (`test_stream_generate[xai-grok-4.5]`, `test_stream_analyze_image`).