### PR TITLE
Add descriptions to audio voices

### DIFF
--- a/src/celeste/modalities/audio/providers/elevenlabs/voices.py
+++ b/src/celeste/modalities/audio/providers/elevenlabs/voices.py
@@ -4,320 +4,122 @@ from celeste.core import Provider
 
 from ...voices import Voice
 
-# ElevenLabs default voices (from API: GET /v2/voices?voice_type=default)
+# Snapshot 2026-07-14: 21 default voices from GET /v2/voices?voice_type=default.
+# Source: https://elevenlabs.io/docs/api-reference/voices/search
 ELEVENLABS_VOICES = [
     Voice(
-        id="21m00Tcm4TlvDq8ikWAM",
+        id=voice_id,
         provider=Provider.ELEVENLABS,
-        name="Rachel",
-        languages=set(),
-    ),
-    Voice(
-        id="29vD33N1CtxCmqQRPOHJ",
-        provider=Provider.ELEVENLABS,
-        name="Drew",
-        languages=set(),
-    ),
-    Voice(
-        id="2EiwWnXFnvU5JabPnv8n",
-        provider=Provider.ELEVENLABS,
-        name="Clyde",
-        languages=set(),
-    ),
-    Voice(
-        id="5Q0t7uMcjvnagumLfvZi",
-        provider=Provider.ELEVENLABS,
-        name="Paul",
-        languages=set(),
-    ),
-    Voice(
-        id="9BWtsMINqrJLrRacOk9x",
-        provider=Provider.ELEVENLABS,
-        name="Aria",
-        languages=set(),
-    ),
-    Voice(
-        id="AZnzlk1XvdvUeBnXmlld",
-        provider=Provider.ELEVENLABS,
-        name="Domi",
-        languages=set(),
-    ),
-    Voice(
-        id="CYw3kZ02Hs0563khs1Fj",
-        provider=Provider.ELEVENLABS,
-        name="Dave",
-        languages=set(),
-    ),
-    Voice(
-        id="CwhRBWXzGAHq8TQ4Fs17",
-        provider=Provider.ELEVENLABS,
-        name="Roger",
-        languages=set(),
-    ),
-    Voice(
-        id="D38z5RcWu1voky8WS1ja",
-        provider=Provider.ELEVENLABS,
-        name="Fin",
-        languages=set(),
-    ),
-    Voice(
-        id="EXAVITQu4vr4xnSDxMaL",
-        provider=Provider.ELEVENLABS,
-        name="Sarah",
-        languages=set(),
-    ),
-    Voice(
-        id="ErXwobaYiN019PkySvjV",
-        provider=Provider.ELEVENLABS,
-        name="Antoni",
-        languages=set(),
-    ),
-    Voice(
-        id="FGY2WhTYpPnrIDTdsKH5",
-        provider=Provider.ELEVENLABS,
-        name="Laura",
-        languages=set(),
-    ),
-    Voice(
-        id="GBv7mTt0atIp3Br8iCZE",
-        provider=Provider.ELEVENLABS,
-        name="Thomas",
-        languages=set(),
-    ),
-    Voice(
-        id="IKne3meq5aSn9XLyUdCD",
-        provider=Provider.ELEVENLABS,
-        name="Charlie",
-        languages=set(),
-    ),
-    Voice(
-        id="JBFqnCBsd6RMkjVDRZzb",
-        provider=Provider.ELEVENLABS,
-        name="George",
-        languages=set(),
-    ),
-    Voice(
-        id="LcfcDJNUP1GQjkzn1xUU",
-        provider=Provider.ELEVENLABS,
-        name="Emily",
-        languages=set(),
-    ),
-    Voice(
-        id="MF3mGyEYCl7XYWbV9V6O",
-        provider=Provider.ELEVENLABS,
-        name="Elli",
-        languages=set(),
-    ),
-    Voice(
-        id="N2lVS1w4EtoT3dr4eOWO",
-        provider=Provider.ELEVENLABS,
-        name="Callum",
-        languages=set(),
-    ),
-    Voice(
-        id="ODq5zmih8GrVes37Dizd",
-        provider=Provider.ELEVENLABS,
-        name="Patrick",
-        languages=set(),
-    ),
-    Voice(
-        id="SAz9YHcvj6GT2YYXdXww",
-        provider=Provider.ELEVENLABS,
-        name="River",
-        languages=set(),
-    ),
-    Voice(
-        id="SOYHLrjzK2X1ezoPC6cr",
-        provider=Provider.ELEVENLABS,
-        name="Harry",
-        languages=set(),
-    ),
-    Voice(
-        id="TX3LPaxmHKxFdv7VOQHJ",
-        provider=Provider.ELEVENLABS,
-        name="Liam",
-        languages=set(),
-    ),
-    Voice(
-        id="ThT5KcBeYPX3keUQqHPh",
-        provider=Provider.ELEVENLABS,
-        name="Dorothy",
-        languages=set(),
-    ),
-    Voice(
-        id="TxGEqnHWrfWFTfGW9XjX",
-        provider=Provider.ELEVENLABS,
-        name="Josh",
-        languages=set(),
-    ),
-    Voice(
-        id="VR6AewLTigWG4xSOukaG",
-        provider=Provider.ELEVENLABS,
-        name="Arnold",
-        languages=set(),
-    ),
-    Voice(
-        id="XB0fDUnXU5powFXDhCwa",
-        provider=Provider.ELEVENLABS,
-        name="Charlotte",
-        languages=set(),
-    ),
-    Voice(
-        id="Xb7hH8MSUJpSbSDYk0k2",
-        provider=Provider.ELEVENLABS,
-        name="Alice",
-        languages=set(),
-    ),
-    Voice(
-        id="XrExE9yKIg1WjnnlVkGX",
-        provider=Provider.ELEVENLABS,
-        name="Matilda",
-        languages=set(),
-    ),
-    Voice(
-        id="ZQe5CZNOzWyzPSCn5a3c",
-        provider=Provider.ELEVENLABS,
-        name="James",
-        languages=set(),
-    ),
-    Voice(
-        id="Zlb1dXrM653N07WRdFW3",
-        provider=Provider.ELEVENLABS,
-        name="Joseph",
-        languages=set(),
-    ),
-    Voice(
-        id="bIHbv24MWmeRgasZH58o",
-        provider=Provider.ELEVENLABS,
-        name="Will",
-        languages=set(),
-    ),
-    Voice(
-        id="bVMeCyTHy58xNoL34h3p",
-        provider=Provider.ELEVENLABS,
-        name="Jeremy",
-        languages=set(),
-    ),
-    Voice(
-        id="cgSgspJ2msm6clMCkdW9",
-        provider=Provider.ELEVENLABS,
-        name="Jessica",
-        languages=set(),
-    ),
-    Voice(
-        id="cjVigY5qzO86Huf0OWal",
-        provider=Provider.ELEVENLABS,
-        name="Eric",
-        languages=set(),
-    ),
-    Voice(
-        id="flq6f7yk4E4fJM5XTYuZ",
-        provider=Provider.ELEVENLABS,
-        name="Michael",
-        languages=set(),
-    ),
-    Voice(
-        id="g5CIjZEefAph4nQFvHAz",
-        provider=Provider.ELEVENLABS,
-        name="Ethan",
-        languages=set(),
-    ),
-    Voice(
-        id="iP95p4xoKVk53GoZ742B",
-        provider=Provider.ELEVENLABS,
-        name="Chris",
-        languages=set(),
-    ),
-    Voice(
-        id="jBpfuIE2acCO8z3wKNLl",
-        provider=Provider.ELEVENLABS,
-        name="Gigi",
-        languages=set(),
-    ),
-    Voice(
-        id="jsCqWAovK2LkecY7zXl4",
-        provider=Provider.ELEVENLABS,
-        name="Freya",
-        languages=set(),
-    ),
-    Voice(
-        id="nPczCjzI2devNBz1zQrb",
-        provider=Provider.ELEVENLABS,
-        name="Brian",
-        languages=set(),
-    ),
-    Voice(
-        id="oWAxZDx7w5VEj9dCyTzz",
-        provider=Provider.ELEVENLABS,
-        name="Grace",
-        languages=set(),
-    ),
-    Voice(
-        id="onwK4e9ZLuTAKqWW03F9",
-        provider=Provider.ELEVENLABS,
-        name="Daniel",
-        languages=set(),
-    ),
-    Voice(
-        id="pFZP5JQG7iQjIQuC4Bku",
-        provider=Provider.ELEVENLABS,
-        name="Lily",
-        languages=set(),
-    ),
-    Voice(
-        id="pMsXgVXv3BLzUgSXRplE",
-        provider=Provider.ELEVENLABS,
-        name="Serena",
-        languages=set(),
-    ),
-    Voice(
-        id="pNInz6obpgDQGcFmaJgB",
-        provider=Provider.ELEVENLABS,
-        name="Adam",
-        languages=set(),
-    ),
-    Voice(
-        id="piTKgcLEGmPE4e6mEKli",
-        provider=Provider.ELEVENLABS,
-        name="Nicole",
-        languages=set(),
-    ),
-    Voice(
-        id="pqHfZKP75CvOlQylNhV4",
-        provider=Provider.ELEVENLABS,
-        name="Bill",
-        languages=set(),
-    ),
-    Voice(
-        id="t0jbNlBVZ17f02VDIeMI",
-        provider=Provider.ELEVENLABS,
-        name="Jessie",
-        languages=set(),
-    ),
-    Voice(
-        id="yoZ06aMxZJJ28mfd3POQ",
-        provider=Provider.ELEVENLABS,
-        name="Sam",
-        languages=set(),
-    ),
-    Voice(
-        id="z9fAnlkpzviPz146aGWa",
-        provider=Provider.ELEVENLABS,
-        name="Glinda",
-        languages=set(),
-    ),
-    Voice(
-        id="zcAOhNBS3c14rBihAFp1",
-        provider=Provider.ELEVENLABS,
-        name="Giovanni",
-        languages=set(),
-    ),
-    Voice(
-        id="zrHiDhphv9ZnVXBqCLjz",
-        provider=Provider.ELEVENLABS,
-        name="Mimi",
-        languages=set(),
-    ),
+        name=name,
+        description=description,
+    )
+    for voice_id, name, description in [
+        (
+            "pNInz6obpgDQGcFmaJgB",
+            "Adam - Dominant, Firm",
+            "A bright tenor pitch that immediately cuts through. The delivery is brash and openly confident, speaking with unwavering certainty and a slightly aggressive self-assurance.",
+        ),
+        (
+            "Xb7hH8MSUJpSbSDYk0k2",
+            "Alice - Clear, Engaging Educator",
+            "Clear and engaging, friendly woman with a British accent suitable for e-learning.",
+        ),
+        (
+            "hpp4J3VqNfWAUOO0d1Us",
+            "Bella - Professional, Bright, Warm",
+            "This voice is warm, bright, and professional, characterized by a Standard American accent and a polished, narrative quality. It features a medium-high pitch with crisp diction and a deliberate, rhythmic pace that makes it highly intelligible and engaging for long-form listening.",
+        ),
+        (
+            "pqHfZKP75CvOlQylNhV4",
+            "Bill - Wise, Mature, Balanced",
+            "Friendly and comforting voice ready to narrate your stories.",
+        ),
+        (
+            "nPczCjzI2devNBz1zQrb",
+            "Brian - Deep, Resonant and Comforting",
+            "Middle-aged man with a resonant and comforting tone. Great for narrations and advertisements.",
+        ),
+        (
+            "N2lVS1w4EtoT3dr4eOWO",
+            "Callum - Husky Trickster",
+            "Deceptively gravelly, yet unsettling edge.",
+        ),
+        (
+            "IKne3meq5aSn9XLyUdCD",
+            "Charlie - Deep, Confident, Energetic",
+            "A young Australian male with a confident and energetic voice.",
+        ),
+        (
+            "iP95p4xoKVk53GoZ742B",
+            "Chris - Charming, Down-to-Earth",
+            "Natural and real, this down-to-earth voice is great across many use-cases.",
+        ),
+        (
+            "onwK4e9ZLuTAKqWW03F9",
+            "Daniel - Steady Broadcaster",
+            "A strong voice perfect for delivering a professional broadcast or news story.",
+        ),
+        (
+            "cjVigY5qzO86Huf0OWal",
+            "Eric - Smooth, Trustworthy",
+            "A smooth tenor pitch from a man in his 40s - perfect for agentic use cases.",
+        ),
+        (
+            "JBFqnCBsd6RMkjVDRZzb",
+            "George - Warm, Captivating Storyteller",
+            "Warm resonance that instantly captivates listeners.",
+        ),
+        (
+            "SOYHLrjzK2X1ezoPC6cr",
+            "Harry - Fierce Warrior",
+            "An animated warrior ready to charge forward.",
+        ),
+        (
+            "cgSgspJ2msm6clMCkdW9",
+            "Jessica - Playful, Bright, Warm",
+            "Young and popular, this playful American female voice is perfect for trendy content.",
+        ),
+        (
+            "FGY2WhTYpPnrIDTdsKH5",
+            "Laura - Enthusiast, Quirky Attitude",
+            "This young adult female voice delivers sunny enthusiasm with a quirky attitude.",
+        ),
+        (
+            "TX3LPaxmHKxFdv7VOQHJ",
+            "Liam - Energetic, Social Media Creator",
+            "A young adult with energy and warmth - suitable for reels and shorts.",
+        ),
+        (
+            "pFZP5JQG7iQjIQuC4Bku",
+            "Lily - Velvety Actress",
+            "Velvety British female voice delivers news and narrations with warmth and clarity.",
+        ),
+        (
+            "XrExE9yKIg1WjnnlVkGX",
+            "Matilda - Knowledgable, Professional",
+            "A professional woman with a pleasing alto pitch. Suitable for many use cases.",
+        ),
+        (
+            "SAz9YHcvj6GT2YYXdXww",
+            "River - Relaxed, Neutral, Informative",
+            "A relaxed, neutral voice ready for narrations or conversational projects.",
+        ),
+        (
+            "CwhRBWXzGAHq8TQ4Fs17",
+            "Roger - Laid-Back, Casual, Resonant",
+            "Easy going and perfect for casual conversations.",
+        ),
+        (
+            "EXAVITQu4vr4xnSDxMaL",
+            "Sarah - Mature, Reassuring, Confident",
+            "Young adult woman with a confident and warm, mature quality and a reassuring, professional tone.",
+        ),
+        (
+            "bIHbv24MWmeRgasZH58o",
+            "Will - Relaxed Optimist",
+            "Conversational and laid back.",
+        ),
+    ]
 ]
 
 __all__ = ["ELEVENLABS_VOICES"]

--- a/src/celeste/modalities/audio/providers/google/voices.py
+++ b/src/celeste/modalities/audio/providers/google/voices.py
@@ -5,7 +5,7 @@ from celeste.core import Provider
 from ...languages import Language
 from ...voices import Voice
 
-# All supported languages for Google Gemini TTS (24 languages, auto-detected)
+# Language metadata shared across Google Gemini TTS voices (auto-detected).
 _SUPPORTED_LANGUAGES = {
     Language.ARABIC,
     Language.GERMAN,
@@ -28,186 +28,46 @@ _SUPPORTED_LANGUAGES = {
     Language.TAMIL,
 }
 
-# Google Gemini TTS voices (30 voices, all support all languages)
+# Snapshot 2026-07-14: 30 prebuilt voices.
+# Source: https://ai.google.dev/gemini-api/docs/speech-generation#voices
 GOOGLE_VOICES = [
     Voice(
-        id="Zephyr",
+        id=name,
         provider=Provider.GOOGLE,
-        name="Zephyr (Bright)",
+        name=name,
+        description=description,
         languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Puck",
-        provider=Provider.GOOGLE,
-        name="Puck (Upbeat)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Charon",
-        provider=Provider.GOOGLE,
-        name="Charon (Informative)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Kore",
-        provider=Provider.GOOGLE,
-        name="Kore (Firm)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Fenrir",
-        provider=Provider.GOOGLE,
-        name="Fenrir (Excitable)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Leda",
-        provider=Provider.GOOGLE,
-        name="Leda (Youthful)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Orus",
-        provider=Provider.GOOGLE,
-        name="Orus (Firm)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Aoede",
-        provider=Provider.GOOGLE,
-        name="Aoede (Breezy)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Callirrhoe",
-        provider=Provider.GOOGLE,
-        name="Callirrhoe (Easy-going)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Autonoe",
-        provider=Provider.GOOGLE,
-        name="Autonoe (Bright)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Enceladus",
-        provider=Provider.GOOGLE,
-        name="Enceladus (Breathy)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Iapetus",
-        provider=Provider.GOOGLE,
-        name="Iapetus (Clear)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Umbriel",
-        provider=Provider.GOOGLE,
-        name="Umbriel (Easy-going)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Algieba",
-        provider=Provider.GOOGLE,
-        name="Algieba (Smooth)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Despina",
-        provider=Provider.GOOGLE,
-        name="Despina (Smooth)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Erinome",
-        provider=Provider.GOOGLE,
-        name="Erinome (Clear)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Algenib",
-        provider=Provider.GOOGLE,
-        name="Algenib (Gravelly)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Rasalgethi",
-        provider=Provider.GOOGLE,
-        name="Rasalgethi (Informative)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Laomedeia",
-        provider=Provider.GOOGLE,
-        name="Laomedeia (Upbeat)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Achernar",
-        provider=Provider.GOOGLE,
-        name="Achernar (Soft)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Alnilam",
-        provider=Provider.GOOGLE,
-        name="Alnilam (Firm)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Schedar",
-        provider=Provider.GOOGLE,
-        name="Schedar (Even)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Gacrux",
-        provider=Provider.GOOGLE,
-        name="Gacrux (Mature)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Pulcherrima",
-        provider=Provider.GOOGLE,
-        name="Pulcherrima (Forward)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Achird",
-        provider=Provider.GOOGLE,
-        name="Achird (Friendly)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Zubenelgenubi",
-        provider=Provider.GOOGLE,
-        name="Zubenelgenubi (Casual)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Vindemiatrix",
-        provider=Provider.GOOGLE,
-        name="Vindemiatrix (Gentle)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Sadachbia",
-        provider=Provider.GOOGLE,
-        name="Sadachbia (Lively)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Sadaltager",
-        provider=Provider.GOOGLE,
-        name="Sadaltager (Knowledgeable)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
-    Voice(
-        id="Sulafat",
-        provider=Provider.GOOGLE,
-        name="Sulafat (Warm)",
-        languages=_SUPPORTED_LANGUAGES,
-    ),
+    )
+    for name, description in [
+        ("Zephyr", "Bright"),
+        ("Puck", "Upbeat"),
+        ("Charon", "Informative"),
+        ("Kore", "Firm"),
+        ("Fenrir", "Excitable"),
+        ("Leda", "Youthful"),
+        ("Orus", "Firm"),
+        ("Aoede", "Breezy"),
+        ("Callirrhoe", "Easy-going"),
+        ("Autonoe", "Bright"),
+        ("Enceladus", "Breathy"),
+        ("Iapetus", "Clear"),
+        ("Umbriel", "Easy-going"),
+        ("Algieba", "Smooth"),
+        ("Despina", "Smooth"),
+        ("Erinome", "Clear"),
+        ("Algenib", "Gravelly"),
+        ("Rasalgethi", "Informative"),
+        ("Laomedeia", "Upbeat"),
+        ("Achernar", "Soft"),
+        ("Alnilam", "Firm"),
+        ("Schedar", "Even"),
+        ("Gacrux", "Mature"),
+        ("Pulcherrima", "Forward"),
+        ("Achird", "Friendly"),
+        ("Zubenelgenubi", "Casual"),
+        ("Vindemiatrix", "Gentle"),
+        ("Sadachbia", "Lively"),
+        ("Sadaltager", "Knowledgeable"),
+        ("Sulafat", "Warm"),
+    ]
 ]

--- a/src/celeste/modalities/audio/providers/gradium/voices.py
+++ b/src/celeste/modalities/audio/providers/gradium/voices.py
@@ -2,101 +2,417 @@
 
 from celeste.core import Provider
 
+from ...languages import Language
 from ...voices import Voice
 
-# Gradium flagship voices
-# Full list at https://gradium.ai/api_dpocs.html
+# Snapshot 2026-07-14: 66 flagship voices.
+# Source: https://docs.gradium.ai/guides/voices/flagship-voices
 GRADIUM_VOICES = [
-    # English (US)
     Voice(
-        id="YTpq7expH9539ERJ",
+        id=voice_id,
         provider=Provider.GRADIUM,
-        name="Emma",
-        languages={"en"},
-    ),
-    Voice(
-        id="LFZvm12tW_z0xfGo",
-        provider=Provider.GRADIUM,
-        name="Kent",
-        languages={"en"},
-    ),
-    Voice(
-        id="jtEKaLYNn6iif5PR",
-        provider=Provider.GRADIUM,
-        name="Sydney",
-        languages={"en"},
-    ),
-    Voice(
-        id="KWJiFWu2O9nMPYcR",
-        provider=Provider.GRADIUM,
-        name="John",
-        languages={"en"},
-    ),
-    # English (GB)
-    Voice(
-        id="ubuXFxVQwVYnZQhy",
-        provider=Provider.GRADIUM,
-        name="Eva",
-        languages={"en"},
-    ),
-    Voice(
-        id="m86j6D7UZpGzHsNu",
-        provider=Provider.GRADIUM,
-        name="Jack",
-        languages={"en"},
-    ),
-    # French
-    Voice(
-        id="b35yykvVppLXyw_l",
-        provider=Provider.GRADIUM,
-        name="Elise",
-        languages={"fr"},
-    ),
-    Voice(
-        id="axlOaUiFyOZhy4nv",
-        provider=Provider.GRADIUM,
-        name="Leo",
-        languages={"fr"},
-    ),
-    # German
-    Voice(
-        id="-uP9MuGtBqAvEyxI",
-        provider=Provider.GRADIUM,
-        name="Mia",
-        languages={"de"},
-    ),
-    Voice(
-        id="0y1VZjPabOBU3rWy",
-        provider=Provider.GRADIUM,
-        name="Maximilian",
-        languages={"de"},
-    ),
-    # Spanish
-    Voice(
-        id="B36pbz5_UoWn4BDl",
-        provider=Provider.GRADIUM,
-        name="Valentina",
-        languages={"es"},
-    ),
-    Voice(
-        id="xu7iJ_fn2ElcWp2s",
-        provider=Provider.GRADIUM,
-        name="Sergio",
-        languages={"es"},
-    ),
-    # Portuguese (Brazilian)
-    Voice(
-        id="pYcGZz9VOo4n2ynh",
-        provider=Provider.GRADIUM,
-        name="Alice",
-        languages={"pt"},
-    ),
-    Voice(
-        id="M-FvVo9c-jGR4PgP",
-        provider=Provider.GRADIUM,
-        name="Davi",
-        languages={"pt"},
-    ),
+        name=name,
+        description=description,
+        languages={Language(language)},
+    )
+    for voice_id, name, description, language in [
+        (
+            "NbpkqMVS3CJeq2j8",
+            "Zoey",
+            "Playful, upbeat and Gen Z energy voice with a standard American accent. Perfect for engaging conversations!",
+            "en",
+        ),
+        (
+            "cLONiZ4hQ8VpQ4Sz",
+            "Skyler",
+            "Breezy, fun and youthful voice with a standard American accent.",
+            "en",
+        ),
+        (
+            "7aEKz4P1ogZ0UsRP",
+            "Riley",
+            "Sporty, bright and approachable voice with standard American accent. Let's go!",
+            "en",
+        ),
+        (
+            "vtG8ddh4IN32Otad",
+            "Quinn",
+            "Snappy, cool and contemporary voice with standard American accent. Great for conversational use cases.",
+            "en",
+        ),
+        (
+            "4SZHfMpw-p46Ywgs",
+            "Harper",
+            "Modern, confident and friendly voice with a standard American accent.",
+            "en",
+        ),
+        (
+            "6MFfc37kq0sBjBjy",
+            "Sterling",
+            "A warm energetic American adult voice with theatrical flair that makes every sentence feel like the start of something big.",
+            "en",
+        ),
+        (
+            "_6Aslh2DxfmnRLmP",
+            "Russell",
+            "A high-energy American adult voice that pushes and encourages with the intensity of someone who genuinely believes in you.",
+            "en",
+        ),
+        (
+            "r2sIQdqqoqgRJuXw",
+            "Marcus",
+            "A high-energy resonant American adult voice that speaks with the unshakeable conviction of someone who's already sold you.",
+            "en",
+        ),
+        (
+            "POBHtemksfWQbng0",
+            "Garrett",
+            "A smooth low-pitched American adult voice with the easy confidence and quiet magnetism of someone who never has to raise his voice.",
+            "en",
+        ),
+        (
+            "KUpE0JVhjiIzp1Fk",
+            "Damon",
+            "A bright American adult voice that lights up with the unfiltered excitement of someone explaining their favorite obsession.",
+            "en",
+        ),
+        (
+            "4rdlkbxRv4m3UQTW",
+            "Tilly",
+            "A bright, welcoming British English adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "en",
+        ),
+        (
+            "uem82D50GRv2Dwma",
+            "Pippa",
+            "A confident, upbeat British English adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "en",
+        ),
+        (
+            "6PWnV0Nq4wu7RVBT",
+            "Maeve",
+            "A sparky, attentive British English adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "en",
+        ),
+        (
+            "gDT1nz7Ie36ZhL-C",
+            "Imogen",
+            "A bubbly, friendly British English adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "en",
+        ),
+        (
+            "dME3IWyZBvmh1n1q",
+            "Toby",
+            "A sparky, attentive British English adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "en",
+        ),
+        (
+            "CF0NgaMwHMMrHZn0",
+            "Reuben",
+            "A confident, upbeat British English adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "en",
+        ),
+        (
+            "s_k3kLBbgeK9-xUg",
+            "Freddie",
+            "An easy-going, friendly British English adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "en",
+        ),
+        (
+            "kfzLbcdE_yXgLeUI",
+            "Archie",
+            "A bright, welcoming British English adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "en",
+        ),
+        (
+            "jBULVCDhf05tOJN5",
+            "Romane",
+            "A confident, upbeat French adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "fr",
+        ),
+        (
+            "J8c9KBRYAGGYwjns",
+            "Margaux",
+            "A bright, welcoming French adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "fr",
+        ),
+        (
+            "3hQIj8JOo7bU31Jw",
+            "Garance",
+            "A vibrant, engaging French adult voice that makes every explanation feel personal. Built for product guides and walk-through assistants.",
+            "fr",
+        ),
+        (
+            "P4GqVY98hjQSvkiu",
+            "Capucine",
+            "A bubbly, friendly French adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "fr",
+        ),
+        (
+            "6oIkS98REoVZ1dEw",
+            "Apolline",
+            "A sparky, attentive French adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "fr",
+        ),
+        (
+            "biuhvu17TxVKOcyy",
+            "Marius",
+            "An energetic, well-poised French adult voice with the confident assurance of a natural closer. Ideal for sales pitches and high-conviction content.",
+            "fr",
+        ),
+        (
+            "YKeBw3OV1RgpdhLh",
+            "Jules",
+            "A lively, expressive French adult voice that lights up around topics it loves. Great for animated recommendations and high-energy dialogue.",
+            "fr",
+        ),
+        (
+            "iEu63s1rhn_kegTr",
+            "Gaspard",
+            "A warm, grounded French adult voice with the easy confidence of a trusted friend. Ideal for friendly assistants and peer-to-peer dialogue.",
+            "fr",
+        ),
+        (
+            "25AzBFyp6svYnJsj",
+            "Damien",
+            "An intense, engaging French adult voice that pushes with real conviction. Built for coaching and motivational content.",
+            "fr",
+        ),
+        (
+            "Tek4tJXiX6_yvXq7",
+            "Augustin",
+            "A curious, animated French adult voice that lights up when sharing an unexpected fact. Perfect for geeky explainers and trivia-driven dialogue.",
+            "fr",
+        ),
+        (
+            "mmLFHtCjt_6jw0vT",
+            "Roxane",
+            "A calm, attentive Québécois French adult voice that gets to the point with a smile. Ideal for efficient customer support and helpful voice assistants.",
+            "fr",
+        ),
+        (
+            "sX0PcxM_Ie2ctBGH",
+            "Frédérique",
+            "A confident, upbeat Québécois French adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "fr",
+        ),
+        (
+            "sBLwTd5womVX8JOw",
+            "Maude",
+            "A bubbly, reassuring Québécois French (FR-CA) adult voice that puts callers instantly at ease. Great for onboarding assistants and step-by-step guidance.",
+            "fr",
+        ),
+        (
+            "SqFfhmAgR2XdN83R",
+            "Svenja",
+            "A confident, upbeat German adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "de",
+        ),
+        (
+            "6XwZeudK_gn719g5",
+            "Ronja",
+            "A vibrant, engaging German adult voice that makes every explanation feel personal. Built for product guides and walk-through assistants.",
+            "de",
+        ),
+        (
+            "nMNZ0sOWZVbKyjaI",
+            "Mila",
+            "A bright, welcoming German adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "de",
+        ),
+        (
+            "yHyu3PRfSmmiL2a4",
+            "Marlene",
+            "A bubbly, friendly German adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "de",
+        ),
+        (
+            "p6Uutkyi3j2iNAUu",
+            "Annika",
+            "A sparky, attentive German adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "de",
+        ),
+        (
+            "Kf5m22mROozoMWj3",
+            "Mats",
+            "A sparky, attentive German adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "de",
+        ),
+        (
+            "20zdyYrQPzKlCwkk",
+            "Leon",
+            "A bright, welcoming German adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "de",
+        ),
+        (
+            "yyS1KYWs6mXoEw7D",
+            "Henrik",
+            "An easy-going, friendly German adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "de",
+        ),
+        (
+            "lbpBQTVCOcOHJ5zS",
+            "Erik",
+            "A confident, upbeat German adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "de",
+        ),
+        (
+            "3ZKKapPOvuWFcw9f",
+            "Anton",
+            "A vibrant, engaging German adult voice that makes every explanation feel personal. Built for product guides and walk-through assistants.",
+            "de",
+        ),
+        (
+            "TXbEUrHXNFlYBBKb",
+            "Sophie",
+            "A warm, easy-going Austrian German adult voice with effortless local charm. Perfect for friendly assistants and welcoming customer support.",
+            "de",
+        ),
+        (
+            "Xtp0vUDvtAfi1xkH",
+            "Stefan",
+            "A composed, welcoming Austrian German adult voice with the calm reliability of a trusted advisor. Ideal for professional support and onboarding interactions.",
+            "de",
+        ),
+        (
+            "BPHlOW9jPs79KtW4",
+            "Maxi",
+            "A playful, expressive Austrian German adult voice that brings warmth and humor to every interaction. Great for engaging assistants and conversational AI.",
+            "de",
+        ),
+        (
+            "m3lIeODdTQ3bOh4z",
+            "Vega",
+            "A sparky, attentive Peninsular Spanish adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "es",
+        ),
+        (
+            "hP6WA-7ybEGApJ68",
+            "Paula",
+            "A bubbly, friendly Peninsular Spanish adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "es",
+        ),
+        (
+            "A3UKMLXQUzknYpQa",
+            "Lucia",
+            "A bright, welcoming Peninsular Spanish adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "es",
+        ),
+        (
+            "9UogMEa01dHR9Xbc",
+            "Aitana",
+            "A confident, upbeat Peninsular Spanish adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "es",
+        ),
+        (
+            "sVLgzKMqaptUdaY8",
+            "Mateo",
+            "A sparky, attentive Peninsular Spanish adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "es",
+        ),
+        (
+            "jvPx8j8zLGQ3utZz",
+            "Marcos",
+            "A confident, upbeat Peninsular Spanish adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "es",
+        ),
+        (
+            "t-_TS1e-0GzDAX02",
+            "Iker",
+            "An easy-going, friendly Peninsular Spanish adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "es",
+        ),
+        (
+            "ZeL1KGaZ4BZ2w0Np",
+            "Alvaro",
+            "A bright, welcoming Peninsular Spanish adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "es",
+        ),
+        (
+            "4NLtOv1m0azv9rGL",
+            "Camila",
+            "A warm, welcoming Mexican Spanish adult voice with the easy hospitality of a great host. Perfect for greeting customers and friendly front-line support.",
+            "es",
+        ),
+        (
+            "VDwnGxAo68C8U8vC",
+            "Ximena",
+            "A playful, expressive Mexican Spanish adult voice that turns everyday moments into stories. Great for engaging assistants and personable conversational AI.",
+            "es",
+        ),
+        (
+            "s58clrg2fe0MO7Y-",
+            "Regina",
+            "A confident, upbeat Mexican Spanish adult voice with the natural assurance of a closer. Ideal for proactive assistants and sales-led customer interactions.",
+            "es",
+        ),
+        (
+            "yHToO6ssaQHz5kIP",
+            "Santiago",
+            "A warm, welcoming Mexican Spanish adult voice with calm professional reassurance. Perfect for greeting customers and friendly front-line support.",
+            "es",
+        ),
+        (
+            "n7vovxcDTVG4gClo",
+            "Diego",
+            "A lively, expressive Mexican Spanish adult voice with natural storytelling flair. Great for animated assistants and engaging conversational AI.",
+            "es",
+        ),
+        (
+            "tWll9uiMafMXfOGw",
+            "Emiliano",
+            "An assured, upbeat Mexican Spanish adult voice with a touch of humor. Built for confident product guides and proactive customer success.",
+            "es",
+        ),
+        (
+            "YnWEONxJy7ptGhfb",
+            "Yara",
+            "A vibrant, engaging Brazilian Portuguese adult voice that makes every explanation feel personal. Built for product guides and walk-through assistants.",
+            "pt",
+        ),
+        (
+            "fd7e1fLVAAJzzs8P",
+            "Manuela",
+            "A confident, upbeat Brazilian Portuguese adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "pt",
+        ),
+        (
+            "DUFZMTh4n-53Ly9O",
+            "Larissa",
+            "A bubbly, friendly Brazilian Portuguese adult voice that puts callers instantly at ease. Great for onboarding assistants and warm concierge interactions.",
+            "pt",
+        ),
+        (
+            "ycGyxoEy9wLaX11R",
+            "Helena",
+            "A sparky, attentive Brazilian Portuguese adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "pt",
+        ),
+        (
+            "uCqxlQCKi8sPHwG2",
+            "Bianca",
+            "A bright, welcoming Brazilian Portuguese adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "pt",
+        ),
+        (
+            "AByHrwi1S-yLzW-s",
+            "Mateus",
+            "A bright, welcoming Brazilian Portuguese adult voice with the warmth of a great receptionist. Perfect for greeting customers and friendly front-line support.",
+            "pt",
+        ),
+        (
+            "NuUr_x5V90hSHzCJ",
+            "Davi",
+            "A confident, upbeat Brazilian Portuguese adult voice with infectious energy. Perfect for proactive assistants and motivating customer success calls.",
+            "pt",
+        ),
+        (
+            "Qit9Oc9fEO9yXsVw",
+            "Caio",
+            "A sparky, attentive Brazilian Portuguese adult voice that gets to the point with a smile. Ideal for fast, efficient customer support and helpful voice assistants.",
+            "pt",
+        ),
+    ]
 ]
 
 __all__ = ["GRADIUM_VOICES"]

--- a/src/celeste/modalities/audio/providers/openai/voices.py
+++ b/src/celeste/modalities/audio/providers/openai/voices.py
@@ -4,134 +4,35 @@ from celeste.core import Provider
 
 from ...voices import Voice
 
-# Model-specific voice lists
-# tts-1 supports: alloy, ash, coral, echo, fable, nova, onyx, sage, shimmer (9 voices, NO ballad)
-TTS1_VOICES = [
+# Snapshot 2026-07-14: 13 built-in voices.
+# OpenAI publishes previews, but no text descriptions.
+# Source: https://platform.openai.com/docs/api-reference/audio/createSpeech
+OPENAI_VOICES = [
     Voice(
-        id="alloy",
+        id=voice_id,
         provider=Provider.OPENAI,
-        name="Alloy",
-        languages=set(),  # OpenAI voices support multiple languages but don't specify per-voice
-    ),
-    Voice(
-        id="ash",
-        provider=Provider.OPENAI,
-        name="Ash",
-        languages=set(),
-    ),
-    Voice(
-        id="coral",
-        provider=Provider.OPENAI,
-        name="Coral",
-        languages=set(),
-    ),
-    Voice(
-        id="echo",
-        provider=Provider.OPENAI,
-        name="Echo",
-        languages=set(),
-    ),
-    Voice(
-        id="fable",
-        provider=Provider.OPENAI,
-        name="Fable",
-        languages=set(),
-    ),
-    Voice(
-        id="nova",
-        provider=Provider.OPENAI,
-        name="Nova",
-        languages=set(),
-    ),
-    Voice(
-        id="onyx",
-        provider=Provider.OPENAI,
-        name="Onyx",
-        languages=set(),
-    ),
-    Voice(
-        id="sage",
-        provider=Provider.OPENAI,
-        name="Sage",
-        languages=set(),
-    ),
-    Voice(
-        id="shimmer",
-        provider=Provider.OPENAI,
-        name="Shimmer",
-        languages=set(),
-    ),
+        name=voice_id.title(),
+    )
+    for voice_id in (
+        "alloy",
+        "ash",
+        "ballad",
+        "coral",
+        "echo",
+        "fable",
+        "onyx",
+        "nova",
+        "sage",
+        "shimmer",
+        "verse",
+        "marin",
+        "cedar",
+    )
 ]
 
-# tts-1-hd supports same voices as tts-1 (conservative assumption)
-TTS1_HD_VOICES = TTS1_VOICES
-
-# gpt-4o-mini-tts supports all 10 voices including ballad
-GPT4O_MINI_TTS_VOICES = [
-    Voice(
-        id="alloy",
-        provider=Provider.OPENAI,
-        name="Alloy",
-        languages=set(),
-    ),
-    Voice(
-        id="ash",
-        provider=Provider.OPENAI,
-        name="Ash",
-        languages=set(),
-    ),
-    Voice(
-        id="ballad",
-        provider=Provider.OPENAI,
-        name="Ballad",
-        languages=set(),
-    ),
-    Voice(
-        id="coral",
-        provider=Provider.OPENAI,
-        name="Coral",
-        languages=set(),
-    ),
-    Voice(
-        id="echo",
-        provider=Provider.OPENAI,
-        name="Echo",
-        languages=set(),
-    ),
-    Voice(
-        id="fable",
-        provider=Provider.OPENAI,
-        name="Fable",
-        languages=set(),
-    ),
-    Voice(
-        id="nova",
-        provider=Provider.OPENAI,
-        name="Nova",
-        languages=set(),
-    ),
-    Voice(
-        id="onyx",
-        provider=Provider.OPENAI,
-        name="Onyx",
-        languages=set(),
-    ),
-    Voice(
-        id="sage",
-        provider=Provider.OPENAI,
-        name="Sage",
-        languages=set(),
-    ),
-    Voice(
-        id="shimmer",
-        provider=Provider.OPENAI,
-        name="Shimmer",
-        languages=set(),
-    ),
-]
-
-# Union of all voices for package-level exports
-OPENAI_VOICES = GPT4O_MINI_TTS_VOICES
+TTS1_VOICES = OPENAI_VOICES
+TTS1_HD_VOICES = OPENAI_VOICES
+GPT4O_MINI_TTS_VOICES = OPENAI_VOICES
 
 __all__ = [
     "GPT4O_MINI_TTS_VOICES",

--- a/src/celeste/modalities/audio/voices.py
+++ b/src/celeste/modalities/audio/voices.py
@@ -13,6 +13,7 @@ class Voice(BaseModel):
     id: str
     provider: Provider
     name: str
+    description: str | None = None
     languages: set[Language] = Field(default_factory=set)
 
 

--- a/tests/unit_tests/test_audio_voices.py
+++ b/tests/unit_tests/test_audio_voices.py
@@ -1,0 +1,54 @@
+import pytest
+
+from celeste.core import Provider
+from celeste.modalities.audio.constraints import VoiceConstraint
+from celeste.modalities.audio.providers.elevenlabs.voices import ELEVENLABS_VOICES
+from celeste.modalities.audio.providers.google.voices import GOOGLE_VOICES
+from celeste.modalities.audio.providers.gradium.voices import GRADIUM_VOICES
+from celeste.modalities.audio.providers.openai.voices import OPENAI_VOICES
+from celeste.modalities.audio.voices import Voice
+
+
+def test_voice_description_defaults_to_none() -> None:
+    voice = Voice(id="voice-id", provider=Provider.OPENAI, name="Voice")
+
+    assert voice.description is None
+
+
+@pytest.mark.parametrize(
+    ("voices", "expected_count"),
+    [
+        (GRADIUM_VOICES, 66),
+        (ELEVENLABS_VOICES, 21),
+        (GOOGLE_VOICES, 30),
+        (OPENAI_VOICES, 13),
+    ],
+)
+def test_voice_catalogs_are_complete_and_unique(
+    voices: list[Voice], expected_count: int
+) -> None:
+    assert len(voices) == expected_count
+    assert len({voice.id for voice in voices}) == expected_count
+    assert len({voice.name for voice in voices}) == expected_count
+
+
+def test_provider_descriptions_match_published_metadata() -> None:
+    assert all(voice.description for voice in GRADIUM_VOICES)
+    assert all(voice.description for voice in ELEVENLABS_VOICES)
+    assert all(voice.description for voice in GOOGLE_VOICES)
+    assert all(voice.description is None for voice in OPENAI_VOICES)
+
+    assert GRADIUM_VOICES[0].description == (
+        "Playful, upbeat and Gen Z energy voice with a standard American accent. "
+        "Perfect for engaging conversations!"
+    )
+    assert GOOGLE_VOICES[0].name == "Zephyr"
+    assert GOOGLE_VOICES[0].description == "Bright"
+
+
+def test_voice_constraint_still_accepts_name_and_id() -> None:
+    voice = GRADIUM_VOICES[0]
+    constraint = VoiceConstraint(voices=GRADIUM_VOICES)
+
+    assert constraint(voice.name) == voice.id
+    assert constraint(voice.id) == voice.id


### PR DESCRIPTION
## Summary

- add an optional `description` field to `Voice`
- refresh provider catalogs with published metadata for 66 Gradium, 21 ElevenLabs, 30 Google, and 13 OpenAI voices
- preserve existing voice name/id constraint behavior
- leave OpenAI descriptions empty because OpenAI publishes voice previews but no text descriptions

## Why

Consumers need provider-supplied voice context to choose an appropriate voice instead of selecting from names alone.

## Impact

This is backward-compatible: `description` defaults to `None`, and existing voice selection continues to accept both names and IDs.

## Checks

- `make lint`
- `make typecheck`
- `make test` — 698 passed
- repository pre-commit and pre-push hooks