### PR TITLE
test(core): dispatcher delegation guard

### DIFF
--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -159,6 +159,23 @@ class ModalityClient[
             async def generate(self, prompt: str, **parameters) -> ImageGenerationOutput:
                 inputs = ImageGenerationInput(prompt=prompt)
                 return await self._predict(inputs, **parameters)
+
+    Hook contract — everything _predict() / _stream() invoke on self:
+    - unary: parameter_mappers, _validate_artifacts, _init_request,
+      _build_request, _make_request, _parse_content, _transform_output,
+      _parse_tool_calls, _parse_reasoning, _parse_grounding, _parse_container,
+      _parse_usage, _parse_finish_reason, _build_metadata
+    - streaming: parameter_mappers, _validate_artifacts, _init_request,
+      _build_request, _make_stream_request, _handle_error_response,
+      _transform_output, and _stream_class via the modality stream namespaces
+
+    A multi-backend dispatcher ({Provider}{Modality}Client holding a _strategy)
+    must define every hook a backend customizes, forwarding to self._strategy —
+    otherwise this base implementation runs silently. _transform_output and
+    _build_metadata read per-class state (parameter_mappers(), _content_fields),
+    so a dispatcher forwards them whenever that state differs from its own — for
+    merged mapper lists, always. Enforced per dispatcher, hook, and backend by
+    tests/unit_tests/test_dispatcher_delegation.py.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/celeste/modalities/images/providers/google/client.py
+++ b/src/celeste/modalities/images/providers/google/client.py
@@ -63,6 +63,14 @@ class GoogleImagesClient(ImagesClient):
     ) -> dict[str, Any]:
         return self._strategy._build_request(inputs, **parameters)  # type: ignore[union-attr]
 
+    def _transform_output(
+        self, content: ImageContent, **parameters: Unpack[ImageParameters]
+    ) -> ImageContent:
+        return self._strategy._transform_output(content, **parameters)  # type: ignore[union-attr]
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        return self._strategy._build_metadata(response_data)  # type: ignore[union-attr]
+
     def _parse_usage(
         self, response_data: dict[str, Any]
     ) -> dict[str, int | float | None]:

--- a/tests/unit_tests/test_dispatcher_delegation.py
+++ b/tests/unit_tests/test_dispatcher_delegation.py
@@ -1,0 +1,119 @@
+"""Dispatcher delegation contract: every backend-customized hook must be forwarded."""
+
+import inspect
+import types
+import typing
+from collections.abc import Callable
+
+import pytest
+
+from celeste import _CLIENT_MAP
+from celeste.client import ModalityClient
+
+_HOOK_KINDS = (types.FunctionType, classmethod, staticmethod, property)
+# Required only when a backend actually streams (defines _stream_class): the
+# streaming namespaces call _stream_class first, which base-raises otherwise.
+_STREAMING_HOOKS = frozenset({"_make_stream_request", "_stream_class"})
+# Construction hook: pydantic injects per-class init_private_attributes wrappers
+# that break identity comparison.
+_EXCLUDED = frozenset({"model_post_init"})
+# Hooks whose base implementation reads per-class state, so method identity
+# alone cannot see divergence: hook name -> the state the base impl reads.
+_STATE_DRIVEN_HOOKS: dict[str, Callable[[type[ModalityClient]], object]] = {
+    "_build_metadata": lambda c: c._content_fields,
+    "_transform_output": lambda c: list(c.parameter_mappers()),
+}
+
+
+def _dispatchers() -> list[type[ModalityClient]]:
+    """Registered clients whose private-attr union selects backend clients."""
+    found: dict[type[ModalityClient], None] = {}
+    for cls in _CLIENT_MAP.values():
+        for name in cls.__private_attributes__:
+            hint = typing.get_type_hints(cls).get(name)
+            backends = [
+                arg
+                for arg in typing.get_args(hint)
+                if isinstance(arg, type) and issubclass(arg, ModalityClient)
+            ]
+            if backends:
+                assert name == "_strategy", (
+                    f"{cls.__name__}: dispatcher attr is {name!r} — rename to "
+                    "_strategy or extend test_dispatcher_delegation.py"
+                )
+                found[cls] = None
+    return list(found)
+
+
+def _backends(dispatcher: type[ModalityClient]) -> list[type[ModalityClient]]:
+    """Backend classes from the dispatcher's _strategy union annotation."""
+    union = typing.get_type_hints(dispatcher)["_strategy"]
+    return [arg for arg in typing.get_args(union) if arg is not type(None)]
+
+
+def _hook_names(modality_base: type[ModalityClient]) -> set[str]:
+    """Every celeste-defined callable name reachable on the modality base."""
+    return {
+        name
+        for klass in modality_base.__mro__
+        if klass.__module__.startswith("celeste")
+        for name, attr in vars(klass).items()
+        if not name.startswith("__")
+        and isinstance(attr, _HOOK_KINDS)
+        and name not in _EXCLUDED
+    }
+
+
+def test_registry_discovers_known_dispatchers() -> None:
+    names = {d.__name__ for d in _dispatchers()}
+    assert "GoogleImagesClient" in names
+
+
+@pytest.mark.parametrize("dispatcher", _dispatchers(), ids=lambda d: d.__name__)
+def test_dispatcher_defines_every_backend_customized_hook(
+    dispatcher: type[ModalityClient],
+) -> None:
+    modality_base = next(
+        c for c in dispatcher.__mro__[1:] if issubclass(c, ModalityClient)
+    )
+    assert modality_base is not ModalityClient
+    backends = _backends(dispatcher)
+    assert len(backends) >= 2, f"{dispatcher.__name__}: dispatcher needs >= 2 backends"
+    assert all(issubclass(b, modality_base) for b in backends)
+    hook_names = _hook_names(modality_base)
+    assert len(hook_names) >= 20, "hook derivation broke — sweep would be hollow"
+
+    streaming_served = any(
+        inspect.getattr_static(backend, "_stream_class")
+        is not inspect.getattr_static(modality_base, "_stream_class")
+        for backend in backends
+    )
+
+    required: dict[str, str] = {}
+    for name in hook_names:
+        if name in _STREAMING_HOOKS and not streaming_served:
+            continue
+        customizing = [
+            backend.__name__
+            for backend in backends
+            if inspect.getattr_static(backend, name)
+            is not inspect.getattr_static(modality_base, name)
+        ]
+        if customizing:
+            required[name] = f"customized by {', '.join(customizing)}"
+    for name, state in _STATE_DRIVEN_HOOKS.items():
+        diverging = [b.__name__ for b in backends if state(b) != state(dispatcher)]
+        if diverging and name not in required:
+            required[name] = (
+                f"state the base impl reads differs in {', '.join(diverging)}"
+            )
+
+    missing = [
+        f"{name} ({required[name]})"
+        for name in sorted(required)
+        if name not in vars(dispatcher)
+    ]
+    assert not missing, (
+        f"{dispatcher.__name__} must define these hooks — without a delegate the "
+        f"{modality_base.__name__} implementation runs silently: " + "; ".join(missing)
+    )


### PR DESCRIPTION
Adds a structural unit test enforcing the multi-backend dispatcher contract: a dispatcher must define every hook a backend customizes — a missing delegate silently runs the modality-base implementation.

How it works (`tests/unit_tests/test_dispatcher_delegation.py`):
- **Auto-discovery**: scans every registered client in `_CLIENT_MAP` for a private attr whose union annotation contains `ModalityClient` subclasses (then asserts it is named `_strategy`, so a rename fails loudly instead of escaping the sweep). New dispatchers are covered with zero test edits.
- **Derived hook set**: the hook surface comes from `vars()` of the celeste-owned classes in the modality base's MRO — never a hardcoded list, so hooks added to `_predict`/`_stream` later are enforced automatically.
- **Identity + state rules**: a hook is required when a backend's `inspect.getattr_static` resolution differs from the modality base's, plus two state-driven rules identity cannot see — `_build_metadata` (base impl reads `self._content_fields`) and `_transform_output` (base impl iterates the merged `parameter_mappers()`).
- **Streaming gate**: `_make_stream_request`/`_stream_class` are required only when some backend defines `_stream_class` — flipping a backend to streaming turns the requirement on.
- Loud-failure floor: broken discovery or hook derivation fails the test rather than silently passing.

The guard proves itself on this very PR: run against main it fails, naming `GoogleImagesClient`'s two missing delegates — `_transform_output` (customized by `ImagenImagesClient`, so `num_images` singularize/pluralize silently didn't run through the dispatcher) and `_build_metadata` (backend `_content_fields` never stripped, leaking full content arrays into `metadata.raw_response`). Both delegates are added here; the state rules exist precisely because the naive identity check would have missed `_build_metadata`.

Also documents the full hook contract in `ModalityClient`'s docstring, pointing at the guard as its enforcement.

Second of the 4-PR stack: uniformity (#316) → **guard** → docs/templates → Interactions migration.

`make ci` green.