### PR TITLE
feat(google): seed parameter + UrlContext tool

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -13,7 +13,7 @@ from celeste.constraints import (
 )
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
-from celeste.tools import CodeExecution, WebSearch
+from celeste.tools import CodeExecution, UrlContext, WebSearch
 
 from ...parameters import TextParameter
 
@@ -30,7 +30,9 @@ MODELS: list[Model] = [
             # Flash: allows -1 (dynamic), 0 (disable), or >= 0
             TextParameter.THINKING_BUDGET: Range(min=-1, max=24576),
             TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -54,7 +56,9 @@ MODELS: list[Model] = [
                 min=512, max=24576, special_values=[-1, 0]
             ),
             TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -78,7 +82,9 @@ MODELS: list[Model] = [
                 min=128, max=32768, special_values=[-1]
             ),
             TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -98,7 +104,9 @@ MODELS: list[Model] = [
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
             TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -118,7 +126,9 @@ MODELS: list[Model] = [
             Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
             TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -140,7 +150,9 @@ MODELS: list[Model] = [
             TextParameter.THINKING_LEVEL: Choice(
                 options=["minimal", "low", "medium", "high"]
             ),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support
@@ -162,7 +174,9 @@ MODELS: list[Model] = [
             TextParameter.THINKING_LEVEL: Choice(
                 options=["minimal", "low", "medium", "high"]
             ),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, CodeExecution]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             # Media input support

--- a/src/celeste/modalities/text/providers/google/parameters.py
+++ b/src/celeste/modalities/text/providers/google/parameters.py
@@ -8,6 +8,9 @@ from celeste.providers.google.generate_content.parameters import (
     ResponseJsonSchemaMapper as _VertexResponseJsonSchemaMapper,
 )
 from celeste.providers.google.generate_content.parameters import (
+    SeedMapper as _VertexSeedMapper,
+)
+from celeste.providers.google.generate_content.parameters import (
     TemperatureMapper as _VertexTemperatureMapper,
 )
 from celeste.providers.google.generate_content.parameters import (
@@ -27,6 +30,9 @@ from celeste.providers.google.interactions.parameters import (
 )
 from celeste.providers.google.interactions.parameters import (
     ResponseFormatMapper as _InteractionsResponseFormatMapper,
+)
+from celeste.providers.google.interactions.parameters import (
+    SeedMapper as _InteractionsSeedMapper,
 )
 from celeste.providers.google.interactions.parameters import (
     TemperatureMapper as _InteractionsTemperatureMapper,
@@ -87,9 +93,16 @@ class VertexToolChoiceMapper(_VertexToolChoiceMapper[TextContent]):
     name = TextParameter.TOOL_CHOICE
 
 
+class VertexSeedMapper(_VertexSeedMapper[TextContent]):
+    """Map seed to Google's generationConfig.seed parameter."""
+
+    name = TextParameter.SEED
+
+
 GOOGLE_VERTEX_PARAMETER_MAPPERS: list[ParameterMapper[TextContent]] = [
     VertexTemperatureMapper(),
     VertexMaxTokensMapper(),
+    VertexSeedMapper(),
     VertexThinkingBudgetMapper(),
     VertexThinkingLevelMapper(),
     VertexOutputSchemaMapper(),
@@ -134,9 +147,16 @@ class InteractionsToolChoiceMapper(_InteractionsToolChoiceMapper):
     name = TextParameter.TOOL_CHOICE
 
 
+class InteractionsSeedMapper(_InteractionsSeedMapper):
+    """Map seed to Google's generation_config.seed parameter."""
+
+    name = TextParameter.SEED
+
+
 GOOGLE_INTERACTIONS_PARAMETER_MAPPERS: list[ParameterMapper[TextContent]] = [
     InteractionsTemperatureMapper(),
     InteractionsMaxTokensMapper(),
+    InteractionsSeedMapper(),
     InteractionsThinkingLevelMapper(),
     InteractionsOutputSchemaMapper(),
     InteractionsToolsMapper(),

--- a/src/celeste/providers/google/generate_content/parameters.py
+++ b/src/celeste/providers/google/generate_content/parameters.py
@@ -34,6 +34,24 @@ class TemperatureMapper[Content](ParameterMapper[Content]):
         return request
 
 
+class SeedMapper[Content](ParameterMapper[Content]):
+    """Map seed to Google generationConfig.seed field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform seed into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        request.setdefault("generationConfig", {})["seed"] = validated_value
+        return request
+
+
 class MaxOutputTokensMapper[Content](ParameterMapper[Content]):
     """Map max_tokens to Google generationConfig.maxOutputTokens field."""
 

--- a/src/celeste/providers/google/generate_content/tools.py
+++ b/src/celeste/providers/google/generate_content/tools.py
@@ -4,7 +4,14 @@ import warnings
 from typing import Any, ClassVar
 
 from celeste.exceptions import UnsupportedParameterWarning
-from celeste.tools import CodeExecution, Tool, ToolCall, ToolMapper, WebSearch
+from celeste.tools import (
+    CodeExecution,
+    Tool,
+    ToolCall,
+    ToolMapper,
+    UrlContext,
+    WebSearch,
+)
 
 _NATIVE_REPLAY_PART_KEYS = {
     "codeExecutionResult",
@@ -70,11 +77,25 @@ class CodeExecutionMapper(ToolMapper):
         return {"code_execution": {}}
 
 
-TOOL_MAPPERS: list[ToolMapper] = [WebSearchMapper(), CodeExecutionMapper()]
+class UrlContextMapper(ToolMapper):
+    """Map UrlContext to Google url_context wire format."""
+
+    tool_type = UrlContext
+
+    def map_tool(self, tool: Tool) -> dict[str, Any]:
+        return {"url_context": {}}
+
+
+TOOL_MAPPERS: list[ToolMapper] = [
+    WebSearchMapper(),
+    CodeExecutionMapper(),
+    UrlContextMapper(),
+]
 
 __all__ = [
     "TOOL_MAPPERS",
     "CodeExecutionMapper",
+    "UrlContextMapper",
     "WebSearchMapper",
     "needs_native_replay",
     "tool_calls_from_parts",

--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -56,6 +56,24 @@ class MaxOutputTokensMapper(ParameterMapper[TextContent]):
         return request
 
 
+class SeedMapper(ParameterMapper[TextContent]):
+    """Map seed to Google Interactions generation_config.seed field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform seed into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        request.setdefault("generation_config", {})["seed"] = validated_value
+        return request
+
+
 class ThinkingLevelMapper[Content](ParameterMapper[Content]):
     """Map thinking_level to Google Interactions generation_config.thinking_level field."""
 
@@ -406,6 +424,7 @@ __all__ = [
     "MaxOutputTokensMapper",
     "MediaContentMapper",
     "ResponseFormatMapper",
+    "SeedMapper",
     "TemperatureMapper",
     "ThinkingLevelMapper",
     "ToolChoiceMapper",

--- a/src/celeste/providers/google/interactions/tools.py
+++ b/src/celeste/providers/google/interactions/tools.py
@@ -5,7 +5,14 @@ from typing import Any, ClassVar
 from uuid import uuid4
 
 from celeste.exceptions import UnsupportedParameterWarning
-from celeste.tools import CodeExecution, Tool, ToolCall, ToolMapper, WebSearch
+from celeste.tools import (
+    CodeExecution,
+    Tool,
+    ToolCall,
+    ToolMapper,
+    UrlContext,
+    WebSearch,
+)
 
 
 def tool_calls_from_steps(steps: list[dict[str, Any]]) -> list[ToolCall]:
@@ -59,11 +66,25 @@ class CodeExecutionMapper(ToolMapper):
         return {"type": "code_execution"}
 
 
-TOOL_MAPPERS: list[ToolMapper] = [WebSearchMapper(), CodeExecutionMapper()]
+class UrlContextMapper(ToolMapper):
+    """Map UrlContext to Google Interactions url_context wire format."""
+
+    tool_type = UrlContext
+
+    def map_tool(self, tool: Tool) -> dict[str, Any]:
+        return {"type": "url_context"}
+
+
+TOOL_MAPPERS: list[ToolMapper] = [
+    WebSearchMapper(),
+    CodeExecutionMapper(),
+    UrlContextMapper(),
+]
 
 __all__ = [
     "TOOL_MAPPERS",
     "CodeExecutionMapper",
+    "UrlContextMapper",
     "WebSearchMapper",
     "tool_calls_from_steps",
 ]

--- a/src/celeste/tools.py
+++ b/src/celeste/tools.py
@@ -49,6 +49,12 @@ class CodeExecution(Tool):
     kind: Literal["code_execution"] = "code_execution"
 
 
+class UrlContext(Tool):
+    """URL context tool: the model fetches URLs referenced in the prompt (Google)."""
+
+    kind: Literal["url_context"] = "url_context"
+
+
 class ToolMapper(ABC):
     """Maps a single Tool type to provider wire format.
 
@@ -67,6 +73,7 @@ _TOOL_KINDS: dict[str, type[Tool]] = {
     "web_search": WebSearch,
     "x_search": XSearch,
     "code_execution": CodeExecution,
+    "url_context": UrlContext,
 }
 
 
@@ -184,6 +191,7 @@ __all__ = [
     "ToolOutput",
     "ToolResult",
     "ToolResultContent",
+    "UrlContext",
     "WebSearch",
     "XSearch",
     "rehydrate_tools",

--- a/tests/unit_tests/test_google_tools_mapper.py
+++ b/tests/unit_tests/test_google_tools_mapper.py
@@ -10,10 +10,17 @@ from celeste.core import Provider
 from celeste.modalities.text.parameters import TextParameter
 from celeste.models import Model
 from celeste.providers.google.generate_content.parameters import ToolsMapper
-from celeste.tools import CodeExecution, ToolDefinition, WebSearch
+from celeste.providers.google.interactions.parameters import (
+    ToolsMapper as InteractionsToolsMapper,
+)
+from celeste.tools import CodeExecution, ToolDefinition, UrlContext, WebSearch
 
 
 class _GoogleToolsMapper(ToolsMapper):
+    name = TextParameter.TOOLS
+
+
+class _GoogleInteractionsToolsMapper(InteractionsToolsMapper):
     name = TextParameter.TOOLS
 
 
@@ -31,6 +38,12 @@ def _map(tool: dict) -> dict:
 
 def _map_tools(tools: list[ToolDefinition]) -> dict[str, Any]:
     return _MAPPER.map({}, tools, _MODEL)
+
+
+def test_url_context_maps_to_both_wire_shapes() -> None:
+    assert _map_tools([UrlContext()])["tools"] == [{"url_context": {}}]
+    interactions = _GoogleInteractionsToolsMapper().map({}, [UrlContext()], _MODEL)
+    assert interactions["tools"] == [{"type": "url_context"}]
 
 
 def test_maps_to_parameters_json_schema() -> None:

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -88,6 +88,7 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
     [
         (GOOGLE_VERTEX, T.TEMPERATURE, 0.2, (*GC, "temperature"), 0.2),
         (GOOGLE_VERTEX, T.MAX_TOKENS, 80, (*GC, "maxOutputTokens"), 80),
+        (GOOGLE_VERTEX, T.SEED, 7, (*GC, "seed"), 7),
         (
             GOOGLE_VERTEX,
             T.THINKING_BUDGET,
@@ -142,6 +143,7 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
             ("generation_config", "max_output_tokens"),
             80,
         ),
+        (GOOGLE_INTERACTIONS, T.SEED, 7, ("generation_config", "seed"), 7),
         (
             GOOGLE_INTERACTIONS,
             T.THINKING_LEVEL,


### PR DESCRIPTION
Two net-new Google capabilities from the #323 parity-audit follow-up list, wired on **both** text backends so the catalog surface stays backend-agnostic (a single-backend mapping would recreate the thinking_budget-class silent drop for ADC users).

**Commit 1 — `seed`** (reproducible decoding)
- Wire mappers: `generation_config.seed` (Interactions) / `generationConfig.seed` (GenerateContent), per the API references.
- `Vertex`/`Interactions` modality bindings for the pre-existing `TextParameter.SEED`; two wire-contract matrix rows.
- No catalog constraint — the reference documents no range; passthrough by design.

**Commit 2 — `UrlContext`** (model fetches URLs referenced in the prompt)
- `UrlContext` tool class + `_TOOL_KINDS` rehydration entry.
- Wire mappers: `{"type": "url_context"}` (Interactions) / `{"url_context": {}}` (GenerateContent — the reference doesn't show the legacy shape; **pinned by live ADC call**).
- Added to all seven Google text models' `ToolSupport`; wire-shape test covers both forms.
- No config fields per the reference; the 20-public-URLs-per-request limit is provider-enforced (no local guard).

**Live verification (all four cells)**
- seed × Interactions: accepted; two calls with `seed=42, temperature=1.0` returned **identical** output.
- seed × Vertex (ADC): accepted.
- url_context × Interactions and × Vertex: both fetched `https://example.com` and described its actual content.
- `make ci` green per commit; google text integration set 14/14.

Refs: [Interactions API reference](https://ai.google.dev/api/interactions-api), [URL context guide](https://ai.google.dev/gemini-api/docs/url-context).