### PR TITLE
docs: API-addition playbook, naming rules, templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,20 @@ Celeste: unified multi-modal AI SDK for Python (3.12+, uv). One client API acros
    - Parameter mapper classes here carry no `.name`.
 2. `src/celeste/modalities/<modality>/providers/<vendor>/` — composition layer.
    - `client.py` composes wire mixin + modality client; `parameters.py` binds unified `.name`s; `models.py` is the model catalog.
-3. `src/celeste/protocols/` + `src/celeste/modalities/text/protocols/` — shared OpenAI-compatible base clients (`chatcompletions`, `openresponses`).
+3. `src/celeste/protocols/` + `src/celeste/modalities/text/protocols/` — shared protocol base clients: a protocol is a wire format served by many vendors (currently `chatcompletions`, `openresponses`).
    - RULE: editing a protocol changes every inheriting vendor (DeepSeek, Moonshot, Groq, Mistral, HuggingFace, ...).
    - Vendor-specific behavior goes in that vendor's override (`client.py` / `parameters.py`), never in the shared base.
 
-Template-first: new files start from `templates/` — `cp` the template, then edit. Never write provider/modality files from scratch. Registration checklist: CONTRIBUTING.md "Adding a provider".
+Multi-backend providers (one provider, several wire APIs — e.g. Google):
+
+- The `PROVIDERS` registry always maps a `Provider` to one `{Provider}{Modality}Client` class. It never branches and never holds functions.
+- `client.py` is then a dispatcher: `{Provider}{Modality}Client({Modality}Client)` selects the backend once in `model_post_init` (by auth and/or model id) via `object.__setattr__(self, "_strategy", ...)`, copies the endpoint ClassVars it routes on, concatenates all backend mapper lists in `parameter_mappers()`, and forwards every hook a backend customizes to `self._strategy` — a missing delegate silently runs the base implementation. Enforced by `tests/unit_tests/test_dispatcher_delegation.py`, which auto-discovers dispatchers from the registry and fails CI naming the hook, dispatcher, and backend; `ModalityClient`'s docstring (`src/celeste/client.py`) describes the hook surface.
+- Each backend is the old single-backend client body in an api-named file (`interactions.py`, `vertex.py`), classes renamed `{Provider}{Api}{Modality}Client`; every mapper set in `parameters.py` takes the backend token too (`VertexTemperatureMapper`, `GOOGLE_VERTEX_PARAMETER_MAPPERS`) — a bare set never coexists with a tokened one.
+- Where variation lives, in escalation order: endpoint ClassVar (`_generate_endpoint`, `_edit_endpoint`) for same-wire operations → `_build_url` auth branch for the same wire format on another host (Vertex) → `_strategy` dispatcher only for genuinely different wire formats.
+
+Naming: wire mixin `{Provider}{Api}Client` (`GoogleInteractionsClient`); registered composite `{Provider}{Modality}Client` (`GoogleTextClient`); per-backend composite `{Provider}{Api}{Modality}Client` (`GoogleInteractionsTextClient`). The prefix is always the `Provider` enum name, never a brand or model family (`Google`, not `Gemini`). Composition files always alias the wire imports — `{Provider}{Api}Client as {Provider}{Api}Mixin`, `{Provider}{Api}Stream as _{Provider}{Api}Stream` — and never alias `config`.
+
+Template-first: new files start from `templates/` — `cp` the template, then edit. Never write provider/modality files from scratch. Routing map: `templates/README.md`. Registration checklist: CONTRIBUTING.md "Adding a provider" / "Adding a second API to an existing provider".
 
 ## Model catalog rules (`models.py` entries)
 
@@ -42,6 +51,11 @@ Template-first: new files start from `templates/` — `cp` the template, then ed
 - Never add local guards, omit-and-warn mappers, or constraints whose only purpose is to reject what the provider already rejects.
 - Never encode a mode-conditional restriction (e.g. thinking-mode-only) as an unconditional constraint.
 
+## Code style
+
+- One-line docstrings on private methods and module helpers.
+- No banner/section comments (`# --- x ---`). Comments state invariants, never history or narration.
+
 ## Workflow
 
 - Implementation starts in a fresh worktree: `git worktree add -b <branch> .worktrees/<name> main`, then `uv sync --all-extras` inside it.
@@ -53,6 +67,7 @@ Template-first: new files start from `templates/` — `cp` the template, then ed
 ## Testing
 
 - `make ci` is the gate. House style: wire-contract tests are data-driven over mapper lists (`_map` / `_at` in `tests/unit_tests/test_parameter_wire_contracts.py`); request-payload tests call `client._init_request(...)` directly; stream parse tests instantiate via `object.__new__(...)`; never mock httpx in provider/parameter tests (only `tests/unit_tests/test_http.py` touches the transport).
+- Every new wire mapper list joins the `test_parameter_wire_contracts.py` matrix; a multi-backend dispatcher gets dispatch-selection asserts on `client._strategy`.
 - A test must earn its place: focused, guarding real behavior, parametrized over cases instead of duplicated. No test ceremony, no coverage bloat. If a test is not clearly required, no test is better than a weak one.
 
 ## Transport quirks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Template-first: new files start from `templates/` — `cp` the template, then ed
 - `Model.streaming` means celeste's adapter transport streams this model — not the vendor's advertised capability. Flip it only after a live call through celeste's own streaming path.
 - A `MAX_TOKENS` Range comes only from a provider-documented max-completion/output figure. A context window is never a completion cap; if no completion max is documented, omit the constraint.
 - Choice/enum literals verbatim from the provider's API request-parameter reference, not marketing/model pages (those use display tokens). If two official pages conflict, keep the current value and record the conflict.
+- When the API reference and live serving disagree, live serving wins for constraints and tests; record the conflict in the PR.
 - One `parameter_constraints` dict serves every call mode (unary AND streaming). Constrain to the union; let the provider reject mode-specific invalids.
 - Remove a model id only after a live authenticated call hard-rejects it. Lifecycle/deprecation tables are announcements; providers keep retired aliases serving or silently redirect them.
 
@@ -50,11 +51,14 @@ Template-first: new files start from `templates/` — `cp` the template, then ed
 - A parameter with no constraint passes through to the provider unvalidated — by design (commit d713074).
 - Never add local guards, omit-and-warn mappers, or constraints whose only purpose is to reject what the provider already rejects.
 - Never encode a mode-conditional restriction (e.g. thinking-mode-only) as an unconditional constraint.
+- A mapper may only write fields that exist in the provider's API request reference. The wire-contract matrix asserts our own mapping, never the API's truth — only a live call proves a field.
+- A unified parameter with no wire representation on a backend gets no mapper there — never invent a translation (thinking_budget exists on Vertex, not on Interactions).
 
 ## Code style
 
 - One-line docstrings on private methods and module helpers.
 - No banner/section comments (`# --- x ---`). Comments state invariants, never history or narration.
+- Modality-layer signatures type parameter kwargs as `Unpack[{Modality}Parameters]`; wire and protocol layers are modality-agnostic and use `**parameters: Any`.
 
 ## Workflow
 
@@ -62,7 +66,8 @@ Template-first: new files start from `templates/` — `cp` the template, then ed
 - `make ci` gates every commit (format, lint, typecheck, security, unit tests).
 - Integration tests hit real provider APIs (cost money, need keys in `.env`): `make integration-test`.
 - One PR per concern: provider-global changes (protocol / transport / `core.py`) never ride in model-addition PRs.
-- Never commit or push without explicit maintainer approval.
+- Groundwork (conventions, guards, docs) merges before the feature that motivated it; the feature lands already conforming.
+- Never commit or push without explicit maintainer approval. On a branch under review, fixes are follow-up commits — never amend or force-push.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,20 @@ Always start by copying from the templates. Replace `{provider_slug}`, `{api_slu
 
 ### Protocol-based providers
 
-Most OpenAI-compatible vendors (DeepSeek, Moonshot, Groq, Mistral, HuggingFace, ...) subclass a shared protocol client from `src/celeste/protocols/` (`chatcompletions`, `openresponses`) instead of copying the full provider template — templates live at `templates/protocols/`. Editing a protocol changes every inheriting vendor: vendor-specific behavior goes in that vendor's own `client.py` / `parameters.py` override, never in the shared base.
+A protocol is a wire format served by many vendors (`chatcompletions`, `openresponses`). Vendors that speak one (DeepSeek, Moonshot, Groq, Mistral, HuggingFace, ...) subclass the shared protocol client from `src/celeste/protocols/` instead of copying the full provider template — templates live at `templates/protocols/`. Editing a protocol changes every inheriting vendor: vendor-specific behavior goes in that vendor's own `client.py` / `parameters.py` override, never in the shared base.
+
+### Adding a second API to an existing provider
+
+The steps above assume a new provider. For a new wire API on an existing one (e.g. Interactions next to GenerateContent), the delta is:
+
+1. Steps 1–3 are already done — enum, auth, and exports stay untouched.
+2. Copy `templates/providers/` into `src/celeste/providers/<provider>/<new_api>/`, including `__init__.py`.
+3. On the modality side, rename the existing `client.py` to `<old_api>.py` and its classes `{Provider}{Modality}Client` → `{Provider}{Api}{Modality}Client`; the new backend lands in `<new_api>.py` with the same shape.
+4. The new `client.py` is the dispatcher (`templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template`): selects a backend in `model_post_init`, merges mapper lists, copies endpoint ClassVars, and forwards every hook a backend customizes — `tests/unit_tests/test_dispatcher_delegation.py` fails CI naming any hook you missed (`ModalityClient`'s docstring describes the hook surface).
+5. `parameters.py` now serves two backends, so every set carries its backend token: rename the existing classes to `{Api1}NameMapper` and the existing list to `{PROVIDER}_{API1}_PARAMETER_MAPPERS`, then add the parallel `{Api2}` set with `{PROVIDER}_{API2}_PARAMETER_MAPPERS` — no bare set survives in a multi-backend file. Same-file helper functions take the backend token as a suffix (`map_grounding_vertex` / `map_grounding_interactions`).
+6. Step 10 is a no-op: the `PROVIDERS` entry keeps pointing at `{Provider}{Modality}Client` — the registry never branches.
+7. Live probes before pinning: the endpoint version must serve every catalog model (stable and preview ids); `Model.streaming` flips only after a live call through celeste's stream path; model ids verified against the new API's reference.
+8. Tests: dispatch-selection asserts on `client._strategy`, per-backend `_init_request` payload tests, and wire-contract matrix rows for the new mapper list. The delegation guard (`tests/unit_tests/test_dispatcher_delegation.py`) picks the new dispatcher up automatically from the registry — no new rows.
 
 ## Model catalog rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ cp .env.example .env   # Fill in your API keys
 make integration-test
 ```
 
+Vertex-path tests authenticate via ADC, not `.env` keys: `gcloud auth application-default login` with an account that has `roles/aiplatform.user` on the project and a usable quota project. Claude-on-Vertex additionally needs the model enabled in the project's Model Garden.
+
 ## Before you start
 
 Small fixes (typos, tests, minor bugfixes) — go ahead and open a PR directly.
@@ -81,8 +83,9 @@ The steps above assume a new provider. For a new wire API on an existing one (e.
 4. The new `client.py` is the dispatcher (`templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template`): selects a backend in `model_post_init`, merges mapper lists, copies endpoint ClassVars, and forwards every hook a backend customizes — `tests/unit_tests/test_dispatcher_delegation.py` fails CI naming any hook you missed (`ModalityClient`'s docstring describes the hook surface).
 5. `parameters.py` now serves two backends, so every set carries its backend token: rename the existing classes to `{Api1}NameMapper` and the existing list to `{PROVIDER}_{API1}_PARAMETER_MAPPERS`, then add the parallel `{Api2}` set with `{PROVIDER}_{API2}_PARAMETER_MAPPERS` — no bare set survives in a multi-backend file. Same-file helper functions take the backend token as a suffix (`map_grounding_vertex` / `map_grounding_interactions`).
 6. Step 10 is a no-op: the `PROVIDERS` entry keeps pointing at `{Provider}{Modality}Client` — the registry never branches.
-7. Live probes before pinning: the endpoint version must serve every catalog model (stable and preview ids); `Model.streaming` flips only after a live call through celeste's stream path; model ids verified against the new API's reference.
+7. Live probes before pinning: the endpoint version must serve every catalog model (stable and preview ids); `Model.streaming` flips only after a live call through celeste's stream path; model ids verified against the new API's reference. A mapper may only write fields that exist in that reference — the wire-contract matrix asserts our mapping, not the API's truth.
 8. Tests: dispatch-selection asserts on `client._strategy`, per-backend `_init_request` payload tests, and wire-contract matrix rows for the new mapper list. The delegation guard (`tests/unit_tests/test_dispatcher_delegation.py`) picks the new dispatcher up automatically from the registry — no new rows.
+9. Before calling it done, run the provider's integration tests (`make integration-test`) — they are the only check that proves wire fields against the live API. Sort failures into billing / auth / pre-existing before treating any as a code defect; when the API reference and live serving disagree, live serving wins.
 
 ## Model catalog rules
 
@@ -109,6 +112,8 @@ Include:
 - A short summary (what and why).
 - A test plan (`make ci` output, plus any integration tests you ran).
 - If you touched provider behavior: provider, model ID, and endpoints tested.
+
+Address review feedback with follow-up commits — never amend or force-push a branch under review.
 
 ## Issues
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -28,3 +28,4 @@ The prefix is always the `Provider` enum name, never a brand or model family (`G
 ## Notes
 
 - The commented Vertex block in `providers/{provider_slug}/{api_slug}/client.py.template` is only for providers that serve the SAME wire API on both api-key and ADC auth (different host). A different wire format per auth is route 3, not a `_build_url` branch.
+- When a modality stream needs events the base `_parse_chunk` filtering drops (tool calls, thought signatures), retain them: seed a private list in `__init__`, append in `_parse_chunk` before calling `super()`, and return it from the matching `_aggregate_*` hook (see the anthropic and google streams).

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,30 @@
+# Templates
+
+Copy the template, replace the `{placeholders}`, strip the `.template` extension. Never write provider or modality files from scratch.
+
+## Which route
+
+1. **New provider with its own wire API** — copy `providers/{provider_slug}/{api_slug}/` (wire mixin: HTTP + parsing, mappers with no `.name`) and `modalities/{modality_slug}/providers/{provider_slug}/` (composite client, `.name`-bound mappers, model catalog). Checklist: CONTRIBUTING.md "Adding a provider".
+2. **Provider speaks an existing protocol** (`chatcompletions`, `openresponses`) — subclass the shared clients in `src/celeste/protocols/` via `templates/protocols/`; do not copy the provider templates. A protocol is a wire format served by many vendors.
+3. **Second wire API on an existing provider** — copy only `providers/{provider_slug}/{api_slug}/` (including `__init__.py`). On the modality side: demote the existing `client.py` to `{old_api}.py` (classes renamed `{Provider}{Api}{Modality}Client`), give every mapper set in `parameters.py` its backend token (see Naming), add `{new_api}.py` with the same shape, and make `client.py` the dispatcher from `modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template`. Enum, auth, exports, and the `PROVIDERS` registry entry stay untouched. Checklist: CONTRIBUTING.md "Adding a second API to an existing provider".
+
+## Naming
+
+| Thing | Name | Example |
+|---|---|---|
+| Wire mixin (`providers/`) | `{Provider}{Api}Client` | `GoogleInteractionsClient` |
+| Registered modality client | `{Provider}{Modality}Client` | `GoogleTextClient` |
+| Per-backend modality client | `{Provider}{Api}{Modality}Client` | `GoogleInteractionsTextClient` |
+| Wire-mixin import (composition side) | `{Provider}{Api}Client as {Provider}{Api}Mixin` — always, collision or not | `CohereChatClient as CohereChatMixin` |
+| Wire-stream import (composition side) | `{Provider}{Api}Stream as _{Provider}{Api}Stream` — always | `CohereChatStream as _CohereChatStream` |
+| Wire config import | plain `from celeste.providers.{provider}.{api} import config` — never aliased | — |
+| Mapper set, single-backend file | bare classes + one `{PROVIDER}_PARAMETER_MAPPERS` | `TemperatureMapper`, `COHERE_PARAMETER_MAPPERS` |
+| Mapper set, multi-backend file | every set tokened: `{Backend}NameMapper` classes, `_{Backend}NameMapper` wire aliases, `{PROVIDER}_{BACKEND}_PARAMETER_MAPPERS` lists — no bare set survives | `VertexTemperatureMapper`, `GOOGLE_VERTEX_PARAMETER_MAPPERS` |
+| Module functions, multi-backend file | backend-token suffix on every function | `map_grounding_vertex`, `map_grounding_interactions` |
+| Public module-level data constants | `{PROVIDER}_...`; `MODELS` is the sole bare contract name | `GOOGLE_VOICES`, `GOOGLE_SUPPORTED_MIME_TYPES` |
+
+The prefix is always the `Provider` enum name, never a brand or model family (`Google`, not `Gemini`). A family token may follow the provider prefix only when parallel same-kind constants partition the data (`GOOGLE_IMAGEN_MODELS` / `GOOGLE_GEMINI_MODELS`). The backend token is the backend file name (`imagen.py` → `Imagen`, `vertex.py` → `Vertex`, `interactions.py` → `Interactions`). Wire helper functions, protocol base clients, and module-private names (`_IMAGEN_MODEL_IDS`) keep their real names.
+
+## Notes
+
+- The commented Vertex block in `providers/{provider_slug}/{api_slug}/client.py.template` is only for providers that serve the SAME wire API on both api-key and ADC auth (different host). A different wire format per auth is route 3, not a `_build_url` branch.

--- a/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
+++ b/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
@@ -1,0 +1,130 @@
+"""{Provider} {modality} client (dispatches across wire backends).
+
+Use only when one provider serves two or more wire APIs; single-backend
+providers use client.py.template. The PROVIDERS registry entry stays
+{Provider}{Modality}Client — the registry never branches.
+"""
+
+from typing import Any, Unpack
+
+from celeste.grounding import Grounding
+from celeste.parameters import ParameterMapper
+from celeste.tools import ToolCall
+from celeste.types import {Content}
+
+from ...client import {Modality}Client
+from ...io import {Modality}Input
+from ...parameters import {Modality}Parameters
+from .{api1_slug} import {Provider}{Api1}{Modality}Client
+from .{api2_slug} import {Provider}{Api2}{Modality}Client
+from .parameters import (
+    {PROVIDER}_{API1}_PARAMETER_MAPPERS,
+    {PROVIDER}_{API2}_PARAMETER_MAPPERS,
+)
+
+
+class {Provider}{Modality}Client({Modality}Client):
+    """{Provider} {modality} client (selects the {Api1} or {Api2} backend)."""
+
+    _strategy: {Provider}{Api1}{Modality}Client | {Provider}{Api2}{Modality}Client | None = None
+
+    def model_post_init(self, __context: object) -> None:
+        """Select the backend once — by auth type and/or model id."""
+        super().model_post_init(__context)
+
+        # Selection axes used in-repo:
+        #   by auth:     {Api2}... if isinstance(self.auth, {Provider}ADC) else {Api1}...
+        #   by model id: {Api1}... if self.model.id in _{API1}_MODEL_IDS else ...
+        StrategyClass = {Provider}{Api1}{Modality}Client
+        strategy = StrategyClass(
+            modality=self.modality,
+            model=self.model,
+            provider=self.provider,
+            auth=self.auth,
+            base_url=self.base_url,
+        )
+        object.__setattr__(self, "_strategy", strategy)
+        # Copy every endpoint ClassVar the modality routes on:
+        # if strategy._generate_endpoint is not None:
+        #     object.__setattr__(self, "_generate_endpoint", strategy._generate_endpoint)
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[{Content}]]:
+        return [
+            *{PROVIDER}_{API1}_PARAMETER_MAPPERS,
+            *{PROVIDER}_{API2}_PARAMETER_MAPPERS,
+        ]
+
+    # Forward every hook a backend customizes — a missing delegate silently runs
+    # the base implementation. tests/unit_tests/test_dispatcher_delegation.py
+    # auto-discovers this class from the registry and fails CI naming any hook it
+    # must define; ModalityClient's docstring (src/celeste/client.py) describes
+    # the hook surface.
+    def _init_request(self, inputs: {Modality}Input) -> dict[str, Any]:
+        return self._strategy._init_request(inputs)  # type: ignore[union-attr]
+
+    def _build_request(
+        self,
+        inputs: {Modality}Input,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Unpack[{Modality}Parameters],
+    ) -> dict[str, Any]:
+        return self._strategy._build_request(  # type: ignore[union-attr]
+            inputs, extra_body=extra_body, streaming=streaming, **parameters
+        )
+
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[{Modality}Parameters],
+    ) -> dict[str, Any]:
+        return await self._strategy._make_request(  # type: ignore[union-attr]
+            request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
+        )
+
+    def _parse_content(self, response_data: dict[str, Any]) -> {Content}:
+        return self._strategy._parse_content(response_data)  # type: ignore[union-attr]
+
+    def _parse_usage(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
+        return self._strategy._parse_usage(response_data)  # type: ignore[union-attr]
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> Any:
+        return self._strategy._parse_finish_reason(response_data)  # type: ignore[union-attr]
+
+    def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
+        return self._strategy._parse_tool_calls(response_data)  # type: ignore[union-attr]
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        return self._strategy._parse_reasoning(response_data)  # type: ignore[union-attr]
+
+    def _parse_grounding(self, response_data: dict[str, Any]) -> Grounding | None:
+        return self._strategy._parse_grounding(response_data)  # type: ignore[union-attr]
+
+    def _parse_container(self, response_data: dict[str, Any]) -> dict[str, Any] | None:
+        return self._strategy._parse_container(response_data)  # type: ignore[union-attr]
+
+    def _transform_output(self, content: {Content}, **parameters: Any) -> {Content}:
+        return self._strategy._transform_output(content, **parameters)  # type: ignore[union-attr]
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        return self._strategy._build_metadata(response_data)  # type: ignore[union-attr]
+
+    # Streaming path — delete if this provider does not stream this modality:
+    # def _make_stream_request(self, request_body, *, endpoint=None, extra_headers=None, **parameters):
+    #     return self._strategy._make_stream_request(
+    #         request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
+    #     )
+    #
+    # def _stream_class(self) -> type[{Modality}Stream]:
+    #     return self._strategy._stream_class()
+
+
+__all__ = ["{Provider}{Modality}Client"]

--- a/templates/modalities/{modality_slug}/providers/{provider_slug}/parameters.py.template
+++ b/templates/modalities/{modality_slug}/providers/{provider_slug}/parameters.py.template
@@ -15,6 +15,10 @@ class AspectRatioMapper(_ExampleMapper):
     name = {Modality}Parameter.ASPECT_RATIO
 
 
+# A second wire API makes this file multi-backend: rename this set with the first
+# backend's token ({Api1}NameMapper / {PROVIDER}_{API1}_PARAMETER_MAPPERS), add the
+# parallel {Api2} set, and let the dispatcher client.py merge the lists in
+# parameter_mappers(). No bare set survives in a multi-backend file.
 {PROVIDER}_PARAMETER_MAPPERS: list[ParameterMapper[{Content}]] = [
     AspectRatioMapper(),
 ]

--- a/templates/providers/{provider_slug}/{api_slug}/client.py.template
+++ b/templates/providers/{provider_slug}/{api_slug}/client.py.template
@@ -3,8 +3,6 @@
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
-import httpx
-
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
@@ -22,7 +20,6 @@ class {Provider}{Api}Client(APIMixin):
     Provides shared HTTP implementation:
     - _make_request(endpoint=...) - HTTP POST to specified endpoint
     - _make_stream_request() - HTTP streaming (if supported, otherwise raises StreamingNotSupportedError)
-    - _make_poll_request() - Poll long-running operations (if supported, otherwise remove)
     - _parse_usage() - Extract usage dict from response
     - _parse_content() - Extract content from response
     - _parse_finish_reason() - Extract finish reason (if provided)
@@ -127,27 +124,6 @@ class {Provider}{Api}Client(APIMixin):
             headers=headers,
             json_body=request_body,
         )
-
-    async def _make_poll_request(
-        self,
-        operation_name: str,
-        extra_headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Poll a long-running operation.
-
-        If this API does not use long-running operations, remove this method.
-        Override for Vertex AI support (POST to fetchPredictOperation).
-        """
-        headers = self._merge_headers(self.auth.get_headers(), extra_headers)
-        poll_url = f"{config.BASE_URL}{config.{Provider}{Api}Endpoint.GET_OPERATION.format(operation_name=operation_name)}"
-
-        response = await self.http_client.get(
-            poll_url,
-            headers=headers,
-        )
-        self._handle_error_response(response)
-        data: dict[str, Any] = response.json()
-        return data
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:


### PR DESCRIPTION
Writes down everything that was previously oral tradition about adding a wire API — the gaps that made the Interactions migration painful.

- **CLAUDE.md**: multi-backend dispatcher pattern (registry invariant, `_strategy` selection, hook forwarding enforced by the delegation guard from #317), the naming scheme incl. wire-import alias rules, the variation escalation ladder (endpoint ClassVar → `_build_url` auth branch → dispatcher), a Code style section, and the wire-contract-matrix / dispatch-assert testing obligations. Protocol description made vendor-neutral (a protocol is a wire format served by many vendors, not an OpenAI feature).
- **CONTRIBUTING.md**: new "Adding a second API to an existing provider" — the 8-step delta against the new-provider checklist (which steps are no-ops, demote `client.py` → `{api}.py`, dispatcher, backend-tokened mapper sets, live probes before pinning, test shapes).
- **templates/README.md** (new): the three routes (new provider / speaks an existing protocol / second wire API), the naming table, and the Vertex-block scope note.
- **`_dispatcher.py.template`** (new): the strategy-wrapper skeleton — the largest hand-written artifact of a second-API migration previously had no template.
- Template fixes: parameters template documents the multi-backend rename rule; wire client template drops its unused `import httpx` (an F401 trap once stripped) and the speculative `_make_poll_request` used by zero committed clients.

A few naming examples (`GOOGLE_VERTEX_PARAMETER_MAPPERS`, `VertexTemperatureMapper`) reference names the Interactions migration PR introduces — docs run briefly ahead of the code until it lands.

Third of the 4-PR stack: uniformity (#316) → guard (#317) → **docs** → Interactions migration.

`make ci` green.