### PR TITLE
fix(google): replay native tool context across calls

### DIFF
--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -1,7 +1,6 @@
 """Google text client (modality)."""
 
 from typing import Any
-from uuid import uuid4
 
 from celeste.grounding import Grounding
 from celeste.messages import (
@@ -17,6 +16,10 @@ from celeste.providers.google.generate_content.grounding import (
 )
 from celeste.providers.google.generate_content.streaming import (
     GoogleGenerateContentStream as _GoogleGenerateContentStream,
+)
+from celeste.providers.google.generate_content.tools import (
+    needs_native_replay,
+    tool_calls_from_parts,
 )
 from celeste.providers.google.utils import build_media_part
 from celeste.tools import ToolCall, ToolResult
@@ -56,35 +59,18 @@ class GoogleTextStream(_GoogleGenerateContentStream, TextStream):
         self, chunks: list, raw_events: list[dict[str, Any]]
     ) -> list[ToolCall]:
         """Extract tool calls from Google streaming events."""
-        tool_calls: list[ToolCall] = []
-        for event in raw_events:
-            for candidate in event.get("candidates", []):
-                for part in candidate.get("content", {}).get("parts", []):
-                    if "functionCall" in part:
-                        kwargs: dict[str, Any] = {}
-                        if "thoughtSignature" in part:
-                            kwargs["thoughtSignature"] = part["thoughtSignature"]
-                        tool_calls.append(
-                            ToolCall(
-                                id=str(uuid4()),
-                                name=part["functionCall"]["name"],
-                                arguments=part["functionCall"].get("args", {}),
-                                **kwargs,
-                            )
-                        )
-        return tool_calls
+        return tool_calls_from_parts(self._content_parts)
 
     def _aggregate_signature(
         self, chunks: list, raw_events: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Extract thought parts with signatures from Google streaming events."""
-        thought_parts: list[dict[str, Any]] = []
-        for event in raw_events:
-            for candidate in event.get("candidates", []):
-                for part in candidate.get("content", {}).get("parts", []):
-                    if part.get("thought") and "thoughtSignature" in part:
-                        thought_parts.append(part)
-        return thought_parts
+        """Return exact native Parts or signed thought Parts."""
+        parts = self._content_parts
+        if needs_native_replay(parts):
+            return parts
+        return [
+            part for part in parts if part.get("thought") and "thoughtSignature" in part
+        ]
 
 
 class GoogleTextClient(GoogleGenerateContentClient, TextClient):
@@ -133,6 +119,7 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
                         "parts": [
                             {
                                 "functionResponse": {
+                                    "id": msg.tool_call_id,
                                     "name": msg.name,
                                     "response": {"result": tool_result_object(msg)},
                                 }
@@ -143,20 +130,26 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
             else:
                 role = "model" if msg.role == Role.ASSISTANT else msg.role
                 sig_blocks = msg.signature
+                if (
+                    msg.role == Role.ASSISTANT
+                    and sig_blocks
+                    and needs_native_replay(sig_blocks)
+                ):
+                    contents.append({"role": role, "parts": sig_blocks})
+                    continue
                 msg_parts = list(sig_blocks) if sig_blocks else []
                 msg_parts.extend(content_to_parts(msg.content))
                 if msg.tool_calls:
                     for tc in msg.tool_calls:
-                        part: dict[str, Any] = {
-                            "functionCall": {
-                                "name": tc.name,
-                                "args": tc.arguments,
+                        msg_parts.append(
+                            {
+                                "functionCall": {
+                                    "id": tc.id,
+                                    "name": tc.name,
+                                    "args": tc.arguments,
+                                }
                             }
-                        }
-                        thought_sig = getattr(tc, "thoughtSignature", None)
-                        if thought_sig:
-                            part["thoughtSignature"] = thought_sig
-                        msg_parts.append(part)
+                        )
                 contents.append({"role": role, "parts": msg_parts})
 
         result: dict[str, Any] = {"contents": contents}
@@ -187,14 +180,9 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
         if not candidates:
             return None, []
         parts = candidates[0].get("content", {}).get("parts", [])
-        reasoning_parts: list[str] = []
-        signature_blocks: list[dict[str, Any]] = []
-        for p in parts:
-            if p.get("thought"):
-                text = p.get("text", "")
-                if text:
-                    reasoning_parts.append(text)
-                signature_blocks.append(p)
+        thought_parts = [p for p in parts if p.get("thought")]
+        reasoning_parts = [p["text"] for p in thought_parts if p.get("text")]
+        signature_blocks = parts if needs_native_replay(parts) else thought_parts
         text = "\n".join(reasoning_parts) if reasoning_parts else None
         return text, signature_blocks
 
@@ -211,21 +199,7 @@ class GoogleTextClient(GoogleGenerateContentClient, TextClient):
         if not candidates:
             return []
         parts = candidates[0].get("content", {}).get("parts", [])
-        tool_calls: list[ToolCall] = []
-        for p in parts:
-            if "functionCall" in p:
-                kwargs: dict[str, Any] = {}
-                if "thoughtSignature" in p:
-                    kwargs["thoughtSignature"] = p["thoughtSignature"]
-                tool_calls.append(
-                    ToolCall(
-                        id=str(uuid4()),
-                        name=p["functionCall"]["name"],
-                        arguments=p["functionCall"].get("args", {}),
-                        **kwargs,
-                    )
-                )
-        return tool_calls
+        return tool_calls_from_parts(parts)
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/providers/google/generate_content/streaming.py
+++ b/src/celeste/providers/google/generate_content/streaming.py
@@ -19,13 +19,22 @@ class GoogleGenerateContentStream:
     """
 
     _error_type_fields: ClassVar[tuple[str, ...]] = ("status", "code")
+    _content_parts: list[dict[str, Any]]
     _grounding_metadata: list[dict[str, Any]]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        super().__init__(*args, **kwargs)
+        self._content_parts = []
+        self._grounding_metadata = []
+
     def _parse_chunk(self, event_data: dict[str, Any]) -> Any | None:  # noqa: ANN401
-        """Capture grounding metadata before normal chunk filtering."""
-        if not hasattr(self, "_grounding_metadata"):
-            self._grounding_metadata = []
-        for candidate in event_data.get("candidates", []):
+        """Capture native Parts and grounding before normal chunk filtering."""
+        candidates = event_data.get("candidates", [])
+        if candidates:
+            self._content_parts.extend(
+                candidates[0].get("content", {}).get("parts", [])
+            )
+        for candidate in candidates:
             meta = candidate.get("groundingMetadata")
             if isinstance(meta, dict):
                 self._grounding_metadata.append(meta)

--- a/src/celeste/providers/google/generate_content/tools.py
+++ b/src/celeste/providers/google/generate_content/tools.py
@@ -1,10 +1,40 @@
-"""Google GenerateContent API tool mappers."""
+"""Google GenerateContent API tool helpers."""
 
 import warnings
 from typing import Any, ClassVar
 
 from celeste.exceptions import UnsupportedParameterWarning
-from celeste.tools import CodeExecution, Tool, ToolMapper, WebSearch
+from celeste.tools import CodeExecution, Tool, ToolCall, ToolMapper, WebSearch
+
+_NATIVE_REPLAY_PART_KEYS = {
+    "codeExecutionResult",
+    "executableCode",
+    "functionCall",
+    "toolCall",
+    "toolResponse",
+}
+
+
+def needs_native_replay(parts: list[dict[str, Any]]) -> bool:
+    """Return whether Google requires the complete Parts on the next turn."""
+    return any(not _NATIVE_REPLAY_PART_KEYS.isdisjoint(part) for part in parts)
+
+
+def tool_calls_from_parts(parts: list[dict[str, Any]]) -> list[ToolCall]:
+    """Parse Google function-call Parts into canonical tool calls."""
+    tool_calls: list[ToolCall] = []
+    for part in parts:
+        function_call = part.get("functionCall")
+        if not isinstance(function_call, dict):
+            continue
+        tool_calls.append(
+            ToolCall(
+                id=function_call["id"],
+                name=function_call["name"],
+                arguments=function_call.get("args", {}),
+            )
+        )
+    return tool_calls
 
 
 class WebSearchMapper(ToolMapper):
@@ -42,4 +72,10 @@ class CodeExecutionMapper(ToolMapper):
 
 TOOL_MAPPERS: list[ToolMapper] = [WebSearchMapper(), CodeExecutionMapper()]
 
-__all__ = ["TOOL_MAPPERS", "CodeExecutionMapper", "WebSearchMapper"]
+__all__ = [
+    "TOOL_MAPPERS",
+    "CodeExecutionMapper",
+    "WebSearchMapper",
+    "needs_native_replay",
+    "tool_calls_from_parts",
+]

--- a/tests/unit_tests/test_google_native_replay.py
+++ b/tests/unit_tests/test_google_native_replay.py
@@ -1,0 +1,86 @@
+"""Regression coverage for Google native tool transcript replay."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pydantic import SecretStr
+
+from celeste import Model
+from celeste.auth import AuthHeader
+from celeste.core import Provider
+from celeste.modalities.text.io import TextInput
+from celeste.modalities.text.providers.google.client import (
+    GoogleTextClient,
+    GoogleTextStream,
+)
+from celeste.tools import ToolResult
+
+
+async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+async def test_google_stream_replays_native_tool_parts_verbatim() -> None:
+    parts = [
+        {
+            "toolCall": {
+                "toolType": "GOOGLE_SEARCH_WEB",
+                "args": {"queries": ["today's news"]},
+                "id": "search-1",
+            },
+            "thoughtSignature": "search-call-signature",
+        },
+        {
+            "toolResponse": {
+                "toolType": "GOOGLE_SEARCH_WEB",
+                "response": {"search_suggestions": "<div>suggestions</div>"},
+                "id": "search-1",
+            },
+            "thoughtSignature": "search-response-signature",
+        },
+        {
+            "functionCall": {
+                "name": "generate_audio",
+                "args": {"text": "news"},
+                "id": "audio-1",
+            },
+            "thoughtSignature": "audio-call-signature",
+        },
+    ]
+    events: list[dict[str, Any]] = [
+        {"candidates": [{"content": {"parts": [part]}}]} for part in parts
+    ]
+    events[-1]["candidates"][0]["finishReason"] = "STOP"
+    events[-1]["usageMetadata"] = {"totalTokenCount": 3}
+
+    stream = GoogleTextStream(_async_iter(events))
+    async for _ in stream:
+        pass
+
+    output = stream.output
+    assert output.signature == parts
+    assert output.tool_calls[0].id == "audio-1"
+
+    client = GoogleTextClient(
+        model=Model(
+            id="test-model", provider=Provider.GOOGLE, display_name="Test Model"
+        ),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+    request = client._init_request(
+        TextInput(
+            messages=[
+                output.message,
+                ToolResult(
+                    tool_call_id="audio-1",
+                    name="generate_audio",
+                    content="audio-artifact-1",
+                ),
+            ]
+        )
+    )
+
+    assert request["contents"][0] == {"role": "model", "parts": parts}
+    assert request["contents"][1]["parts"][0]["functionResponse"]["id"] == "audio-1"


### PR DESCRIPTION
## Summary

- preserve Google GenerateContent native Parts before generic stream filtering
- replay the exact model transcript and keep provider function-call IDs through tool results
- keep GenerateContent parsing in the Google provider layer with thin text-modality glue

## Tests

- one focused streamed native-tool replay regression test
- full unit suite: 699 passed
- Ruff lint and format checks
- mypy for source and tests
- Bandit security scan