### PR TITLE
fix: provider bugs and catalog corrections from model-watch findings

### DIFF
--- a/src/celeste/modalities/audio/providers/elevenlabs/models.py
+++ b/src/celeste/modalities/audio/providers/elevenlabs/models.py
@@ -9,9 +9,10 @@ from ...languages import Language
 from ...parameters import AudioParameter
 from .voices import ELEVENLABS_VOICES
 
-# Valid output formats for ElevenLabs API
+# Valid output formats for ElevenLabs API (ulaw/alaw excluded: no AudioMimeType label)
 ELEVENLABS_OUTPUT_FORMATS = [
     "mp3_22050_32",
+    "mp3_24000_48",
     "mp3_44100_32",
     "mp3_44100_64",
     "mp3_44100_96",
@@ -21,10 +22,16 @@ ELEVENLABS_OUTPUT_FORMATS = [
     "pcm_16000",
     "pcm_22050",
     "pcm_24000",
+    "pcm_32000",
     "pcm_44100",
     "pcm_48000",
-    "ulaw_8000",
-    "alaw_8000",
+    "wav_8000",
+    "wav_16000",
+    "wav_22050",
+    "wav_24000",
+    "wav_32000",
+    "wav_44100",
+    "wav_48000",
     "opus_48000_32",
     "opus_48000_64",
     "opus_48000_96",

--- a/src/celeste/modalities/images/providers/bfl/models.py
+++ b/src/celeste/modalities/images/providers/bfl/models.py
@@ -34,7 +34,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -62,7 +62,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -90,7 +90,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -118,7 +118,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -146,7 +146,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -174,7 +174,7 @@ MODELS: list[Model] = [
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
     Model(
@@ -199,10 +199,10 @@ MODELS: list[Model] = [
                     "Portrait 9:21": "832x1920",
                 },
             ),
-            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=9),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
-            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
             ImageParameter.STEPS: Range(min=1, max=50),
             ImageParameter.GUIDANCE: Range(min=1.5, max=10.0),
         },

--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -108,12 +108,16 @@ GEMINI_MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Choice(
                 options=[
                     "1:1",
+                    "1:4",
+                    "1:8",
                     "2:3",
                     "3:2",
                     "3:4",
+                    "4:1",
                     "4:3",
                     "4:5",
                     "5:4",
+                    "8:1",
                     "9:16",
                     "16:9",
                     "21:9",

--- a/src/celeste/modalities/text/providers/cohere/client.py
+++ b/src/celeste/modalities/text/providers/cohere/client.py
@@ -90,9 +90,23 @@ class CohereTextClient(CohereChatClient, TextClient):
     ) -> TextContent:
         """Parse content from response."""
         content_array = super()._parse_content(response_data)
-        first_content = content_array[0]
-        text = first_content.get("text") or ""
-        return text
+        return "".join(
+            block.get("text") or ""
+            for block in content_array
+            if block.get("type", "text") == "text"
+        )
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Parse reasoning from thinking content blocks."""
+        content_array = response_data.get("message", {}).get("content", [])
+        reasoning = "".join(
+            block.get("thinking") or ""
+            for block in content_array
+            if block.get("type") == "thinking"
+        )
+        return reasoning or None, []
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""

--- a/src/celeste/modalities/text/providers/cohere/models.py
+++ b/src/celeste/modalities/text/providers/cohere/models.py
@@ -15,7 +15,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
+            Parameter.MAX_TOKENS: Range(min=1, max=64000, step=1),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=65536),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),

--- a/src/celeste/modalities/text/providers/deepseek/client.py
+++ b/src/celeste/modalities/text/providers/deepseek/client.py
@@ -1,12 +1,15 @@
 """DeepSeek text client (modality)."""
 
+from typing import Any
+
 from celeste.parameters import ParameterMapper
 from celeste.providers.deepseek.chat.client import DeepSeekChatClient
 from celeste.providers.deepseek.chat.streaming import (
     DeepSeekChatStream as _DeepSeekChatStream,
 )
-from celeste.types import TextContent
+from celeste.types import Message, Role, TextContent
 
+from ...io import TextInput
 from ...protocols.chatcompletions.client import (
     ChatCompletionsTextClient,
 )
@@ -23,6 +26,20 @@ class DeepSeekTextStream(_DeepSeekChatStream, _ChatCompletionsTextStream):
 
 class DeepSeekTextClient(DeepSeekChatClient, ChatCompletionsTextClient):
     """DeepSeek text client."""
+
+    def _init_request(self, inputs: TextInput) -> dict[str, Any]:
+        request = super()._init_request(inputs)
+        for source, serialized in zip(
+            inputs.messages or [], request["messages"], strict=False
+        ):
+            if (
+                isinstance(source, Message)
+                and source.role == Role.ASSISTANT
+                and source.reasoning is not None
+                and source.tool_calls is not None
+            ):
+                serialized["reasoning_content"] = source.reasoning
+        return request
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:

--- a/src/celeste/modalities/text/providers/deepseek/models.py
+++ b/src/celeste/modalities/text/providers/deepseek/models.py
@@ -8,32 +8,6 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
-        id="deepseek-chat",
-        provider=Provider.DEEPSEEK,
-        display_name="DeepSeek Chat",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=8192, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.TOOLS: ToolSupport(tools=[]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-        },
-    ),
-    Model(
-        id="deepseek-reasoner",
-        provider=Provider.DEEPSEEK,
-        display_name="DeepSeek Reasoner",
-        operations={Modality.TEXT: {Operation.GENERATE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-        },
-    ),
-    Model(
         id="deepseek-v4-flash",
         provider=Provider.DEEPSEEK,
         display_name="DeepSeek V4 Flash",

--- a/src/celeste/modalities/text/providers/groq/models.py
+++ b/src/celeste/modalities/text/providers/groq/models.py
@@ -98,6 +98,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["low", "medium", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
         },
@@ -111,6 +112,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["low", "medium", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
         },
@@ -124,6 +126,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=65536, step=1),
+            TextParameter.THINKING_BUDGET: Choice(options=["low", "medium", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
         },

--- a/src/celeste/modalities/text/providers/huggingface/models.py
+++ b/src/celeste/modalities/text/providers/huggingface/models.py
@@ -15,7 +15,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[]),
         },
@@ -31,7 +30,6 @@ MODELS: list[Model] = [
             Parameter.MAX_TOKENS: Range(min=1, max=32768, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.TOOLS: ToolSupport(tools=[]),
         },
     ),
 ]

--- a/src/celeste/modalities/text/providers/moonshot/models.py
+++ b/src/celeste/modalities/text/providers/moonshot/models.py
@@ -20,12 +20,13 @@ MODELS: list[Model] = [
         id="kimi-k3",
         provider=Provider.MOONSHOT,
         display_name="Kimi K3",
-        operations={Modality.TEXT: {Operation.GENERATE}},
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=1_048_576, step=1),
             TextParameter.THINKING_BUDGET: Choice(options=["max"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.TOOLS: ToolSupport(tools=[]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
         },
@@ -37,7 +38,6 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.TOOLS: ToolSupport(tools=[]),
@@ -53,7 +53,6 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.VIDEO: VideosConstraint(),
@@ -70,7 +69,6 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.VIDEO: VideosConstraint(),
@@ -87,7 +85,6 @@ MODELS: list[Model] = [
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=262_144, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.VIDEO: VideosConstraint(),
@@ -105,7 +102,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=8192, step=1),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),

--- a/src/celeste/modalities/text/providers/xai/models.py
+++ b/src/celeste/modalities/text/providers/xai/models.py
@@ -54,7 +54,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=131072),
             TextParameter.THINKING_BUDGET: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -70,7 +69,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=131072),
             TextParameter.THINKING_BUDGET: Choice(
                 options=["none", "low", "medium", "high"]
             ),
@@ -88,7 +86,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=131072),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -103,7 +100,6 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=131072),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),

--- a/src/celeste/modalities/videos/providers/openai/models.py
+++ b/src/celeste/modalities/videos/providers/openai/models.py
@@ -14,7 +14,7 @@ MODELS: list[Model] = [
         display_name="Sora 2",
         operations={Modality.VIDEOS: {Operation.GENERATE}},
         parameter_constraints={
-            VideoParameter.DURATION: Choice(options=["4", "8", "12"]),
+            VideoParameter.DURATION: Choice(options=["4", "8", "12", "16", "20"]),
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p"]),
         },
@@ -25,9 +25,9 @@ MODELS: list[Model] = [
         display_name="Sora 2 Pro",
         operations={Modality.VIDEOS: {Operation.GENERATE}},
         parameter_constraints={
-            VideoParameter.DURATION: Choice(options=["4", "8", "12"]),
+            VideoParameter.DURATION: Choice(options=["4", "8", "12", "16", "20"]),
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
-            VideoParameter.RESOLUTION: Choice(options=["720p"]),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=[
                     ImageMimeType.JPEG,
@@ -43,7 +43,7 @@ MODELS: list[Model] = [
         display_name="Sora 2 (December 2025)",
         operations={Modality.VIDEOS: {Operation.GENERATE}},
         parameter_constraints={
-            VideoParameter.DURATION: Choice(options=["4", "8", "12"]),
+            VideoParameter.DURATION: Choice(options=["4", "8", "12", "16", "20"]),
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p"]),
         },

--- a/src/celeste/modalities/videos/providers/openai/parameters.py
+++ b/src/celeste/modalities/videos/providers/openai/parameters.py
@@ -23,40 +23,13 @@ from celeste.types import VideoContent
 
 from ...parameters import VideoParameter
 
-# Resolution to height mapping
-_RESOLUTION_HEIGHT: dict[str, int] = {
-    "720p": 720,
-    "1080p": 1080,
-    "4k": 2160,
+# (aspect_ratio, resolution) → documented OpenAI size; catalogs permit only these combos
+_SIZES: dict[tuple[str, str], str] = {
+    ("16:9", "720p"): "1280x720",
+    ("9:16", "720p"): "720x1280",
+    ("16:9", "1080p"): "1920x1080",
+    ("9:16", "1080p"): "1080x1920",
 }
-
-# Aspect ratio to (width_ratio, height_ratio) mapping
-_ASPECT_RATIOS: dict[str, tuple[int, int]] = {
-    "16:9": (16, 9),
-    "9:16": (9, 16),
-    "1:1": (1, 1),
-    "4:3": (4, 3),
-    "3:4": (3, 4),
-}
-
-
-def _compute_size(aspect_ratio: str, resolution: str) -> str:
-    """Compute OpenAI size from aspect ratio and resolution.
-
-    Args:
-        aspect_ratio: Aspect ratio like "16:9" or "9:16".
-        resolution: Resolution like "720p" or "1080p".
-
-    Returns:
-        Size string like "1280x720".
-    """
-    height = _RESOLUTION_HEIGHT.get(resolution, 720)
-    width_ratio, height_ratio = _ASPECT_RATIOS.get(aspect_ratio, (16, 9))
-
-    # Compute width from height and aspect ratio
-    width = int(height * width_ratio / height_ratio)
-
-    return f"{width}x{height}"
 
 
 class AspectRatioMapper(ParameterMapper[VideoContent]):
@@ -96,7 +69,7 @@ class ResolutionMapper(_SizeMapper):
             return request
 
         aspect_ratio = request.pop("_aspect_ratio", "16:9")
-        size = _compute_size(aspect_ratio, str(validated_value))
+        size = _SIZES.get((aspect_ratio, str(validated_value)), "1280x720")
 
         # Delegate to provider's SizeMapper
         return super().map(request, size, model)

--- a/src/celeste/providers/cohere/chat/streaming.py
+++ b/src/celeste/providers/cohere/chat/streaming.py
@@ -30,6 +30,18 @@ class CohereChatStream:
 
         return None
 
+    def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
+        """Extract reasoning delta from SSE event."""
+        event_type = event_data.get("type")
+
+        if event_type == "content-delta":
+            delta = event_data.get("delta", {})
+            message = delta.get("message", {})
+            content = message.get("content", {})
+            return content.get("thinking") or None
+
+        return None
+
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]
     ) -> dict[str, int | float | None] | None:

--- a/src/celeste/providers/elevenlabs/text_to_speech/client.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/client.py
@@ -48,6 +48,9 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         if voice_id is None:
             voice_id = parameters.get("voice", config.DEFAULT_VOICE_ID)
 
+        # output_format is a query parameter, not a body field
+        output_format = request_body.pop("output_format", None)
+
         # Set model_id
         request_body["model_id"] = self.model.id
 
@@ -58,8 +61,12 @@ class ElevenLabsTextToSpeechClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
 
+        url = f"{config.BASE_URL}{endpoint}"
+        if output_format:
+            url = f"{url}?output_format={output_format}"
+
         response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
+            url,
             headers=headers,
             json_body=request_body,
         )
@@ -87,6 +94,9 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         if voice_id is None:
             voice_id = parameters.get("voice", config.DEFAULT_VOICE_ID)
 
+        # output_format is a query parameter, not a body field
+        output_format = request_body.pop("output_format", None)
+
         # Set model_id
         request_body["model_id"] = self.model.id
 
@@ -97,8 +107,12 @@ class ElevenLabsTextToSpeechClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
 
+        url = f"{config.BASE_URL}{endpoint}"
+        if output_format:
+            url = f"{url}?output_format={output_format}"
+
         return self._stream_binary_audio(
-            f"{config.BASE_URL}{endpoint}",
+            url,
             headers=headers,
             json_body=request_body,
         )
@@ -180,8 +194,8 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         codec_map: dict[str, AudioMimeType] = {
             "mp3": AudioMimeType.MP3,
             "pcm": AudioMimeType.PCM,
-            "aac": AudioMimeType.AAC,
-            "flac": AudioMimeType.FLAC,
+            "wav": AudioMimeType.WAV,
+            "opus": AudioMimeType.OGG,
         }
         return codec_map.get(codec, AudioMimeType.MP3)
 

--- a/tests/integration_tests/text/test_generate.py
+++ b/tests/integration_tests/text/test_generate.py
@@ -7,7 +7,7 @@ from celeste.providers.google.auth import GoogleADC
 MODELS = [
     (Provider.ANTHROPIC, "claude-haiku-4-5"),
     (Provider.COHERE, "command-r7b-12-2024"),
-    (Provider.DEEPSEEK, "deepseek-chat"),
+    (Provider.DEEPSEEK, "deepseek-v4-flash"),
     (Provider.GOOGLE, "gemini-2.5-flash-lite"),
     (Provider.GROQ, "llama-3.1-8b-instant"),
     (Provider.HUGGINGFACE, "Qwen/Qwen3-4B-Instruct-2507"),

--- a/tests/integration_tests/text/test_tools.py
+++ b/tests/integration_tests/text/test_tools.py
@@ -14,7 +14,7 @@ WEB_SEARCH_MODELS = [
 
 FUNCTION_TOOL_MODELS = [
     (Provider.ANTHROPIC, "claude-haiku-4-5", True),
-    (Provider.DEEPSEEK, "deepseek-chat", True),
+    (Provider.DEEPSEEK, "deepseek-v4-flash", True),
     (Provider.GOOGLE, "gemini-2.5-flash-lite", True),
     (Provider.GROQ, "llama-3.1-8b-instant", False),
     (Provider.HUGGINGFACE, "Qwen/Qwen3-4B-Instruct-2507", False),


### PR DESCRIPTION
## Summary

Fixes three provider bugs and a batch of doc-verified catalog corrections surfaced by the Celeste Model Watch automation (findings since #313). Every change was verified against official provider documentation or a live API probe; automation claims that failed verification were rejected (Google `512px`, BFL 7/9/3 counts, eleven_v3 streaming, all BytePlus items, Mistral removals).

## Provider fixes

- **DeepSeek**: thinking mode requires `reasoning_content` replayed on assistant tool-call turns (HTTP 400 otherwise, per the official thinking-mode guide). Adds the Moonshot-style `_init_request` override, scoped to tool-call turns. Removes `deepseek-chat`/`deepseek-reasoner` (retired 2026-07-24; V4 replacements already registered).
- **Cohere**: Chat v2 returns `message.content` as typed blocks; the parser read `content[0]` only, so reasoning-enabled responses (thinking block first) returned empty text. Now joins all `text` blocks and surfaces `thinking` blocks as reasoning, in both non-streaming and streaming paths. `command-a-plus` max output corrected to the documented 64,000.
- **ElevenLabs**: `output_format` is a query parameter on both TTS endpoints (per the official OpenAPI); it was sent in the JSON body and ignored — every request returned default MP3 mislabeled as the requested codec. Live-verified after the fix: `pcm_16000` returns raw PCM, `opus_48000_32` returns Ogg. Codec→MIME map corrected, format list completed. Note: `wav_*` is valid on the unary endpoint only; the stream endpoint rejects it server-side, consistent with the SDK's pass-through validation stance.

## Catalog corrections (all doc-quoted)

- Moonshot: context windows (262144 / 8192) removed where they masqueraded as completion caps; `kimi-k3` gains its documented image input (base64 data URLs). K3's explicit 1,048,576 completion cap kept.
- xAI: undocumented 131072 output caps removed from grok-4.5 / grok-4.3 / grok-4.20 pair (cards document context windows only).
- Google: gemini-3.1-flash-image gains the four new extreme aspect ratios (1:4, 4:1, 1:8, 8:1).
- BFL: `webp` output on all flux-2 models; reference-image counts set to edit-safe slot maxima (7 for max/pro/pro-preview/flex, 3 for klein — the edit image occupies slot 1).
- Groq: reasoning-effort choice (low/medium/high) on the three gpt-oss models — live-probed HTTP 200 on safeguard-20b.
- HuggingFace: fabricated Qwen3-4B output cap removed; gemma-3n tools removed (only live provider reports `supports_tools: false`).
- Sora: 16/20-second durations, 1080p on sora-2-pro, and the size mapper now emits documented portrait sizes (720x1280 / 1080x1920 — previously 405x720 / 607x1080).

## Deliberately not changed

- Mistral: live probes show every registered alias still serves (pixtral-12b-latest silently redirects to ministral-14b-latest) — no removals; `magistral-*-latest` retire Jul 31, recheck then.
- No local unsupported-parameter rejection mechanism: consistent with the pass-through precedent (d713074) and thin-SDK norms.

## Verification

`make ci` green (427 unit tests). Live checks: ElevenLabs pcm/opus byte-sniff, Groq reasoning_effort probe, Mistral models-list audit.
