### PR TITLE
feat(models): register GPT-5.6 models

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -208,6 +208,78 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="gpt-5.6",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.6",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="gpt-5.6-sol",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.6 Sol",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="gpt-5.6-terra",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.6 Terra",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="gpt-5.6-luna",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.6 Luna",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="gpt-5.5",
         provider=Provider.OPENAI,
         display_name="GPT-5.5",


### PR DESCRIPTION
## Summary
Registers GPT-5.6 Sol, Terra, Luna, and the `gpt-5.6` alias for the OpenAI text provider.

## Why
OpenAI documents `gpt-5.6` as an alias that routes to GPT-5.6 Sol. Celeste has established provider-alias precedent, so both accepted IDs are discoverable and validated.

## Impact
Consumers can select all documented GPT-5.6 text model IDs and use their supported text, image, document, structured-output, function-calling, web-search, streaming, and reasoning settings.

## Validation
- `uv run ruff check src/celeste/modalities/text/providers/openai/models.py`
- `git diff --check -- src/celeste/modalities/text/providers/openai/models.py`

No tests run: registered-model integration coverage runs automatically.