### PR TITLE
fix(templates): Unpack in dispatcher template _transform_output

### DIFF
--- a/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
+++ b/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
@@ -111,7 +111,9 @@ class {Provider}{Modality}Client({Modality}Client):
     def _parse_container(self, response_data: dict[str, Any]) -> dict[str, Any] | None:
         return self._strategy._parse_container(response_data)  # type: ignore[union-attr]
 
-    def _transform_output(self, content: {Content}, **parameters: Any) -> {Content}:
+    def _transform_output(
+        self, content: {Content}, **parameters: Unpack[{Modality}Parameters]
+    ) -> {Content}:
         return self._strategy._transform_output(content, **parameters)  # type: ignore[union-attr]
 
     def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Review finding on #318: the dispatcher template's `_transform_output` used `**parameters: Any` while the sibling hooks and the modality-layer Code style rule require `Unpack[{Modality}Parameters]`. One line.