### PR TITLE
fix(mistral): align reasoning constraints and catalog with the live API

### DIFF
--- a/src/celeste/modalities/text/providers/mistral/models.py
+++ b/src/celeste/modalities/text/providers/mistral/models.py
@@ -54,6 +54,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["none", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -70,9 +71,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["none", "minimal", "low", "medium", "high", "xhigh"]
-            ),
+            TextParameter.THINKING_BUDGET: Choice(options=["none", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -89,9 +88,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["none", "minimal", "low", "medium", "high", "xhigh"]
-            ),
+            TextParameter.THINKING_BUDGET: Choice(options=["none", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -108,6 +105,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["none", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -201,22 +199,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="pixtral-large-latest",
-        provider=Provider.MISTRAL,
-        display_name="Pixtral Large",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
-            TextParameter.TOOLS: ToolSupport(tools=[]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
         id="ministral-3b-latest",
         provider=Provider.MISTRAL,
         display_name="Ministral 3B",
@@ -259,18 +241,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="voxtral-mini-2507",
-        provider=Provider.MISTRAL,
-        display_name="Voxtral Mini",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-        },
-    ),
-    Model(
         id="magistral-small-latest",
         provider=Provider.MISTRAL,
         display_name="Magistral Small",
@@ -279,7 +249,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32768, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["none", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
@@ -295,7 +265,6 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32768, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),

--- a/tests/integration_tests/text/test_reasoning.py
+++ b/tests/integration_tests/text/test_reasoning.py
@@ -7,7 +7,7 @@ MODELS: list[tuple[Provider, str, int | str]] = [
     (Provider.ANTHROPIC, "claude-haiku-4-5", 1024),
     (Provider.COHERE, "command-a-plus-05-2026", 1024),
     (Provider.GOOGLE, "gemini-2.5-flash-lite", 1024),
-    (Provider.MISTRAL, "mistral-small-2603", "low"),
+    (Provider.MISTRAL, "mistral-small-2603", "high"),
     (Provider.OPENAI, "gpt-5-nano", "low"),
     (Provider.XAI, "grok-3-mini", "low"),
 ]


### PR DESCRIPTION
## What

Corrects the Mistral text catalog where it diverged from the live API, verified by probing every cataloged Mistral model directly (the API's 400 responses enumerate the accepted `reasoning_effort` values per model; the schema-level API reference lists six values, but per-model acceptance differs).

### Reasoning constraints

Mistral accepts exactly `none` and `high` on reasoning-enabled models:

| Model | Before | After |
|---|---|---|
| `mistral-medium-3-5` | 6-value Choice | `Choice(["none", "high"])` |
| `mistral-small-2603` | 6-value Choice | `Choice(["none", "high"])` |
| `mistral-medium-latest` | missing | `Choice(["none", "high"])` (API supports it) |
| `mistral-small-latest` | missing | `Choice(["none", "high"])` (API supports it) |
| `magistral-small-latest` | token `Range(-1..32768)` | `Choice(["none", "high"])` (effort enum, not a budget) |
| `magistral-medium-latest` | token `Range(-1..32768)` | removed (API: reasoning_effort not enabled) |

### Retired models

`pixtral-large-latest` and `voxtral-mini-2507` are past their retirement date per the [official deprecation table](https://docs.mistral.ai/getting-started/models/models_overview/) and the API now returns `Invalid model` — entries removed.

### Tests

Integration reasoning test pinned to `high` for `mistral-small-2603` — the only reasoning-on level the API accepts (default omits reasoning entirely, which the test asserts against).

## Verification

- 406 unit tests pass
- Live integration: `tests/integration_tests/text/test_reasoning.py` passes against the real API
- Every remaining cataloged Mistral model probed live: constraints match acceptance