### PR TITLE
feat(audio): GENERATE operation + Google Lyria music models

### DIFF
--- a/src/celeste/core.py
+++ b/src/celeste/core.py
@@ -123,6 +123,7 @@ DOMAIN_OPERATION_TO_MODALITY: dict[tuple[Domain, Operation], Modality] = {
     (Domain.IMAGES, Operation.EDIT): Modality.IMAGES,
     (Domain.IMAGES, Operation.ANALYZE): Modality.TEXT,
     (Domain.IMAGES, Operation.EMBED): Modality.EMBEDDINGS,
+    (Domain.AUDIO, Operation.GENERATE): Modality.AUDIO,
     (Domain.AUDIO, Operation.EMBED): Modality.EMBEDDINGS,
     (Domain.AUDIO, Operation.SPEAK): Modality.AUDIO,
     (Domain.AUDIO, Operation.ANALYZE): Modality.TEXT,

--- a/src/celeste/modalities/audio/client.py
+++ b/src/celeste/modalities/audio/client.py
@@ -16,7 +16,7 @@ from .streaming import AudioStream
 class AudioClient(
     ModalityClient[AudioInput, AudioOutput, AudioParameters, AudioContent, AudioChunk]
 ):
-    """Base audio client with speak operation."""
+    """Base audio client with speak and generate operations."""
 
     modality: Modality = Modality.AUDIO
     _usage_class = AudioUsage
@@ -24,6 +24,7 @@ class AudioClient(
     _content_fields: ClassVar[set[str]] = {"audio_bytes"}
 
     _speak_endpoint: ClassVar[str | None] = None
+    _generate_endpoint: ClassVar[str | None] = None
 
     @classmethod
     def _output_class(cls) -> type[AudioOutput]:
@@ -38,6 +39,20 @@ class AudioClient(
         """Convert text to speech audio."""
         inputs = AudioInput(text=text)
         return await self._predict(inputs, endpoint=self._speak_endpoint, **parameters)
+
+    async def generate(
+        self,
+        prompt: str,
+        **parameters: Unpack[AudioParameters],
+    ) -> AudioOutput:
+        """Generate audio from a prompt."""
+        if self._generate_endpoint is None:
+            msg = f"Model {self.model.id} does not support audio generation"
+            raise NotImplementedError(msg)
+        inputs = AudioInput(text=prompt)
+        return await self._predict(
+            inputs, endpoint=self._generate_endpoint, **parameters
+        )
 
     @property
     def stream(self) -> "AudioStreamNamespace":
@@ -93,6 +108,27 @@ class AudioSyncNamespace:
         inputs = AudioInput(text=text)
         return async_to_sync(self._client._predict)(
             inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[AudioParameters],
+    ) -> AudioOutput:
+        """Blocking audio generation."""
+        if self._client._generate_endpoint is None:
+            msg = f"Model {self._client.model.id} does not support audio generation"
+            raise NotImplementedError(msg)
+        inputs = AudioInput(text=prompt)
+        return async_to_sync(self._client._predict)(
+            inputs,
+            endpoint=self._client._generate_endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
         )
 
     @property

--- a/src/celeste/modalities/audio/parameters.py
+++ b/src/celeste/modalities/audio/parameters.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from pydantic import Field
 
+from celeste.artifacts import ImageArtifact
 from celeste.parameters import Parameters
 
 
@@ -14,8 +15,8 @@ class AudioParameter(StrEnum):
     VOICE = "voice"
     SPEED = "speed"
     OUTPUT_FORMAT = "output_format"
-    PROMPT = "prompt"
     LANGUAGE = "language"
+    REFERENCE_IMAGES = "reference_images"
 
 
 class AudioParameters(Parameters, total=False):
@@ -28,10 +29,11 @@ class AudioParameters(Parameters, total=False):
         float, Field(description="Playback speed multiplier (1.0 = normal).")
     ]
     output_format: Annotated[str, Field(description="Audio file format.")]
-    prompt: Annotated[
-        str, Field(description="Style or delivery instruction for the voice.")
-    ]
     language: Annotated[str, Field(description="BCP-47 language tag, e.g. 'en-US'.")]
+    reference_images: Annotated[
+        list[ImageArtifact],
+        Field(description="Additional images conditioning the audio."),
+    ]
 
 
 __all__ = [

--- a/src/celeste/modalities/audio/providers/google/client.py
+++ b/src/celeste/modalities/audio/providers/google/client.py
@@ -23,7 +23,7 @@ from .parameters import GOOGLE_PARAMETER_MAPPERS, OutputFormatMapper
 # Interactions audio mime strings → celeste audio mime types
 GOOGLE_AUDIO_MIME_TYPES: dict[str, AudioMimeType] = {
     wire: mime for mime, wire in OutputFormatMapper.mime_map.items()
-}
+} | {"audio/mpeg": AudioMimeType.MP3}
 
 
 def _to_audio_mime(raw: str | None) -> AudioMimeType:
@@ -68,9 +68,10 @@ class GoogleAudioStream(_GoogleInteractionsStream, AudioStream):
 
 
 class GoogleAudioClient(GoogleInteractionsMixin, AudioClient):
-    """Google audio client (Interactions API TTS)."""
+    """Google audio client (Interactions API TTS and music generation)."""
 
     _speak_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
+    _generate_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[AudioContent]]:

--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -1,6 +1,6 @@
-"""Google TTS models for audio modality."""
+"""Google models for audio modality."""
 
-from celeste.constraints import Choice
+from celeste.constraints import Choice, ImagesConstraint
 from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import AudioMimeType
 from celeste.models import Model
@@ -77,6 +77,26 @@ MODELS: list[Model] = [
             AudioParameter.VOICE: VoiceConstraint(voices=GOOGLE_VOICES),
             AudioParameter.LANGUAGE: Choice(options=GOOGLE_SUPPORTED_LANGUAGES),
             AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
+        },
+    ),
+    Model(
+        id="lyria-3-clip-preview",
+        provider=Provider.GOOGLE,
+        display_name="Google Lyria 3 Clip (Preview)",
+        operations={Modality.AUDIO: {Operation.GENERATE}},
+        parameter_constraints={
+            AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
+            AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
+        },
+    ),
+    Model(
+        id="lyria-3-pro-preview",
+        provider=Provider.GOOGLE,
+        display_name="Google Lyria 3 Pro (Preview)",
+        operations={Modality.AUDIO: {Operation.GENERATE}},
+        parameter_constraints={
+            AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
+            AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),
 ]

--- a/src/celeste/modalities/audio/providers/google/parameters.py
+++ b/src/celeste/modalities/audio/providers/google/parameters.py
@@ -11,6 +11,9 @@ from celeste.providers.google.interactions.parameters import (
     LanguageMapper as _LanguageMapper,
 )
 from celeste.providers.google.interactions.parameters import (
+    MediaContentMapper as _MediaContentMapper,
+)
+from celeste.providers.google.interactions.parameters import (
     VoiceMapper as _VoiceMapper,
 )
 from celeste.types import AudioContent
@@ -64,10 +67,17 @@ class OutputFormatMapper(_AudioMimeTypeMapper):
     }
 
 
+class ReferenceImagesMapper(_MediaContentMapper[AudioContent]):
+    """Map reference_images to Google Interactions input content."""
+
+    name = AudioParameter.REFERENCE_IMAGES
+
+
 GOOGLE_PARAMETER_MAPPERS: list[ParameterMapper[AudioContent]] = [
     VoiceMapper(),
     LanguageMapper(),
     OutputFormatMapper(),
+    ReferenceImagesMapper(),
 ]
 
 __all__ = ["GOOGLE_PARAMETER_MAPPERS"]

--- a/src/celeste/modalities/images/providers/google/parameters.py
+++ b/src/celeste/modalities/images/providers/google/parameters.py
@@ -108,7 +108,7 @@ class InteractionsQualityMapper(_InteractionsImageSizeMapper):
     name = ImageParameter.QUALITY
 
 
-class InteractionsReferenceImagesMapper(_InteractionsMediaContentMapper):
+class InteractionsReferenceImagesMapper(_InteractionsMediaContentMapper[ImageContent]):
     """Map reference_images to Google Interactions input content."""
 
     name = ImageParameter.REFERENCE_IMAGES

--- a/src/celeste/namespaces/domains.py
+++ b/src/celeste/namespaces/domains.py
@@ -792,6 +792,27 @@ class SyncAudioNamespace:
         )
         return client.sync.speak(text, **params)
 
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **params: Unpack[AudioParameters],
+    ) -> AudioOutput:
+        """Blocking audio generation."""
+        client = create_client(
+            modality=Modality.AUDIO,
+            operation=Operation.GENERATE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return client.sync.generate(prompt, **params)
+
     def analyze(
         self,
         audio: AudioContent,
@@ -845,7 +866,7 @@ class SyncAudioNamespace:
 class AudioNamespace:
     """celeste.audio.* namespace.
 
-    Provides text-to-speech and audio analysis operations.
+    Provides text-to-speech, audio generation, and audio analysis operations.
     """
 
     async def speak(
@@ -880,6 +901,39 @@ class AudioNamespace:
             auth=auth,
         )
         return await client.speak(text, **parameters)
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **parameters: Unpack[AudioParameters],
+    ) -> AudioOutput:
+        """Generate audio from a prompt.
+
+        Args:
+            prompt: The text prompt for audio generation.
+            model: Model ID to use (required).
+            provider: Optional provider override.
+            api_key: Optional API key override.
+            auth: Optional Authentication object (e.g., GoogleADC for Vertex AI).
+            **parameters: Additional model parameters.
+
+        Returns:
+            AudioOutput with generated audio.
+        """
+        client = create_client(
+            modality=Modality.AUDIO,
+            operation=Operation.GENERATE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return await client.generate(prompt, **parameters)
 
     async def analyze(
         self,

--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -291,7 +291,7 @@ class ImageSizeMapper(ParameterMapper[ImageContent]):
         return request
 
 
-class MediaContentMapper(ParameterMapper[ImageContent]):
+class MediaContentMapper[Content](ParameterMapper[Content]):
     """Map reference_images to Google Interactions input content."""
 
     def map(
@@ -321,6 +321,11 @@ class MediaContentMapper(ParameterMapper[ImageContent]):
         elif isinstance(current_input, list):
             request["input"] = [
                 {"type": "user_input", "content": [*image_parts, *current_input]}
+            ]
+        elif isinstance(current_input, str):
+            request["input"] = [
+                {"type": "text", "text": current_input},
+                *image_parts,
             ]
         else:
             request["input"] = [{"type": "user_input", "content": image_parts}]

--- a/tests/integration_tests/audio/test_generate.py
+++ b/tests/integration_tests/audio/test_generate.py
@@ -1,0 +1,38 @@
+import pytest
+
+from celeste import Modality, Provider, create_client
+from celeste.artifacts import AudioArtifact, ImageArtifact
+from celeste.modalities.audio import AudioOutput
+
+MODELS = [
+    (Provider.GOOGLE, "lyria-3-clip-preview"),
+]
+
+
+@pytest.mark.parametrize(("provider", "model"), MODELS)
+async def test_generate(provider: Provider, model: str) -> None:
+    client = create_client(modality=Modality.AUDIO, provider=provider, model=model)
+
+    response = await client.generate(
+        prompt="A short instrumental acoustic guitar piece."
+    )
+
+    assert isinstance(response, AudioOutput)
+    assert isinstance(response.content, AudioArtifact)
+    assert response.content.has_content
+
+
+@pytest.mark.parametrize(("provider", "model"), MODELS)
+async def test_generate_with_reference_images(
+    provider: Provider, model: str, square_image: ImageArtifact
+) -> None:
+    client = create_client(modality=Modality.AUDIO, provider=provider, model=model)
+
+    response = await client.generate(
+        prompt="An ambient track inspired by the mood and colors in this image.",
+        reference_images=[square_image],
+    )
+
+    assert isinstance(response, AudioOutput)
+    assert isinstance(response.content, AudioArtifact)
+    assert response.content.has_content

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -12,6 +12,7 @@ from celeste.core import Domain, Modality, Operation, infer_modality
         (Domain.TEXT, Operation.EMBED, Modality.EMBEDDINGS),
         (Domain.IMAGES, Operation.ANALYZE, Modality.TEXT),
         (Domain.IMAGES, Operation.EDIT, Modality.IMAGES),
+        (Domain.AUDIO, Operation.GENERATE, Modality.AUDIO),
         (Domain.AUDIO, Operation.SPEAK, Modality.AUDIO),
         (Domain.VIDEOS, Operation.GENERATE, Modality.VIDEOS),
         (Domain.DOCUMENTS, Operation.ANALYZE, Modality.TEXT),

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -4,7 +4,9 @@ import pytest
 from pydantic import BaseModel
 
 from celeste.artifacts import ImageArtifact
-from celeste.mime_types import ImageMimeType
+from celeste.mime_types import AudioMimeType, ImageMimeType
+from celeste.modalities.audio.parameters import AudioParameter
+from celeste.modalities.audio.providers.google import parameters as google_audio
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.bfl import parameters as bfl
 from celeste.modalities.images.providers.google import parameters as google_images
@@ -30,6 +32,7 @@ GOOGLE_INTERACTIONS = google_text.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 IMAGES_VERTEX = google_images.GOOGLE_VERTEX_PARAMETER_MAPPERS
 IMAGES_INTERACTIONS = google_images.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 IMAGES_IMAGEN = google_images.GOOGLE_IMAGEN_PARAMETER_MAPPERS
+AUDIO_GOOGLE = google_audio.GOOGLE_PARAMETER_MAPPERS
 OPEN = openai.OPENAI_PARAMETER_MAPPERS
 CHAT = chat.CHATCOMPLETIONS_PARAMETER_MAPPERS
 ANTHROPIC = anthropic.ANTHROPIC_PARAMETER_MAPPERS
@@ -38,7 +41,7 @@ GROQ = groq.GROQ_PARAMETER_MAPPERS
 BYTEPLUS = byteplus.BYTEPLUS_PARAMETER_MAPPERS
 XAI = xai.XAI_PARAMETER_MAPPERS
 BFL = bfl.BFL_PARAMETER_MAPPERS
-T, IP, V = TextParameter, ImageParameter, VideoParameter
+T, IP, V, AP = TextParameter, ImageParameter, VideoParameter, AudioParameter
 GC = ("generationConfig",)
 TC = (*GC, "thinkingConfig")
 IC = (*GC, "imageConfig")
@@ -104,6 +107,27 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (IMAGES_IMAGEN, IP.ASPECT_RATIO, "16:9", ("parameters", "aspectRatio"), "16:9"),
         (IMAGES_IMAGEN, IP.QUALITY, "2K", ("parameters", "imageSize"), "2K"),
         (IMAGES_IMAGEN, IP.NUM_IMAGES, 2, ("parameters", "sampleCount"), 2),
+        (
+            AUDIO_GOOGLE,
+            AP.VOICE,
+            "Kore",
+            ("generation_config", "speech_config"),
+            [{"voice": "Kore"}],
+        ),
+        (
+            AUDIO_GOOGLE,
+            AP.LANGUAGE,
+            "en",
+            ("generation_config", "speech_config"),
+            [{"language": "en-US"}],
+        ),
+        (
+            AUDIO_GOOGLE,
+            AP.OUTPUT_FORMAT,
+            AudioMimeType.MP3,
+            ("response_format", "mime_type"),
+            "audio/mp3",
+        ),
         (
             GOOGLE_INTERACTIONS,
             T.TEMPERATURE,
@@ -171,6 +195,7 @@ def test_scalar_parameters_use_provider_wire_shape(
         GOOGLE_VERTEX,
         IMAGES_VERTEX,
         IMAGES_IMAGEN,
+        AUDIO_GOOGLE,
         OPEN,
         CHAT,
         ANTHROPIC,
@@ -231,6 +256,50 @@ def test_google_media_precedes_text_content() -> None:
         {"file_data": {"file_uri": IMAGE.url}},
         {"text": "describe"},
     ]
+
+
+@pytest.mark.parametrize(
+    ("mappers", "name", "request_body", "expected_input"),
+    [
+        (
+            IMAGES_INTERACTIONS,
+            IP.REFERENCE_IMAGES,
+            {
+                "input": [
+                    {
+                        "type": "user_input",
+                        "content": [{"type": "text", "text": "describe"}],
+                    }
+                ]
+            },
+            [
+                {
+                    "type": "user_input",
+                    "content": [
+                        {"type": "image", "uri": IMAGE.url},
+                        {"type": "text", "text": "describe"},
+                    ],
+                }
+            ],
+        ),
+        (
+            AUDIO_GOOGLE,
+            AP.REFERENCE_IMAGES,
+            {"input": "describe"},
+            [
+                {"type": "text", "text": "describe"},
+                {"type": "image", "uri": IMAGE.url},
+            ],
+        ),
+    ],
+)
+def test_google_interactions_media_joins_input_content(
+    mappers: list[ParameterMapper[Any]],
+    name: str,
+    request_body: dict[str, Any],
+    expected_input: list[dict[str, Any]],
+) -> None:
+    assert _map(mappers, name, [IMAGE], request_body)["input"] == expected_input
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds audio generation to the unified surface and ships Google Lyria as its first carrier — complete: text-to-music and image-conditioned generation. Closes #320.

## Surface
- `(Domain.AUDIO, Operation.GENERATE) → Modality.AUDIO` — completes the (TEXT/IMAGES/VIDEOS, GENERATE) symmetry; SPEAK stays TTS-only.
- `AudioClient.generate(prompt, ...)` with the `ImagesClient.edit`-style `NotImplementedError` guard (`_generate_endpoint` ClassVar), sync twin, `celeste.audio.generate` namespaces.
- `AudioParameter.REFERENCE_IMAGES` + `reference_images: list[ImageArtifact]` (name reused from images/videos).
- Removes the never-functional `AudioParameter.PROMPT`: no mapper ever bound it on any commit (`git log --all -S` verified — the cloud_tts wire scaffolding existed but was never `.name`-bound), and PEP 692 forbids the key overlapping `generate(prompt=...)`.

## Google Lyria
- Catalog: `lyria-3-clip-preview` / `lyria-3-pro-preview` (`GENERATE`; bare ids hard-reject live with "did you mean -preview"), `OUTPUT_FORMAT: Choice(GOOGLE_SUPPORTED_FORMATS)` (also closes a celeste-side `KeyError` path on unconstrained formats), `REFERENCE_IMAGES: ImagesConstraint(max_count=10)` (limit quoted from the guide).
- `GoogleAudioClient` gains `_generate_endpoint` — same wire format as TTS, so the escalation ladder stops at the endpoint ClassVar; no dispatcher, no new backend.
- Image conditioning with zero TTS risk: `_init_request` keeps the documented string input; the wire `MediaContentMapper` (now generic `[Content]`, `ThinkingLevelMapper` precedent) gains a string-input branch producing the docs' verbatim flat-parts shape — text first, images after. The images turns-branch is untouched.
- Mime fix: Lyria responses carry `audio/mpeg` (requests take `audio/mp3`); the reverse map names it explicitly so artifacts label as MP3, not PCM.

## Tests
- Wire-contract matrix: the audio mapper list joins (voice / language / output_format rows + none-omits), plus a two-case media test asserting both `MediaContentMapper` branches with their per-doc orderings — closes a gap open since #321.
- `test_core.py` row for the new pair.
- Integration: `audio/test_generate.py` — plain and image-conditioned generation, both green live (real audio back). Also validated interactively via the streamlit playground.

## Provider doc conflicts (recorded per house rule)
- Guide says 44.1 kHz; both model pages say 48 kHz (no code impact — sample rate is read from the response).
- Pro model page lists MP3 only while the guide's prose promises WAV "by setting the response_format" — yet no official sample ever shows `mime_type`; the reference-documented `response_format.mime_type: "audio/wav"` passes through and live serving decides.
- The lyria-3-pro-preview page lists `lyria-3-clip-preview` as its model code (Google-side doc bug).

`make ci` green.