### PR TITLE
feat(models): refresh catalogs and provider capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ text   = await celeste.text.generate("Explain quantum computing", model="claude-
 image  = await celeste.images.generate("A serene mountain lake at dawn", model="flux-2-pro")
 speech = await celeste.audio.speak("Welcome to the future", model="eleven_v3")
 video  = await celeste.videos.analyze(video_file, prompt="Summarize this clip", model="gemini-3.1-pro-preview")
-embeddings = await celeste.text.embed(["lorep ipsum", "dolor sit amet"], model="gemini-embedding-001")
+embeddings = await celeste.text.embed(["lorep ipsum", "dolor sit amet"], model="gemini-embedding-2")
 ```
 
 

--- a/src/celeste/io.py
+++ b/src/celeste/io.py
@@ -108,7 +108,7 @@ def get_constraint_input_type(constraint: Constraint) -> InputType | None:
     if artifact_type is not None and artifact_type in INPUT_TYPE_MAPPING:
         return INPUT_TYPE_MAPPING[artifact_type]
 
-    # Fallback: introspect __call__ signature (Str, other constraints)
+    # Otherwise introspect the __call__ signature (Str, other constraints)
     annotations = inspect.get_annotations(constraint.__call__, eval_str=True)
     for param_type in annotations.values():
         result = _extract_input_type(param_type)

--- a/src/celeste/modalities/embeddings/providers/google/models.py
+++ b/src/celeste/modalities/embeddings/providers/google/models.py
@@ -2,8 +2,8 @@
 
 from celeste.constraints import (
     AudiosConstraint,
-    Choice,
     ImagesConstraint,
+    Range,
     VideosConstraint,
 )
 from celeste.core import Modality, Operation, Provider
@@ -13,12 +13,15 @@ from ...parameters import EmbeddingsParameter
 
 MODELS: list[Model] = [
     Model(
-        id="gemini-embedding-001",
+        id="gemini-embedding-2",
         provider=Provider.GOOGLE,
-        display_name="Gemini Embedding 001",
+        display_name="Gemini Embedding 2",
         operations={Modality.EMBEDDINGS: {Operation.EMBED}},
         parameter_constraints={
-            EmbeddingsParameter.DIMENSIONS: Choice(options=[768, 1536, 3072]),
+            EmbeddingsParameter.DIMENSIONS: Range(min=128, max=3072, step=1),
+            EmbeddingsParameter.IMAGE: ImagesConstraint(),
+            EmbeddingsParameter.VIDEO: VideosConstraint(),
+            EmbeddingsParameter.AUDIO: AudiosConstraint(),
         },
     ),
     Model(
@@ -27,7 +30,7 @@ MODELS: list[Model] = [
         display_name="Gemini Embedding 2 Preview",
         operations={Modality.EMBEDDINGS: {Operation.EMBED}},
         parameter_constraints={
-            EmbeddingsParameter.DIMENSIONS: Choice(options=[768, 1536, 3072]),
+            EmbeddingsParameter.DIMENSIONS: Range(min=128, max=3072, step=1),
             EmbeddingsParameter.IMAGE: ImagesConstraint(),
             EmbeddingsParameter.VIDEO: VideosConstraint(),
             EmbeddingsParameter.AUDIO: AudiosConstraint(),

--- a/src/celeste/modalities/images/providers/xai/client.py
+++ b/src/celeste/modalities/images/providers/xai/client.py
@@ -7,6 +7,7 @@ from celeste.parameters import ParameterMapper
 from celeste.providers.xai.images import config
 from celeste.providers.xai.images.client import XAIImagesClient as XAIImagesMixin
 from celeste.types import ImageContent
+from celeste.utils import build_data_url
 
 from ...client import ImagesClient
 from ...io import (
@@ -29,13 +30,7 @@ class XAIImagesClient(XAIImagesMixin, ImagesClient):
         """Initialize request from inputs."""
         request: dict[str, Any] = {"prompt": inputs.prompt}
         if inputs.image is not None:
-            # xAI expects {"image": {"url": "..."}} with URL or data URI
-            if inputs.image.url:
-                request["image"] = {"url": inputs.image.url}
-            else:
-                mime_type = inputs.image.mime_type
-                base64_data = inputs.image.get_base64()
-                request["image"] = {"url": f"data:{mime_type};base64,{base64_data}"}
+            request["image"] = {"url": build_data_url(inputs.image)}
         return request
 
     def _parse_content(

--- a/src/celeste/modalities/text/protocols/chatcompletions/client.py
+++ b/src/celeste/modalities/text/protocols/chatcompletions/client.py
@@ -22,8 +22,16 @@ from celeste.protocols.chatcompletions.tools import (
     parse_tool_calls,
 )
 from celeste.tools import ToolCall, ToolResult
-from celeste.types import DocumentPart, ImagePart, Message, Role, TextContent, TextPart
-from celeste.utils import build_document_data_url, build_image_data_url
+from celeste.types import (
+    DocumentPart,
+    ImagePart,
+    Message,
+    Role,
+    TextContent,
+    TextPart,
+    VideoPart,
+)
+from celeste.utils import build_data_url
 
 from ...client import TextClient
 from ...grounding import map_url_citation_annotations
@@ -43,7 +51,7 @@ def _serialize_content(content: Any) -> Any:
         require_part(
             "Chat Completions",
             part,
-            (TextPart, ImagePart, DocumentPart),
+            (TextPart, ImagePart, VideoPart, DocumentPart),
         )
         if isinstance(part, TextPart):
             items.append({"type": "text", "text": part.text})
@@ -51,14 +59,21 @@ def _serialize_content(content: Any) -> Any:
             items.append(
                 {
                     "type": "image_url",
-                    "image_url": {"url": build_image_data_url(part.image)},
+                    "image_url": {"url": build_data_url(part.image)},
+                }
+            )
+        elif isinstance(part, VideoPart):
+            items.append(
+                {
+                    "type": "video_url",
+                    "video_url": {"url": build_data_url(part.video)},
                 }
             )
         elif isinstance(part, DocumentPart):
             items.append(
                 {
                     "type": "document_url",
-                    "document_url": build_document_data_url(part.document),
+                    "document_url": build_data_url(part.document),
                 }
             )
     return items

--- a/src/celeste/modalities/text/protocols/openresponses/client.py
+++ b/src/celeste/modalities/text/protocols/openresponses/client.py
@@ -26,7 +26,7 @@ from celeste.protocols.openresponses.tools import (
 )
 from celeste.tools import ToolCall, ToolResult
 from celeste.types import DocumentPart, ImagePart, Message, Role, TextContent, TextPart
-from celeste.utils import build_document_data_url, build_image_data_url
+from celeste.utils import build_data_url
 
 from ...client import TextClient
 from ...grounding import map_url_citation_annotations
@@ -44,7 +44,7 @@ def _input_file(document: DocumentArtifact) -> dict[str, Any]:
     return {
         "type": "input_file",
         "filename": document.path.rsplit("/", 1)[-1] if document.path else "document",
-        "file_data": build_document_data_url(document),
+        "file_data": build_data_url(document),
     }
 
 
@@ -62,7 +62,7 @@ def _serialize_content(content: Any) -> Any:
             items.append({"type": "input_text", "text": part.text})
         elif isinstance(part, ImagePart):
             items.append(
-                {"type": "input_image", "image_url": build_image_data_url(part.image)}
+                {"type": "input_image", "image_url": build_data_url(part.image)}
             )
         elif isinstance(part, DocumentPart):
             items.append(_input_file(part.document))

--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -11,7 +11,7 @@ from celeste.constraints import (
 )
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
-from celeste.tools import WebSearch
+from celeste.tools import ToolChoice, WebSearch
 
 from ...parameters import TextParameter
 
@@ -29,7 +29,9 @@ MODELS: list[Model] = [
             ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
@@ -77,6 +79,7 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -93,6 +96,7 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
             TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -109,6 +113,7 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32000),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -125,6 +130,7 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -141,6 +147,7 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -175,41 +182,12 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
             TextParameter.THINKING_LEVEL: Choice(
                 options=["low", "medium", "high", "max"]
             ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
-        },
-    ),
-    Model(
-        id="claude-sonnet-4-20250514",
-        provider=Provider.ANTHROPIC,
-        display_name="Claude Sonnet 4",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
-        },
-    ),
-    Model(
-        id="claude-opus-4-20250514",
-        provider=Provider.ANTHROPIC,
-        display_name="Claude Opus 4",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=32000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.IMAGE: ImagesConstraint(),

--- a/src/celeste/modalities/text/providers/anthropic/parameters.py
+++ b/src/celeste/modalities/text/providers/anthropic/parameters.py
@@ -36,6 +36,17 @@ class TemperatureMapper(_TemperatureMapper):
 
     name = TextParameter.TEMPERATURE
 
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Omit temperature when the model catalog does not support it."""
+        if self._warn_if_unsupported(value, model):
+            return request
+        return super().map(request, value, model)
+
 
 class MaxTokensMapper(_MaxTokensMapper):
     """Map max_tokens to Anthropic's max_tokens parameter."""

--- a/src/celeste/modalities/text/providers/cohere/client.py
+++ b/src/celeste/modalities/text/providers/cohere/client.py
@@ -15,7 +15,7 @@ from celeste.providers.cohere.chat.streaming import (
 )
 from celeste.tools import ToolResult
 from celeste.types import ImagePart, TextContent, TextPart
-from celeste.utils import build_image_data_url
+from celeste.utils import build_data_url
 
 from ...client import TextClient
 from ...io import (
@@ -51,7 +51,7 @@ class CohereTextClient(CohereChatClient, TextClient):
                     items.append(
                         {
                             "type": "image_url",
-                            "image_url": {"url": build_image_data_url(part.image)},
+                            "image_url": {"url": build_data_url(part.image)},
                         }
                     )
             return items

--- a/src/celeste/modalities/text/providers/mistral/models.py
+++ b/src/celeste/modalities/text/providers/mistral/models.py
@@ -169,20 +169,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="labs-devstral-small-2512",
-        provider=Provider.MISTRAL,
-        display_name="Devstral 2 Small",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
         id="pixtral-12b-latest",
         provider=Provider.MISTRAL,
         display_name="Pixtral 12B",

--- a/src/celeste/modalities/text/providers/moonshot/client.py
+++ b/src/celeste/modalities/text/providers/moonshot/client.py
@@ -1,12 +1,15 @@
 """Moonshot text client (modality)."""
 
+from typing import Any
+
 from celeste.parameters import ParameterMapper
 from celeste.providers.moonshot.chat.client import MoonshotChatClient
 from celeste.providers.moonshot.chat.streaming import (
     MoonshotChatStream as _MoonshotChatStream,
 )
-from celeste.types import TextContent
+from celeste.types import Message, Role, TextContent
 
+from ...io import TextInput
 from ...protocols.chatcompletions.client import (
     ChatCompletionsTextClient,
 )
@@ -23,6 +26,19 @@ class MoonshotTextStream(_MoonshotChatStream, _ChatCompletionsTextStream):
 
 class MoonshotTextClient(MoonshotChatClient, ChatCompletionsTextClient):
     """Moonshot text client."""
+
+    def _init_request(self, inputs: TextInput) -> dict[str, Any]:
+        request = super()._init_request(inputs)
+        for source, serialized in zip(
+            inputs.messages or [], request["messages"], strict=False
+        ):
+            if (
+                isinstance(source, Message)
+                and source.role == Role.ASSISTANT
+                and source.reasoning is not None
+            ):
+                serialized["reasoning_content"] = source.reasoning
+        return request
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:

--- a/src/celeste/modalities/text/providers/moonshot/models.py
+++ b/src/celeste/modalities/text/providers/moonshot/models.py
@@ -1,15 +1,17 @@
 """Moonshot models for text modality."""
 
 from celeste.constraints import (
+    Choice,
     ImagesConstraint,
     Range,
     Schema,
     ToolChoiceSupport,
     ToolSupport,
+    VideosConstraint,
 )
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
-from celeste.tools import WebSearch
+from celeste.tools import ToolChoice, WebSearch
 
 from ...parameters import TextParameter
 
@@ -21,11 +23,64 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=65535, step=1),
+            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+        },
+    ),
+    Model(
+        id="kimi-k2.6",
+        provider=Provider.MOONSHOT,
+        display_name="Kimi K2.6",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+        },
+    ),
+    Model(
+        id="kimi-k2.7-code",
+        provider=Provider.MOONSHOT,
+        display_name="Kimi K2.7 Code",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+        },
+    ),
+    Model(
+        id="kimi-k2.7-code-highspeed",
+        provider=Provider.MOONSHOT,
+        display_name="Kimi K2.7 Code Highspeed",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
         },
     ),
     Model(
@@ -39,76 +94,6 @@ MODELS: list[Model] = [
             Parameter.MAX_TOKENS: Range(min=1, max=8192, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="kimi-k2-0905-preview",
-        provider=Provider.MOONSHOT,
-        display_name="Kimi K2 (0905 Preview)",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="kimi-k2-0711-preview",
-        provider=Provider.MOONSHOT,
-        display_name="Kimi K2 (0711 Preview)",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="kimi-k2-turbo-preview",
-        provider=Provider.MOONSHOT,
-        display_name="Kimi K2 Turbo Preview",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="kimi-k2-thinking-turbo",
-        provider=Provider.MOONSHOT,
-        display_name="Kimi K2 Thinking Turbo",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="kimi-k2-thinking",
-        provider=Provider.MOONSHOT,
-        display_name="Kimi K2 Thinking",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
         },

--- a/src/celeste/modalities/text/providers/moonshot/parameters.py
+++ b/src/celeste/modalities/text/providers/moonshot/parameters.py
@@ -1,5 +1,8 @@
 """Moonshot parameter mappers for text."""
 
+from typing import Any
+
+from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.protocols.chatcompletions.parameters import (
     ToolsMapper as _ToolsMapper,
@@ -9,9 +12,13 @@ from celeste.types import TextContent
 
 from ...parameters import TextParameter
 from ...protocols.chatcompletions.parameters import (
-    MaxTokensMapper,
+    MaxTokensMapper as _MaxTokensMapper,
+)
+from ...protocols.chatcompletions.parameters import (
     OutputSchemaMapper,
-    TemperatureMapper,
+)
+from ...protocols.chatcompletions.parameters import (
+    TemperatureMapper as _TemperatureMapper,
 )
 from ...protocols.chatcompletions.parameters import (
     ToolChoiceMapper as _ToolChoiceMapper,
@@ -27,6 +34,23 @@ class ToolsMapper(_ToolsMapper):
 
 class ToolChoiceMapper(_ToolChoiceMapper):
     name = TextParameter.TOOL_CHOICE
+
+
+class TemperatureMapper(_TemperatureMapper):
+    """Map temperature when the model catalog supports it."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        if self._warn_if_unsupported(value, model):
+            return request
+        return super().map(request, value, model)
+
+
+class MaxTokensMapper(_MaxTokensMapper):
+    """Map max_tokens to Moonshot's current field name."""
+
+    field = "max_completion_tokens"
 
 
 MOONSHOT_PARAMETER_MAPPERS: list[ParameterMapper[TextContent]] = [

--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -120,6 +120,23 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="gpt-5.3-codex",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.3 Codex",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["low", "medium", "high", "xhigh"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+        },
+    ),
+    Model(
         id="gpt-5.2-chat-latest",
         provider=Provider.OPENAI,
         display_name="GPT-5.2 Instant",
@@ -296,6 +313,21 @@ MODELS: list[Model] = [
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="gpt-5.5-pro",
+        provider=Provider.OPENAI,
+        display_name="GPT-5.5 Pro",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=False,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(options=["medium", "high", "xhigh"]),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
         },
     ),
     Model(

--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -16,34 +16,6 @@ VEO_SUPPORTED_MIME_TYPES = [
 
 MODELS: list[Model] = [
     Model(
-        id="veo-3.0-generate-001",
-        provider=Provider.GOOGLE,
-        display_name="Veo 3",
-        operations={Modality.VIDEOS: {Operation.GENERATE}},
-        parameter_constraints={
-            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
-            VideoParameter.RESOLUTION: Choice(options=["720p"]),
-            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
-            VideoParameter.FIRST_FRAME: ImageConstraint(
-                supported_mime_types=VEO_SUPPORTED_MIME_TYPES,
-            ),
-        },
-    ),
-    Model(
-        id="veo-3.0-fast-generate-001",
-        provider=Provider.GOOGLE,
-        display_name="Veo 3 Fast",
-        operations={Modality.VIDEOS: {Operation.GENERATE}},
-        parameter_constraints={
-            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
-            VideoParameter.RESOLUTION: Choice(options=["720p"]),
-            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
-            VideoParameter.FIRST_FRAME: ImageConstraint(
-                supported_mime_types=VEO_SUPPORTED_MIME_TYPES
-            ),
-        },
-    ),
-    Model(
         id="veo-3.1-generate-preview",
         provider=Provider.GOOGLE,
         display_name="Veo 3.1 (Preview)",

--- a/src/celeste/modalities/videos/providers/xai/models.py
+++ b/src/celeste/modalities/videos/providers/xai/models.py
@@ -1,6 +1,6 @@
 """xAI models for videos modality."""
 
-from celeste.constraints import Choice, Range
+from celeste.constraints import Choice, ImageConstraint, Range
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
@@ -18,6 +18,21 @@ MODELS: list[Model] = [
                 options=["16:9", "4:3", "1:1", "9:16", "3:4", "3:2", "2:3"]
             ),
             VideoParameter.RESOLUTION: Choice(options=["720p", "480p"]),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+        },
+    ),
+    Model(
+        id="grok-imagine-video-1.5",
+        provider=Provider.XAI,
+        display_name="Grok Imagine Video 1.5",
+        operations={Modality.VIDEOS: {Operation.GENERATE}},
+        parameter_constraints={
+            VideoParameter.DURATION: Range(min=1, max=15),
+            VideoParameter.ASPECT_RATIO: Choice(
+                options=["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
+            ),
+            VideoParameter.RESOLUTION: Choice(options=["480p", "720p", "1080p"]),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
         },
     ),
 ]

--- a/src/celeste/modalities/videos/providers/xai/parameters.py
+++ b/src/celeste/modalities/videos/providers/xai/parameters.py
@@ -8,6 +8,9 @@ from celeste.providers.xai.videos.parameters import (
     DurationMapper as _DurationMapper,
 )
 from celeste.providers.xai.videos.parameters import (
+    FirstFrameMapper as _FirstFrameMapper,
+)
+from celeste.providers.xai.videos.parameters import (
     ResolutionMapper as _ResolutionMapper,
 )
 from celeste.types import VideoContent
@@ -33,10 +36,17 @@ class ResolutionMapper(_ResolutionMapper):
     name = VideoParameter.RESOLUTION
 
 
+class FirstFrameMapper(_FirstFrameMapper):
+    """Map first_frame to xAI's image parameter."""
+
+    name = VideoParameter.FIRST_FRAME
+
+
 XAI_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
     DurationMapper(),
     AspectRatioMapper(),
     ResolutionMapper(),
+    FirstFrameMapper(),
 ]
 
 __all__ = ["XAI_PARAMETER_MAPPERS"]

--- a/src/celeste/parameters.py
+++ b/src/celeste/parameters.py
@@ -1,9 +1,11 @@
 """Parameter system for Celeste."""
 
+import warnings
 from abc import ABC, abstractmethod
 from enum import StrEnum
 from typing import Any, ClassVar, TypedDict
 
+from celeste.exceptions import UnsupportedParameterWarning
 from celeste.models import Model
 
 
@@ -34,6 +36,22 @@ class ParameterMapper[Content](ABC):
     def parse_output(self, content: Content, value: object | None) -> Content:
         """Optionally transform parsed content based on parameter value (default: return unchanged)."""
         return content
+
+    def _warn_if_unsupported(self, value: object, model: Model) -> bool:
+        """Warn when a constrained model does not support this parameter."""
+        if (
+            value is None
+            or not model.parameter_constraints
+            or self.name in model.parameter_constraints
+        ):
+            return False
+        warnings.warn(
+            f"Parameter '{self.name}' is not supported by model "
+            f"'{model.id}' and will be ignored.",
+            UnsupportedParameterWarning,
+            stacklevel=5,
+        )
+        return True
 
     def _validate_value(self, value: Any, model: Model) -> Any:  # noqa: ANN401
         """Validate parameter value using model constraint if present, otherwise pass through."""

--- a/src/celeste/providers/google/auth.py
+++ b/src/celeste/providers/google/auth.py
@@ -68,6 +68,8 @@ class GoogleADC(Authentication):
         """Return the Vertex AI base URL for the configured location."""
         if self.location == "global":
             return VERTEX_GLOBAL_BASE_URL
+        if self.location in ("us", "eu"):
+            return f"https://aiplatform.{self.location}.rep.googleapis.com"
         return VERTEX_BASE_URL.format(location=self.location)
 
     def build_url(self, vertex_endpoint: str, model_id: str | None = None) -> str:

--- a/src/celeste/providers/google/embeddings/client.py
+++ b/src/celeste/providers/google/embeddings/client.py
@@ -1,5 +1,6 @@
 """Google Embeddings API client mixin."""
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
@@ -53,7 +54,6 @@ class GoogleEmbeddingsClient(APIMixin):
         """Map Gemini Embeddings endpoint to Vertex AI endpoint."""
         mapping: dict[str, str] = {
             config.GoogleEmbeddingsEndpoint.EMBED_CONTENT: config.VertexEmbeddingsEndpoint.EMBED_CONTENT,
-            config.GoogleEmbeddingsEndpoint.BATCH_EMBED_CONTENTS: config.VertexEmbeddingsEndpoint.BATCH_EMBED_CONTENTS,
         }
         vertex_endpoint = mapping.get(gemini_endpoint)
         if vertex_endpoint is None:
@@ -64,7 +64,8 @@ class GoogleEmbeddingsClient(APIMixin):
         """Build full URL based on auth type."""
         if isinstance(self.auth, GoogleADC):
             return self.auth.build_url(
-                self._get_vertex_endpoint(endpoint), model_id=self.model.id
+                self._get_vertex_endpoint(endpoint),
+                model_id=self.model.id,
             )
         return f"{config.BASE_URL}{endpoint.format(model_id=self.model.id)}"
 
@@ -77,33 +78,28 @@ class GoogleEmbeddingsClient(APIMixin):
         **parameters: Any,
     ) -> dict[str, Any]:
         """Make HTTP request to embeddings endpoint."""
-        # Vertex :predict expects {"instances": [{"content": "..."}]} format
-        if isinstance(self.auth, GoogleADC):
-            # Check for multimodal parts (inline_data / file_data)
-            parts_to_check: list[dict[str, Any]] = []
-            if "requests" in request_body:
-                for req in request_body["requests"]:
-                    parts_to_check.extend(req["content"]["parts"])
-            else:
-                parts_to_check = request_body["content"]["parts"]
-
-            if any("inline_data" in p or "file_data" in p for p in parts_to_check):
-                msg = (
-                    "Multimodal embeddings (images/videos) are not yet supported "
-                    "via Vertex AI (GoogleADC). Use a Gemini API key instead."
-                )
-                raise ValueError(msg)
-
-            if "requests" in request_body:
-                texts = [
-                    req["content"]["parts"][0]["text"]
-                    for req in request_body["requests"]
-                ]
-            else:
-                texts = [request_body["content"]["parts"][0]["text"]]
-            request_body = {"instances": [{"content": text} for text in texts]}
-
         is_batch = "requests" in request_body
+        if isinstance(self.auth, GoogleADC) and is_batch:
+            shared = {
+                key: value for key, value in request_body.items() if key != "requests"
+            }
+            responses = await asyncio.gather(
+                *(
+                    self._make_request(
+                        shared
+                        | {
+                            key: value
+                            for key, value in request.items()
+                            if key != "model"
+                        },
+                        endpoint=config.GoogleEmbeddingsEndpoint.EMBED_CONTENT,
+                        extra_headers=extra_headers,
+                    )
+                    for request in request_body["requests"]
+                )
+            )
+            return {"embeddings": [response["embedding"] for response in responses]}
+
         endpoint_template = (
             config.GoogleEmbeddingsEndpoint.BATCH_EMBED_CONTENTS
             if is_batch
@@ -112,10 +108,11 @@ class GoogleEmbeddingsClient(APIMixin):
         if endpoint is None:
             endpoint = endpoint_template
 
+        url = self._build_url(endpoint)
         headers = self._json_headers(extra_headers)
 
         response = await self.http_client.post(
-            self._build_url(endpoint),
+            url,
             headers=headers,
             json_body=request_body,
         )
@@ -127,14 +124,8 @@ class GoogleEmbeddingsClient(APIMixin):
         """Extract embedding vectors from response.
 
         Returns list of embedding vectors (already generic - no artifacts needed).
-        Handles both Gemini API and Vertex AI :predict response formats.
+        Handles Gemini API single and batch response formats.
         """
-        # Vertex :predict response
-        if "predictions" in response_data:
-            return [
-                pred["embeddings"]["values"] for pred in response_data["predictions"]
-            ]
-
         # Gemini single embedding response
         if "embedding" in response_data:
             return [response_data["embedding"]["values"]]
@@ -143,7 +134,7 @@ class GoogleEmbeddingsClient(APIMixin):
         if "embeddings" in response_data:
             return [emb["values"] for emb in response_data["embeddings"]]
 
-        msg = "Unexpected response format: missing 'embedding', 'embeddings', or 'predictions' field"
+        msg = "Unexpected response format: missing 'embedding' or 'embeddings' field"
         raise ValueError(msg)
 
     def _parse_usage(

--- a/src/celeste/providers/google/embeddings/config.py
+++ b/src/celeste/providers/google/embeddings/config.py
@@ -13,8 +13,7 @@ class GoogleEmbeddingsEndpoint(StrEnum):
 class VertexEmbeddingsEndpoint(StrEnum):
     """Endpoints for Embeddings on Vertex AI."""
 
-    EMBED_CONTENT = "/v1/projects/{project_id}/locations/{location}/publishers/google/models/{model_id}:predict"
-    BATCH_EMBED_CONTENTS = "/v1/projects/{project_id}/locations/{location}/publishers/google/models/{model_id}:predict"
+    EMBED_CONTENT = "/v1/projects/{project_id}/locations/{location}/publishers/google/models/{model_id}:embedContent"
 
 
 BASE_URL = "https://generativelanguage.googleapis.com"

--- a/src/celeste/providers/google/embeddings/parameters.py
+++ b/src/celeste/providers/google/embeddings/parameters.py
@@ -21,13 +21,10 @@ class OutputDimensionalityMapper(ParameterMapper[EmbeddingsContent]):
         if validated_value is None:
             return request
 
-        # Batch request: add to each individual request
-        if "requests" in request:
-            for req in request["requests"]:
-                req["outputDimensionality"] = validated_value
-        else:
-            # Single request: add at root level
-            request["outputDimensionality"] = validated_value
+        for item in request.get("requests", [request]):
+            item.setdefault("embedContentConfig", {})["outputDimensionality"] = (
+                validated_value
+            )
 
         return request
 

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
-from celeste.utils import build_image_data_url, detect_mime_type
+from celeste.utils import build_data_url, detect_mime_type
 
 from . import config
 
@@ -147,7 +147,7 @@ class OpenAIImagesClient(APIMixin):
         # Non-streaming uses multipart; streaming uses JSON with images array
         if "image" in request_body and hasattr(request_body["image"], "get_base64"):
             artifact = request_body.pop("image")
-            request_body["images"] = [{"image_url": build_image_data_url(artifact)}]
+            request_body["images"] = [{"image_url": build_data_url(artifact)}]
             endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
 
         headers = self._json_headers(extra_headers)

--- a/src/celeste/providers/xai/videos/parameters.py
+++ b/src/celeste/providers/xai/videos/parameters.py
@@ -1,7 +1,11 @@
 """xAI Videos API parameter mappers."""
 
-from celeste.parameters import FieldMapper
+from typing import Any
+
+from celeste.models import Model
+from celeste.parameters import FieldMapper, ParameterMapper
 from celeste.types import VideoContent
+from celeste.utils import build_data_url
 
 
 class DurationMapper(FieldMapper[VideoContent]):
@@ -22,8 +26,26 @@ class ResolutionMapper(FieldMapper[VideoContent]):
     field = "resolution"
 
 
+class FirstFrameMapper(ParameterMapper[VideoContent]):
+    """Map an image-to-video first frame to xAI's image field."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform first_frame into the provider request."""
+        if self._warn_if_unsupported(value, model):
+            return request
+
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        request["image"] = {"url": build_data_url(validated_value)}
+        return request
+
+
 __all__ = [
     "AspectRatioMapper",
     "DurationMapper",
+    "FirstFrameMapper",
     "ResolutionMapper",
 ]

--- a/src/celeste/utils/__init__.py
+++ b/src/celeste/utils/__init__.py
@@ -2,15 +2,13 @@
 
 from celeste.utils.image import get_image_dimensions
 from celeste.utils.mime import (
-    build_document_data_url,
-    build_image_data_url,
+    build_data_url,
     detect_mime_type,
     detect_mime_type_from_path,
 )
 
 __all__ = [
-    "build_document_data_url",
-    "build_image_data_url",
+    "build_data_url",
     "detect_mime_type",
     "detect_mime_type_from_path",
     "get_image_dimensions",

--- a/src/celeste/utils/mime.py
+++ b/src/celeste/utils/mime.py
@@ -1,8 +1,10 @@
 """MIME type detection utilities."""
 
+import base64
+
 import filetype
 
-from celeste.artifacts import DocumentArtifact, ImageArtifact
+from celeste.artifacts import Artifact
 from celeste.mime_types import (
     AudioMimeType,
     DocumentMimeType,
@@ -71,42 +73,22 @@ def detect_mime_type_from_path(path: str) -> MimeType | None:
     return None
 
 
-def build_image_data_url(img: ImageArtifact) -> str:
-    """Build a data URL from an ImageArtifact.
+def build_data_url(artifact: Artifact) -> str:
+    """Return a remote URL or encode local artifact content as a data URL."""
+    if artifact.url and not artifact.data and not artifact.path:
+        return artifact.url
 
-    For images with only a URL (no data or path), returns the URL directly.
-    For images with data or path, builds a data URL with MIME type detection.
-    """
-
-    if img.url and not img.data and not img.path:
-        return img.url
-
-    image_bytes = img.get_bytes()
-    mime = img.mime_type or detect_mime_type(image_bytes)
-    mime_str = mime.value if mime else ""
-
-    return f"data:{mime_str};base64,{img.get_base64()}"
-
-
-def build_document_data_url(doc: DocumentArtifact) -> str:
-    """Build a data URL from a DocumentArtifact.
-
-    For documents with only a URL (no data or path), returns the URL directly.
-    For documents with data or path, builds a data URL with MIME type detection.
-    """
-    if doc.url and not doc.data and not doc.path:
-        return doc.url
-
-    doc_bytes = doc.get_bytes()
-    mime = doc.mime_type or detect_mime_type(doc_bytes)
-    mime_str = mime.value if mime else "application/pdf"
-
-    return f"data:{mime_str};base64,{doc.get_base64()}"
+    data = artifact.get_bytes()
+    mime = artifact.mime_type or detect_mime_type(data)
+    if mime is None:
+        msg = "Artifact MIME type must be specified or detectable"
+        raise ValueError(msg)
+    encoded = base64.b64encode(data).decode("utf-8")
+    return f"data:{mime.value};base64,{encoded}"
 
 
 __all__ = [
-    "build_document_data_url",
-    "build_image_data_url",
+    "build_data_url",
     "detect_mime_type",
     "detect_mime_type_from_path",
 ]

--- a/tests/integration_tests/embeddings/test_embed.py
+++ b/tests/integration_tests/embeddings/test_embed.py
@@ -4,7 +4,7 @@ from celeste import Modality, Provider, create_client
 from celeste.modalities.embeddings import EmbeddingsOutput
 from celeste.providers.google.auth import GoogleADC
 
-MODEL = "gemini-embedding-001"
+MODEL = "gemini-embedding-2"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/embeddings/test_embed_media.py
+++ b/tests/integration_tests/embeddings/test_embed_media.py
@@ -5,7 +5,7 @@ from celeste.artifacts import ImageArtifact
 from celeste.modalities.embeddings import EmbeddingsOutput
 from celeste.providers.google.auth import GoogleADC
 
-MODEL = "gemini-embedding-2-preview"
+MODEL = "gemini-embedding-2"
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ async def test_embed_text_and_image(square_image: ImageArtifact) -> None:
     assert isinstance(response.content[0], float)
 
 
-async def test_vertex_rejects_multimodal(square_image: ImageArtifact) -> None:
+async def test_vertex_embeds_multimodal(square_image: ImageArtifact) -> None:
     client = create_client(
         modality=Modality.EMBEDDINGS,
         provider=Provider.GOOGLE,
@@ -61,5 +61,8 @@ async def test_vertex_rejects_multimodal(square_image: ImageArtifact) -> None:
         auth=GoogleADC(),
     )
 
-    with pytest.raises(ValueError, match="not yet supported via Vertex AI"):
-        await client.embed(images=square_image)
+    response = await client.embed(images=square_image)
+
+    assert isinstance(response, EmbeddingsOutput)
+    assert response.content
+    assert isinstance(response.content[0], float)

--- a/tests/integration_tests/images/test_generate.py
+++ b/tests/integration_tests/images/test_generate.py
@@ -34,7 +34,6 @@ async def test_generate(
 @pytest.mark.parametrize(
     ("model", "parameters"),
     [
-        ("imagen-4.0-fast-generate-001", {"num_images": 1}),
         ("gemini-2.5-flash-image", {}),
     ],
 )

--- a/tests/integration_tests/text/test_analyze.py
+++ b/tests/integration_tests/text/test_analyze.py
@@ -34,6 +34,7 @@ CASES = [
     (Provider.OPENAI, "gpt-4o-mini", "test_document", "document"),
     (Provider.GOOGLE, "gemini-2.5-flash-lite", "test_audio", "audio"),
     (Provider.GOOGLE, "gemini-2.5-flash-lite", "test_video", "video"),
+    (Provider.MOONSHOT, "kimi-k2.6", "test_video", "video"),
 ]
 
 

--- a/tests/integration_tests/text/test_generate.py
+++ b/tests/integration_tests/text/test_generate.py
@@ -12,7 +12,7 @@ MODELS = [
     (Provider.GROQ, "llama-3.1-8b-instant"),
     (Provider.HUGGINGFACE, "Qwen/Qwen3-4B-Instruct-2507"),
     (Provider.MISTRAL, "mistral-tiny"),
-    (Provider.MOONSHOT, "kimi-k2-0711-preview"),
+    (Provider.MOONSHOT, "kimi-k2.6"),
     (Provider.OPENAI, "gpt-4o-mini"),
     (Provider.XAI, "grok-3-mini"),
 ]

--- a/tests/integration_tests/text/test_tools.py
+++ b/tests/integration_tests/text/test_tools.py
@@ -8,7 +8,6 @@ WEB_SEARCH_MODELS = [
     (Provider.ANTHROPIC, "claude-haiku-4-5"),
     (Provider.GOOGLE, "gemini-2.5-flash-lite"),
     (Provider.GROQ, "openai/gpt-oss-20b"),
-    (Provider.MOONSHOT, "kimi-k2-0711-preview"),
     (Provider.OPENAI, "gpt-4o-mini"),
     (Provider.XAI, "grok-4.20-0309-non-reasoning"),
 ]
@@ -20,7 +19,7 @@ FUNCTION_TOOL_MODELS = [
     (Provider.GROQ, "llama-3.1-8b-instant", False),
     (Provider.HUGGINGFACE, "Qwen/Qwen3-4B-Instruct-2507", False),
     (Provider.MISTRAL, "mistral-tiny", True),
-    (Provider.MOONSHOT, "kimi-k2-0711-preview", True),
+    (Provider.MOONSHOT, "kimi-k2.6", False),
     (Provider.OPENAI, "gpt-4o-mini", True),
     (Provider.XAI, "grok-3-mini", False),
 ]

--- a/tests/integration_tests/videos/test_generate.py
+++ b/tests/integration_tests/videos/test_generate.py
@@ -5,7 +5,6 @@ import pytest
 from celeste import Modality, Provider, create_client
 from celeste.artifacts import VideoArtifact
 from celeste.modalities.videos import VideoOutput, VideoUsage
-from celeste.providers.google.auth import GoogleADC
 
 pytestmark = pytest.mark.slow
 
@@ -14,7 +13,7 @@ pytestmark = pytest.mark.slow
     ("provider", "model", "parameters"),
     [
         (Provider.OPENAI, "sora-2", {"duration": 4, "resolution": "720p"}),
-        (Provider.GOOGLE, "veo-3.0-fast-generate-001", {"duration": 4}),
+        (Provider.GOOGLE, "veo-3.1-fast-generate-preview", {"duration": 4}),
         (
             Provider.BYTEPLUS,
             "seedance-1-0-pro-250528",
@@ -34,18 +33,3 @@ async def test_generate(
     assert isinstance(response.content, VideoArtifact)
     assert response.content.has_content
     assert isinstance(response.usage, VideoUsage)
-
-
-async def test_vertex_generate() -> None:
-    client = create_client(
-        modality=Modality.VIDEOS,
-        provider=Provider.GOOGLE,
-        model="veo-3.0-fast-generate-001",
-        auth=GoogleADC(location="us-central1"),
-    )
-
-    response = await client.generate(prompt="A cat walking", duration=4)
-
-    assert isinstance(response, VideoOutput)
-    assert isinstance(response.content, VideoArtifact)
-    assert response.content.has_content

--- a/tests/unit_tests/test_artifacts.py
+++ b/tests/unit_tests/test_artifacts.py
@@ -18,6 +18,7 @@ from celeste.mime_types import (
     ImageMimeType,
     VideoMimeType,
 )
+from celeste.utils import build_data_url
 
 
 @pytest.mark.parametrize(
@@ -63,6 +64,11 @@ def test_get_bytes_prefers_data_then_reads_path(tmp_path: Path) -> None:
 def test_get_bytes_requires_local_content(artifact: Artifact) -> None:
     with pytest.raises(ValueError, match="data or path"):
         artifact.get_bytes()
+
+
+def test_build_data_url_requires_mime_type() -> None:
+    with pytest.raises(ValueError, match="MIME type"):
+        build_data_url(Artifact(data=b"unknown"))
 
 
 def test_data_json_and_base64_round_trip() -> None:

--- a/tests/unit_tests/test_embeddings_multimodal.py
+++ b/tests/unit_tests/test_embeddings_multimodal.py
@@ -1,5 +1,9 @@
 """Unit tests for Google embeddings multimodal request building (no network)."""
 
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
 from pydantic import SecretStr
 
 from celeste import Model
@@ -9,11 +13,12 @@ from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import AudioMimeType, ImageMimeType, VideoMimeType
 from celeste.modalities.embeddings.io import EmbeddingsInput
 from celeste.modalities.embeddings.providers.google.client import GoogleEmbeddingsClient
+from celeste.providers.google.auth import GoogleADC
 
 _MODEL = Model(
-    id="gemini-embedding-2-preview",
+    id="embedding-test",
     provider=Provider.GOOGLE,
-    display_name="Gemini Embedding 2 Preview",
+    display_name="Embedding test",
     operations={Modality.EMBEDDINGS: {Operation.EMBED}},
 )
 
@@ -37,22 +42,74 @@ def _make_client() -> GoogleEmbeddingsClient:
 
 def test_text_only_single() -> None:
     client = _make_client()
-    request = client._init_request(EmbeddingsInput(text="hello"))
+    request = client._build_request(EmbeddingsInput(text="hello"), dimensions=256)
 
     assert "content" in request
     assert request["content"]["parts"] == [{"text": "hello"}]
+    assert request["embedContentConfig"] == {"outputDimensionality": 256}
     assert "requests" not in request
 
 
 def test_text_only_batch() -> None:
     client = _make_client()
-    request = client._init_request(EmbeddingsInput(text=["a", "b"]))
+    request = client._build_request(EmbeddingsInput(text=["a", "b"]), dimensions=512)
 
     assert "requests" in request
     assert len(request["requests"]) == 2
     assert request["requests"][0]["content"]["parts"] == [{"text": "a"}]
     assert request["requests"][1]["content"]["parts"] == [{"text": "b"}]
-    assert request["requests"][0]["model"] == "models/gemini-embedding-2-preview"
+    assert request["requests"][0]["model"] == "models/embedding-test"
+    assert all(
+        item["embedContentConfig"] == {"outputDimensionality": 512}
+        for item in request["requests"]
+    )
+
+
+def _make_adc_client() -> GoogleEmbeddingsClient:
+    return GoogleEmbeddingsClient(
+        model=_MODEL,
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="test-project"),
+    )
+
+
+def test_adc_accepts_single_item_list() -> None:
+    request = _make_adc_client()._init_request(EmbeddingsInput(text=["hello"]))
+
+    assert request == {"content": {"parts": [{"text": "hello"}]}}
+
+
+async def test_adc_sends_batch_as_single_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _make_adc_client()
+    request = client._build_request(
+        EmbeddingsInput(text=["hello", "world"]), dimensions=128
+    )
+    post = AsyncMock(
+        side_effect=[
+            httpx.Response(200, json={"embedding": {"values": [1.0]}}),
+            httpx.Response(200, json={"embedding": {"values": [2.0]}}),
+        ]
+    )
+    monkeypatch.setattr(GoogleADC, "get_headers", lambda self: {})
+    monkeypatch.setattr(client.http_client, "post", post)
+
+    response = await client._make_request(request)
+
+    assert response == {
+        "embeddings": [{"values": [1.0]}, {"values": [2.0]}],
+    }
+    assert [call.kwargs["json_body"] for call in post.await_args_list] == [
+        {
+            "content": {"parts": [{"text": "hello"}]},
+            "embedContentConfig": {"outputDimensionality": 128},
+        },
+        {
+            "content": {"parts": [{"text": "world"}]},
+            "embedContentConfig": {"outputDimensionality": 128},
+        },
+    ]
 
 
 def test_single_image() -> None:

--- a/tests/unit_tests/test_google_tools_mapper.py
+++ b/tests/unit_tests/test_google_tools_mapper.py
@@ -33,7 +33,7 @@ def _map_tools(tools: list[ToolDefinition]) -> dict[str, Any]:
     return _MAPPER.map({}, tools, _MODEL)
 
 
-def test_maps_to_parameters_json_schema_not_legacy_parameters() -> None:
+def test_maps_to_parameters_json_schema() -> None:
     fn = _map(
         {
             "name": "example",

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -4,16 +4,19 @@ import pytest
 from pydantic import BaseModel
 
 from celeste.artifacts import ImageArtifact
-from celeste.exceptions import ValidationError
+from celeste.constraints import Range
+from celeste.exceptions import UnsupportedParameterWarning, ValidationError
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.google import parameters as google_images
 from celeste.modalities.text.parameters import TextParameter
 from celeste.modalities.text.protocols.chatcompletions import parameters as chat
 from celeste.modalities.text.providers.anthropic import parameters as anthropic
 from celeste.modalities.text.providers.google import parameters as google_text
+from celeste.modalities.text.providers.moonshot import parameters as moonshot
 from celeste.modalities.text.providers.openai import parameters as openai
 from celeste.modalities.videos.parameters import VideoParameter
 from celeste.modalities.videos.providers.byteplus import parameters as byteplus
+from celeste.modalities.videos.providers.xai import parameters as xai
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
 
@@ -22,7 +25,9 @@ GEMINI = google_images.GEMINI_PARAMETER_MAPPERS
 OPEN = openai.OPENAI_PARAMETER_MAPPERS
 CHAT = chat.CHATCOMPLETIONS_PARAMETER_MAPPERS
 ANTHROPIC = anthropic.ANTHROPIC_PARAMETER_MAPPERS
+MOONSHOT = moonshot.MOONSHOT_PARAMETER_MAPPERS
 BYTEPLUS = byteplus.BYTEPLUS_PARAMETER_MAPPERS
+XAI = xai.XAI_PARAMETER_MAPPERS
 T, IP, V = TextParameter, ImageParameter, VideoParameter
 GC = ("generationConfig",)
 TC = (*GC, "thinkingConfig")
@@ -91,6 +96,10 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (OPEN, T.VERBOSITY, "low", ("text", "verbosity"), "low"),
         (CHAT, T.TEMPERATURE, 0.6, ("temperature",), 0.6),
         (CHAT, T.MAX_TOKENS, 100, ("max_tokens",), 100),
+        (ANTHROPIC, T.TEMPERATURE, 0.3, ("temperature",), 0.3),
+        (MOONSHOT, T.TEMPERATURE, 0.4, ("temperature",), 0.4),
+        (MOONSHOT, T.MAX_TOKENS, 120, ("max_completion_tokens",), 120),
+        (XAI, V.FIRST_FRAME, IMAGE, ("image", "url"), IMAGE.url),
     ],
 )
 def test_scalar_parameters_use_provider_wire_shape(
@@ -104,11 +113,24 @@ def test_scalar_parameters_use_provider_wire_shape(
     assert _at(request, path) == expected
 
 
-@pytest.mark.parametrize("mappers", [GOOGLE, GEMINI, OPEN, CHAT, ANTHROPIC, BYTEPLUS])
+@pytest.mark.parametrize(
+    "mappers", [GOOGLE, GEMINI, OPEN, CHAT, ANTHROPIC, MOONSHOT, BYTEPLUS, XAI]
+)
 def test_none_omits_every_optional_parameter(
     mappers: list[ParameterMapper[Any]],
 ) -> None:
     assert all(mapper.map({}, None, MODEL) == {} for mapper in mappers)
+
+
+def test_constrained_model_omits_unsupported_parameter() -> None:
+    model = Model(
+        id="constrained-test",
+        display_name="Constrained test",
+        parameter_constraints={T.MAX_TOKENS: Range(min=1, max=2)},
+    )
+
+    with pytest.warns(UnsupportedParameterWarning):
+        assert _mapper(MOONSHOT, T.TEMPERATURE).map({}, 0.2, model) == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_text_multimodal_message_request_building.py
+++ b/tests/unit_tests/test_text_multimodal_message_request_building.py
@@ -33,6 +33,7 @@ from celeste.modalities.text.providers.anthropic.client import AnthropicTextClie
 from celeste.modalities.text.providers.cohere.client import CohereTextClient
 from celeste.modalities.text.providers.google.client import GoogleTextClient
 from celeste.modalities.text.providers.mistral.client import MistralTextClient
+from celeste.modalities.text.providers.moonshot.client import MoonshotTextClient
 from celeste.modalities.text.providers.openai.client import OpenAITextClient
 
 
@@ -92,7 +93,7 @@ def test_openai_message_parts_include_image_and_document_blocks() -> None:
     assert content[2]["file_data"].startswith("data:application/pdf;base64,")
 
 
-def test_chat_completions_message_parts_include_image_and_document_blocks() -> None:
+def test_chat_completions_message_parts_include_media_blocks() -> None:
     client = MistralTextClient(
         model=_model(Provider.MISTRAL),
         provider=Provider.MISTRAL,
@@ -104,6 +105,9 @@ def test_chat_completions_message_parts_include_image_and_document_blocks() -> N
             messages=[
                 _message(
                     ImagePart(image=_image()),
+                    VideoPart(
+                        video=VideoArtifact(data=b"vid", mime_type=VideoMimeType.MP4)
+                    ),
                     DocumentPart(document=_document()),
                     TextPart(text="inspect"),
                 )
@@ -114,9 +118,33 @@ def test_chat_completions_message_parts_include_image_and_document_blocks() -> N
     content = request["messages"][0]["content"]
     assert content[0]["type"] == "image_url"
     assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
-    assert content[1]["type"] == "document_url"
-    assert content[1]["document_url"].startswith("data:application/pdf;base64,")
-    assert content[2] == {"type": "text", "text": "inspect"}
+    assert content[1]["type"] == "video_url"
+    assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
+    assert content[2]["type"] == "document_url"
+    assert content[2]["document_url"].startswith("data:application/pdf;base64,")
+    assert content[3] == {"type": "text", "text": "inspect"}
+
+
+def test_moonshot_replays_assistant_reasoning() -> None:
+    client = MoonshotTextClient(
+        model=_model(Provider.MOONSHOT),
+        provider=Provider.MOONSHOT,
+        auth=_auth(Provider.MOONSHOT),
+    )
+
+    request = client._init_request(
+        TextInput(
+            messages=[
+                Message(
+                    role=Role.ASSISTANT,
+                    content="answer",
+                    reasoning="thinking",
+                )
+            ]
+        )
+    )
+
+    assert request["messages"][0]["reasoning_content"] == "thinking"
 
 
 def test_chat_completions_assistant_tool_call_serializes_message_parts() -> None:

--- a/tests/unit_tests/test_vertex_routing.py
+++ b/tests/unit_tests/test_vertex_routing.py
@@ -104,20 +104,20 @@ def test_vertex_url_requires_project() -> None:
         (
             GoogleImagenClient,
             imagen_config.GoogleImagenEndpoint.CREATE_IMAGE,
-            "imagen-3.0-generate-002",
-            "generativelanguage.googleapis.com/v1beta/models/imagen-3.0-generate-002:predict",
+            "imagen-4.0-generate-001",
+            "generativelanguage.googleapis.com/v1beta/models/imagen-4.0-generate-001:predict",
         ),
         (
             GoogleEmbeddingsClient,
             embeddings_config.GoogleEmbeddingsEndpoint.EMBED_CONTENT,
-            "text-embedding-004",
-            "generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent",
+            "gemini-embedding-2",
+            "generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
         ),
         (
             GoogleVeoClient,
             veo_config.GoogleVeoEndpoint.CREATE_VIDEO,
-            "veo-2.0-generate-001",
-            "generativelanguage.googleapis.com/v1beta/models/veo-2.0-generate-001:predictLongRunning",
+            "veo-3.1-generate-preview",
+            "generativelanguage.googleapis.com/v1beta/models/veo-3.1-generate-preview:predictLongRunning",
         ),
         (
             MistralChatClient,
@@ -157,20 +157,14 @@ def test_api_key_routes_directly(
         (
             GoogleImagenClient,
             imagen_config.GoogleImagenEndpoint.CREATE_IMAGE,
-            "imagen-3.0-generate-002",
-            ("projects/test-project", "publishers/google", "imagen-3.0-generate-002"),
-        ),
-        (
-            GoogleEmbeddingsClient,
-            embeddings_config.GoogleEmbeddingsEndpoint.EMBED_CONTENT,
-            "text-embedding-004",
-            ("projects/test-project", "publishers/google", "text-embedding-004"),
+            "imagen-4.0-generate-001",
+            ("projects/test-project", "publishers/google", "imagen-4.0-generate-001"),
         ),
         (
             GoogleVeoClient,
             veo_config.GoogleVeoEndpoint.CREATE_VIDEO,
-            "veo-2.0-generate-001",
-            ("projects/test-project", "publishers/google", "veo-2.0-generate-001"),
+            "veo-3.1-generate-preview",
+            ("projects/test-project", "publishers/google", "veo-3.1-generate-preview"),
         ),
         (
             MistralChatClient,
@@ -215,6 +209,28 @@ def test_vertex_streaming_uses_stream_endpoint(
     assert "streamRawPredict" in _build_url(
         client_type, endpoint, model_id, _adc(), streaming=True
     )
+
+
+@pytest.mark.parametrize(
+    ("location", "base_url"),
+    [
+        ("global", "https://aiplatform.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us-central1", "https://us-central1-aiplatform.googleapis.com"),
+    ],
+)
+def test_adc_embeddings_use_location_endpoint(location: str, base_url: str) -> None:
+    url = _build_url(
+        GoogleEmbeddingsClient,
+        embeddings_config.GoogleEmbeddingsEndpoint.EMBED_CONTENT,
+        "gemini-embedding-2",
+        _adc(location=location),
+    )
+
+    assert url.startswith(f"{base_url}/v1/")
+    assert f"/locations/{location}/" in url
+    assert url.endswith("/models/gemini-embedding-2:embedContent")
 
 
 def test_veo_poll_routes_match_auth() -> None:


### PR DESCRIPTION
## Summary

Refreshes Celeste's model catalogs and provider behavior from the current model-watch review. This removes retired catalog entries, registers current models, and aligns request serialization and routing with the providers' live API contracts.

## Catalog changes

- **Google**
  - replaces `gemini-embedding-001` with stable `gemini-embedding-2`
  - exposes 128–3072 embedding dimensions and image, video, and audio inputs
  - removes the retired Veo 3.0 and Veo 3.0 Fast catalog entries
  - updates examples and integration selectors to the current embedding and Veo models
- **Anthropic**
  - removes the dated Claude Sonnet 4 and Claude Opus 4 IDs
  - aligns Fable 5 tool-choice and temperature constraints with its supported API surface
- **Mistral**
  - removes the retired `labs-devstral-small-2512` entry
- **Moonshot**
  - registers Kimi K2.6, Kimi K2.7 Code, and Kimi K2.7 Code Highspeed
  - updates context, modality, structured-output, tool, and temperature constraints
- **OpenAI**
  - adds GPT-5.3 Codex and GPT-5.5 Pro
- **xAI**
  - adds Grok Imagine Video 1.5
  - exposes first-frame image input for supported video models

## Provider and SDK behavior

- Routes Google Vertex endpoints by location:
  - `global` → `aiplatform.googleapis.com`
  - `us` / `eu` → the corresponding REP endpoint
  - standard regions → `{location}-aiplatform.googleapis.com`
- Uses Vertex `:embedContent` for Google embeddings, including multimodal requests.
- Preserves Celeste's list-embedding contract under Google ADC by issuing ordered single-item Vertex requests and combining their embeddings; direct Gemini requests continue using the native batch endpoint.
- Sends Google embedding dimensions through `embedContentConfig.outputDimensionality`.
- Replays Moonshot assistant reasoning through `reasoning_content` and maps completion limits to `max_completion_tokens`.
- Adds catalog-driven unsupported-parameter handling instead of concrete model-ID checks.
- Adds `VideoPart` serialization to generic Chat Completions multimodal messages.
- Consolidates image, document, and video URL/data-URL construction into one `build_data_url()` helper and reuses it across Chat Completions, Open Responses, Cohere, OpenAI images, and xAI image/video inputs.

## User impact

Model discovery now reflects the current provider catalogs, and removed model IDs will no longer resolve through Celeste. Google Vertex embedding users gain stable multimodal support without losing list inputs, while xAI video users can provide first frames through the normal Celeste parameter surface.

## Validation

- `make lint`
- `make typecheck`
- `uv run ruff format --check src/celeste tests`
- `make test` — 420 passed, 68.43% coverage
- commit and pre-push hooks — Ruff, formatting, mypy, Bandit, and coverage suite passed

Credentialed slow integration tests were updated but were not executed locally.