### PR TITLE
docs: commit agent guide and fix stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+Celeste: unified multi-modal AI SDK for Python (3.12+, uv). One client API across 20+ providers — text, images, audio, videos, embeddings.
+
+## Core concepts
+
+- **Modality**: the one modality, in addition to text, essential to the model's purpose — the modality the model cannot function without.
+- **Domain**: the resource you work with.
+- Never describe Modality as an output type or Domain as an input type.
+- Key enums, all in `src/celeste/core.py`:
+  - `Modality` (text, embeddings, images, videos, audio)
+  - `Domain` (text, images, audio, videos, documents)
+  - `Operation` — what you do (generate, edit, analyze, speak, transcribe, embed, upscale)
+  - `Provider` — which backend serves the request
+  - `Protocol` (chatcompletions, openresponses)
+- `(Domain, Operation) → Modality` inference: `DOMAIN_OPERATION_TO_MODALITY` in `core.py`.
+
+## Architecture: three layers
+
+1. `src/celeste/providers/<vendor>/<api>/` — wire/HTTP mixins per vendor API.
+   - Dirs are named after the API: `anthropic/messages`, `cohere/chat`, `elevenlabs/text_to_speech`.
+   - Parameter mapper classes here carry no `.name`.
+2. `src/celeste/modalities/<modality>/providers/<vendor>/` — composition layer.
+   - `client.py` composes wire mixin + modality client; `parameters.py` binds unified `.name`s; `models.py` is the model catalog.
+3. `src/celeste/protocols/` + `src/celeste/modalities/text/protocols/` — shared OpenAI-compatible base clients (`chatcompletions`, `openresponses`).
+   - RULE: editing a protocol changes every inheriting vendor (DeepSeek, Moonshot, Groq, Mistral, HuggingFace, ...).
+   - Vendor-specific behavior goes in that vendor's override (`client.py` / `parameters.py`), never in the shared base.
+
+Template-first: new files start from `templates/` — `cp` the template, then edit. Never write provider/modality files from scratch. Registration checklist: CONTRIBUTING.md "Adding a provider".
+
+## Model catalog rules (`models.py` entries)
+
+- `Model.streaming` means celeste's adapter transport streams this model — not the vendor's advertised capability. Flip it only after a live call through celeste's own streaming path.
+- A `MAX_TOKENS` Range comes only from a provider-documented max-completion/output figure. A context window is never a completion cap; if no completion max is documented, omit the constraint.
+- Choice/enum literals verbatim from the provider's API request-parameter reference, not marketing/model pages (those use display tokens). If two official pages conflict, keep the current value and record the conflict.
+- One `parameter_constraints` dict serves every call mode (unary AND streaming). Constrain to the union; let the provider reject mode-specific invalids.
+- Remove a model id only after a live authenticated call hard-rejects it. Lifecycle/deprecation tables are announcements; providers keep retired aliases serving or silently redirect them.
+
+## Validation philosophy
+
+- A parameter with no constraint passes through to the provider unvalidated — by design (commit d713074).
+- Never add local guards, omit-and-warn mappers, or constraints whose only purpose is to reject what the provider already rejects.
+- Never encode a mode-conditional restriction (e.g. thinking-mode-only) as an unconditional constraint.
+
+## Workflow
+
+- Implementation starts in a fresh worktree: `git worktree add -b <branch> .worktrees/<name> main`, then `uv sync --all-extras` inside it.
+- `make ci` gates every commit (format, lint, typecheck, security, unit tests).
+- Integration tests hit real provider APIs (cost money, need keys in `.env`): `make integration-test`.
+- One PR per concern: provider-global changes (protocol / transport / `core.py`) never ride in model-addition PRs.
+- Never commit or push without explicit maintainer approval.
+
+## Testing
+
+- `make ci` is the gate. House style: wire-contract tests are data-driven over mapper lists (`_map` / `_at` in `tests/unit_tests/test_parameter_wire_contracts.py`); request-payload tests call `client._init_request(...)` directly; stream parse tests instantiate via `object.__new__(...)`; never mock httpx in provider/parameter tests (only `tests/unit_tests/test_http.py` touches the transport).
+- A test must earn its place: focused, guarding real behavior, parametrized over cases instead of duplicated. No test ceremony, no coverage bloat. If a test is not clearly required, no test is better than a weak one.
+
+## Transport quirks
+
+- `HTTPClient` (`src/celeste/http.py`) has no query-param support — bake query strings into the URL.
+- ElevenLabs binary streaming bypasses `HTTPClient` entirely (raw httpx `client.stream`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 **Prerequisites:** Python 3.12+, [uv](https://docs.astral.sh/uv/)
 
 ```bash
-uv sync --group dev
+uv sync --all-extras
 uv run pre-commit install
 uv run pre-commit install --hook-type pre-push
 ```
@@ -66,6 +66,29 @@ Always start by copying from the templates. Replace `{provider_slug}`, `{api_slu
 9. Register models in `src/celeste/modalities/<modality>/models.py`.
 10. Register the client in the `PROVIDERS` dict in `src/celeste/modalities/<modality>/providers/__init__.py`.
 11. Add the provider's official API docs link to `src/celeste/providers/api_references.md`.
+
+### Protocol-based providers
+
+Most OpenAI-compatible vendors (DeepSeek, Moonshot, Groq, Mistral, HuggingFace, ...) subclass a shared protocol client from `src/celeste/protocols/` (`chatcompletions`, `openresponses`) instead of copying the full provider template — templates live at `templates/protocols/`. Editing a protocol changes every inheriting vendor: vendor-specific behavior goes in that vendor's own `client.py` / `parameters.py` override, never in the shared base.
+
+## Model catalog rules
+
+- `Model.streaming` means celeste's adapter transport streams this model — not the vendor's advertised capability.
+- A `MAX_TOKENS` Range comes only from a provider-documented max-completion/output figure; a context window is never a completion cap. No documented completion max → omit the constraint.
+- Choice/enum literals verbatim from the provider's API request-parameter reference, not marketing pages. Conflicting official pages → keep the current value, record the conflict.
+- One `parameter_constraints` dict serves every call mode (unary and streaming): constrain to the union, let the provider reject mode-specific invalids.
+- Parameters with no constraint pass through unvalidated by design — do not add local guards for values the provider itself rejects.
+
+See CLAUDE.md for the full rules.
+
+## Removing a model
+
+Remove a model id only after a live authenticated call hard-rejects it. Provider lifecycle/deprecation tables are announcements, not serving status — providers keep "retired" aliases serving or silently redirect them (e.g. `pixtral-12b-latest` serves `ministral-14b-latest`). Precedent: PRs #280, #311, #314.
+
+## Testing
+
+- `make ci` is the gate. Wire-contract tests are data-driven over mapper lists (`_map` / `_at` in `tests/unit_tests/test_parameter_wire_contracts.py`); request-payload tests call `client._init_request(...)` directly; stream parse tests instantiate via `object.__new__(...)`; never mock httpx in provider/parameter tests (only `tests/unit_tests/test_http.py` touches the transport).
+- A test must earn its place: focused, guarding real behavior, parametrized over cases instead of duplicated. No test ceremony, no coverage bloat. If a test is not clearly required, no test is better than a weak one.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ import celeste
 response = await celeste.text.generate(
     "Explain AI",
     model="gpt-4o-mini",
-    temperature=0.7,    # ✅ Validated (0.0-2.0)
-    max_tokens=100,     # ✅ Validated (int)
+    temperature=0.7,    # ✅ Validated against the model's declared Range
+    max_tokens=100,     # ✅ Validated when the model declares a constraint
 )
 
 # Typed response
@@ -214,7 +214,7 @@ print(response.usage.input_tokens)   # int
 print(response.metadata["model"])     # str
 ```
 
-Catch errors **before** production.
+Declared constraints raise locally **before** the API call; unconstrained parameters pass through to the provider.
 
 ---
 

--- a/src/celeste/core.py
+++ b/src/celeste/core.py
@@ -103,8 +103,9 @@ class UsageField(StrEnum):
 class Domain(StrEnum):
     """Semantic grouping of operations by resource type.
 
-    Domain represents what you work with (input type), while
-    Modality represents what you produce (output type).
+    Domain is the resource you work with. Modality is the one modality,
+    in addition to text, essential to the model's purpose — these are not
+    input/output type distinctions.
     """
 
     TEXT = "text"

--- a/src/celeste/http.py
+++ b/src/celeste/http.py
@@ -83,6 +83,8 @@ class HTTPClient:
     ) -> httpx.Response:
         """Make POST request with connection pooling.
 
+        No query-parameter support — encode query strings into `url`.
+
         Args:
             url: Full URL to POST to.
             headers: HTTP headers including authentication.

--- a/src/celeste/models.py
+++ b/src/celeste/models.py
@@ -17,7 +17,13 @@ class Model(BaseModel):
     parameter_constraints: dict[str, SerializeAsAny[Constraint]] = Field(
         default_factory=dict
     )
-    streaming: bool = Field(default=False)
+    streaming: bool = Field(
+        default=False,
+        description=(
+            "Celeste's adapter implements streaming for this model — "
+            "not a claim about the upstream vendor's capability."
+        ),
+    )
 
     @property
     def supported_parameters(self) -> set[str]:

--- a/src/celeste/providers/api_references.md
+++ b/src/celeste/providers/api_references.md
@@ -27,11 +27,14 @@ This document contains the official API reference documentation links for all pr
 | **BytePlus** | Videos | [Videos API Reference](https://docs.byteplus.com/en/docs/ModelArk/1520757) | ✅ |
 | **BFL** | Images | [Images API Reference](https://docs.bfl.ml/flux_2/flux2_text_to_image) | ✅ |
 | **Gradium** | TTS | [TTS API Reference](https://gradium.ai/api_docs.html) | ✅ |
+| **HuggingFace** | Chat Completions (router) | [Chat Completion API Reference](https://huggingface.co/docs/inference-providers/tasks/chat-completion) | — |
+| **Ollama** | Responses (OpenAI-compatible) | [API Reference](https://docs.ollama.com/api) | — |
+| **OpenRouter** | Responses | [API Reference](https://openrouter.ai/docs/api/api-reference) | — |
 
 ## Summary
 
-- **Total APIs:** 21 provider-API combinations
-- **All validated:** ✅ Complete
+- **Total APIs:** 24 provider-API combinations
+- **Validated:** 21 ✅ · 3 pending (—)
 - **Naming convention:** Method names only (Provider column provides context)
 - **Link strategy:** Specific method/endpoint pages when available, general API reference pages otherwise
 


### PR DESCRIPTION
## Summary

Commits `CLAUDE.md` for the first time and aligns the tracked docs with how the codebase actually works. Until now the repo shipped no agent-orientation file — every agent (CI review bots, external automations, fresh clones) had to rediscover the architecture and conventions, and several docs made claims the code contradicts.

## What's in CLAUDE.md

- **Architecture**: the three layers (`providers/<vendor>/<api>/` wire mixins, `modalities/<m>/providers/<vendor>/` composition, `protocols/` shared OpenAI-compatible bases) and the protocol-override rule — editing a protocol changes every inheriting vendor, so vendor-specific behavior goes in vendor overrides.
- **Model catalog rules**: `Model.streaming` = celeste's adapter transport (not vendor capability); `MAX_TOKENS` only from documented completion maxima, never context windows; enum literals verbatim from API references; one constraint dict serves all call modes; model removal only after a live call hard-rejects the id.
- **Validation philosophy**: unconstrained params pass through by design (d713074) — no local guards for values the provider itself rejects.
- **Workflow and testing house style**.

## Doc fixes

- `core.py`: Domain docstring no longer describes Modality/Domain as output/input types (contradicted the project's canonical definitions).
- `models.py`: `streaming` field now documents its adapter-transport semantics.
- `CONTRIBUTING.md`: `uv sync --all-extras` (was `--group dev`, diverging from the Makefile); new Protocol-based providers, Model catalog rules, Removing a model, and Testing sections.
- `README.md`: parameter comments no longer claim a universal `0.0-2.0` validation; validation is per-model constraints with pass-through otherwise.
- `api_references.md`: adds the missing HuggingFace/Ollama/OpenRouter rows (24 total) and stops claiming blanket validation.
- `http.py`: `post()` documents the no-query-param rule (query strings go in the URL).

## Verification

`make ci` green (427 unit tests, ruff, mypy, bandit).
