### PR TITLE
Exclude audio bytes from metadata

### DIFF
--- a/src/celeste/modalities/audio/client.py
+++ b/src/celeste/modalities/audio/client.py
@@ -21,6 +21,7 @@ class AudioClient(
     modality: Modality = Modality.AUDIO
     _usage_class = AudioUsage
     _finish_reason_class = AudioFinishReason
+    _content_fields: ClassVar[set[str]] = {"audio_bytes"}
 
     _speak_endpoint: ClassVar[str | None] = None
 


### PR DESCRIPTION
## What changed

- Exclude the standardized `audio_bytes` response field from audio metadata.

## Why

Audio providers return generated bytes through `audio_bytes`, and Celeste copied that field into `metadata.raw_response`. When `celeste-tools` forwarded the metadata through `ToolOutput`, Pydantic attempted to serialize the binary audio as UTF-8 and raised `UnicodeDecodeError`.

The generated bytes remain in `AudioArtifact.data`; only the duplicate metadata copy is removed. This fixes the shared Gradium, ElevenLabs, and OpenAI audio path. Google retains its existing `audioContent` override.

## Validation

- Confirmed end-to-end with Gradium audio generation in Chat using the patched installed package.
- Repository pre-commit and pre-push hooks passed: Ruff, mypy, Bandit, and 691 unit tests.
- No new test added.