### PR TITLE
fix(google): restore generateContent parity on the Interactions path

### DIFF
--- a/src/celeste/modalities/text/providers/google/grounding.py
+++ b/src/celeste/modalities/text/providers/google/grounding.py
@@ -104,8 +104,13 @@ def map_grounding_interactions(steps: list[dict[str, Any]]) -> Grounding | None:
                     continue
                 if url not in source_indices:
                     source_indices[url] = len(sources)
+                    title = annotation.get("title")
                     sources.append(
-                        GroundingSource(url=url, title=annotation.get("title"))
+                        GroundingSource(
+                            url=url,
+                            title=title,
+                            domain=annotation.get("domain") or title,
+                        )
                     )
                 start = annotation.get("start_index")
                 end = annotation.get("end_index")
@@ -120,6 +125,7 @@ def map_grounding_interactions(steps: list[dict[str, Any]]) -> Grounding | None:
                         start=start,
                         end=end,
                         source_indices=[source_indices[url]],
+                        cited_text=part_text[start:end] or None,
                     )
                 )
 

--- a/src/celeste/modalities/text/providers/google/interactions.py
+++ b/src/celeste/modalities/text/providers/google/interactions.py
@@ -159,17 +159,16 @@ class GoogleInteractionsTextClient(GoogleInteractionsMixin, TextClient):
         self,
         response_data: dict[str, Any],
     ) -> TextContent:
-        """Parse content from response."""
+        """Parse text across all model_output steps (matches stream concatenation)."""
         steps = super()._parse_content(response_data)
-        for step in steps:
-            if step.get("type") != "model_output":
-                continue
-            for part in step.get("content", []):
-                if part.get("type") == "text":
-                    text = part.get("text")
-                    if text is not None:
-                        return text
-        return ""
+        texts = [
+            part.get("text")
+            for step in steps
+            if step.get("type") == "model_output"
+            for part in step.get("content", [])
+            if part.get("type") == "text" and part.get("text") is not None
+        ]
+        return "".join(texts)
 
     def _parse_reasoning(
         self, response_data: dict[str, Any]

--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -29,6 +29,7 @@ MODELS: list[Model] = [
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
             # Flash: allows -1 (dynamic), 0 (disable), or >= 0
             TextParameter.THINKING_BUDGET: Range(min=-1, max=24576),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -52,6 +53,7 @@ MODELS: list[Model] = [
             TextParameter.THINKING_BUDGET: Range(
                 min=512, max=24576, special_values=[-1, 0]
             ),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -75,6 +77,7 @@ MODELS: list[Model] = [
             TextParameter.THINKING_BUDGET: Range(
                 min=128, max=32768, special_values=[-1]
             ),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -105,6 +105,8 @@ class GoogleInteractionsClient(APIMixin):
             UsageField.INPUT_TOKENS: usage_data.get("total_input_tokens"),
             UsageField.OUTPUT_TOKENS: usage_data.get("total_output_tokens"),
             UsageField.TOTAL_TOKENS: usage_data.get("total_tokens"),
+            UsageField.REASONING_TOKENS: usage_data.get("total_thought_tokens"),
+            UsageField.CACHED_TOKENS: usage_data.get("total_cached_tokens"),
         }
 
     def _parse_usage(

--- a/src/celeste/providers/google/interactions/streaming.py
+++ b/src/celeste/providers/google/interactions/streaming.py
@@ -28,6 +28,10 @@ def reconstruct_steps(raw_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
             if delta_type == "text":
                 content = step.setdefault("content", [{"type": "text", "text": ""}])
                 content[0]["text"] += delta.get("text") or ""
+            elif delta_type == "text_annotation_delta":
+                content = step.setdefault("content", [{"type": "text", "text": ""}])
+                annotations = content[0].setdefault("annotations", [])
+                annotations.extend(delta.get("annotations") or [])
             elif delta_type == "arguments_delta":
                 step["_arguments_json"] = step.get("_arguments_json", "") + (
                     delta.get("arguments") or ""
@@ -38,6 +42,14 @@ def reconstruct_steps(raw_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
             elif delta_type == "thought_signature":
                 step["signature"] = step.get("signature", "") + (
                     delta.get("signature") or ""
+                )
+            else:
+                # google_search_call / google_search_result deltas carry complete
+                # step fields (arguments dict, result list, is_error) verbatim.
+                if delta.get("signature"):
+                    step["signature"] = step.get("signature", "") + delta["signature"]
+                step.update(
+                    {k: v for k, v in delta.items() if k not in ("type", "signature")}
                 )
         elif event_type == "step.stop":
             step = pending.pop(index, None)

--- a/tests/integration_tests/text/test_tools.py
+++ b/tests/integration_tests/text/test_tools.py
@@ -45,23 +45,26 @@ async def test_web_search(provider: Provider, model: str) -> None:
 
     assert isinstance(output, TextOutput)
     assert output.content
+    assert output.grounding is not None
+    assert output.grounding.sources
 
 
 @pytest.mark.parametrize(("provider", "model"), WEB_SEARCH_MODELS)
 async def test_stream_web_search(provider: Provider, model: str) -> None:
     client = create_client(modality=Modality.TEXT, provider=provider, model=model)
 
-    chunks = [
-        chunk
-        async for chunk in client.stream.generate(
-            prompt="When was Python 3.12 released?",
-            tools=[WebSearch()],
-            max_tokens=500,
-        )
-    ]
+    stream = client.stream.generate(
+        prompt="When was Python 3.12 released?",
+        tools=[WebSearch()],
+        max_tokens=500,
+    )
+    chunks = [chunk async for chunk in stream]
 
     assert chunks
     assert all(isinstance(chunk, TextChunk) for chunk in chunks)
+    grounding = stream.output.grounding
+    assert grounding is not None
+    assert grounding.sources
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_google_interactions_step_reconstruction.py
+++ b/tests/unit_tests/test_google_interactions_step_reconstruction.py
@@ -141,6 +141,64 @@ def test_reconstructs_interleaved_steps_by_index() -> None:
     assert steps[1]["arguments"] == {"location": "Paris"}
 
 
+def test_reconstructs_text_annotations_and_search_steps() -> None:
+    events = [
+        {
+            "index": 0,
+            "step": {"type": "google_search_call", "id": "s1", "signature": "sig-"},
+            "event_type": "step.start",
+        },
+        {
+            "index": 0,
+            "delta": {
+                "type": "google_search_call",
+                "arguments": {"queries": ["celeste sdk"]},
+                "signature": "call",
+            },
+            "event_type": "step.delta",
+        },
+        {"index": 0, "event_type": "step.stop"},
+        {
+            "index": 1,
+            "step": {"type": "google_search_result"},
+            "event_type": "step.start",
+        },
+        {
+            "index": 1,
+            "delta": {
+                "type": "google_search_result",
+                "result": [{"search_suggestions": "<div/>"}],
+            },
+            "event_type": "step.delta",
+        },
+        {"index": 1, "event_type": "step.stop"},
+        {"index": 2, "step": {"type": "model_output"}, "event_type": "step.start"},
+        {
+            "index": 2,
+            "delta": {"type": "text", "text": "Celeste is a Python SDK."},
+            "event_type": "step.delta",
+        },
+        {
+            "index": 2,
+            "delta": {
+                "type": "text_annotation_delta",
+                "annotations": [{"type": "url_citation", "url": "https://example.com"}],
+            },
+            "event_type": "step.delta",
+        },
+        {"index": 2, "event_type": "step.stop"},
+    ]
+
+    steps = reconstruct_steps(events)
+
+    assert steps[0]["arguments"] == {"queries": ["celeste sdk"]}
+    assert steps[0]["signature"] == "sig-call"
+    assert steps[1]["result"] == [{"search_suggestions": "<div/>"}]
+    annotations = steps[2]["content"][0]["annotations"]
+    assert annotations[0]["type"] == "url_citation"
+    assert annotations[0]["url"] == "https://example.com"
+
+
 def test_step_without_stop_is_dropped() -> None:
     events = [
         {"index": 0, "step": {"type": "model_output"}, "event_type": "step.start"},


### PR DESCRIPTION
A full parity audit of the Interactions migration (#321) — three subagents over the old d1105ba path, the SSE wire, and the GA docs, plus live probes — found and fixes every confirmed regression on the API-key path (the ADC/Vertex path is byte-identical to old and unaffected).

## Regressions fixed (each live-verified)

1. **Streamed grounding lost** — Google streams citations and search steps as three delta shapes `reconstruct_steps` didn't handle: `text_annotation_delta` (url_citations), `google_search_call` (arguments/queries), `google_search_result` (result/search_suggestions), plus signature fragments on those deltas. Streamed `output.grounding` collapsed to `None` — no inline sources in downstream apps. Now reconstructed; verified live: queries, titled sources, char-offset citations, and entry point through celeste's stream path.
2. **`reasoning_tokens`/`cached_tokens` always `None`** — the old path mapped `thoughtsTokenCount`/`cachedContentTokenCount`; `map_usage_fields` dropped both (`total_thought_tokens`/`total_cached_tokens`). Live: `reasoning_tokens=918` now flows, unary and streaming.
3. **Citation `cited_text` and source `domain` lost** — the annotations mapper set neither; old populated both. `cited_text` is sliced from the verified char offsets; `domain` keeps the old title-fallback semantics.
4. **`thinking_budget` silently dead on 2.5 models** — the catalog advertised only THINKING_BUDGET on gemini-2.5-* (no Interactions representation → unmapped → silently dropped; UIs render controls from constraints). Added `THINKING_LEVEL` Choice constraints with live-probed allowlists: flash `low/medium/high`; pro and flash-lite `low/high` (serving's own stated values). Budget constraints stay — the Vertex path still maps them. Conflict recorded: the thinking docs claim flash-lite supports `medium`; serving rejects it, and `low` breaks on Google's own budget translation (256 < 512 floor).
5. **Unary text inconsistent with stream** — `_parse_content` returned only the first text part of the first `model_output` step; now concatenates all text parts across steps, matching stream semantics.
6. **Test gap that let this ship** — `test_web_search`/`test_stream_web_search` asserted only `content`; both now assert `grounding.sources`, and the step-reconstruction unit test covers the three wire-true delta shapes.

## Suspected regressions dissolved by live evidence (documented, no code)

- Finish-reason granularity: token cap returns `status='incomplete'` — passthrough surfaces it; vocabulary change (`MAX_TOKENS`→`incomplete`), not a loss.
- Replay continuity: two-turn conversations after web-search and after code-execution both succeed without replaying server-tool steps (no 400s).
- Wire limitations, not celeste's: `system_instruction` is a string (non-text system parts can't ride); image block diagnostics (`finishMessage`) have no Interactions equivalent.

## Net-new Interactions capabilities (not regressions — the old path lacked them too)

Tracked for follow-up issues rather than riding this fix: `seed` mapper (unified param already exists), `url_context` tool, code-execution step surfacing, multi-speaker `speech_config`, `background` + `GET /interactions/{id}`, `file_search`/`retrieval`/`google_maps`/`computer_use`/`mcp_server` tools, explicit `response_modalities`. Omni video and Lyria already tracked (#319, #320).

## Verification

`make ci` green; live: web-search unary+stream with grounding asserts (2.5-flash-lite), streamed news grounding on 3.5-flash (the original report's scenario), reasoning tokens populated, google generate/stream/reasoning suite 9/9.