### PR TITLE
feat(videos): Gemini Omni video generation + editing via Interactions

### DIFF
--- a/src/celeste/modalities/images/providers/google/parameters.py
+++ b/src/celeste/modalities/images/providers/google/parameters.py
@@ -96,7 +96,7 @@ GOOGLE_VERTEX_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
 ]
 
 
-class InteractionsAspectRatioMapper(_InteractionsAspectRatioMapper):
+class InteractionsAspectRatioMapper(_InteractionsAspectRatioMapper[ImageContent]):
     """Map aspect_ratio to Google Interactions response_format.aspect_ratio."""
 
     name = ImageParameter.ASPECT_RATIO

--- a/src/celeste/modalities/videos/io.py
+++ b/src/celeste/modalities/videos/io.py
@@ -27,6 +27,10 @@ class VideoUsage(Usage):
     """
 
     total_tokens: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cached_tokens: int | None = None
     billed_units: float | None = None
 
 

--- a/src/celeste/modalities/videos/providers/google/client.py
+++ b/src/celeste/modalities/videos/providers/google/client.py
@@ -1,69 +1,114 @@
-"""Google videos client."""
+"""Google videos client (Veo by model family; Omni models use Interactions)."""
 
-from typing import Any
+from typing import Any, Unpack
 
 from celeste.artifacts import VideoArtifact
-from celeste.mime_types import VideoMimeType
 from celeste.parameters import ParameterMapper
-from celeste.providers.google.veo import config
-from celeste.providers.google.veo.client import GoogleVeoClient as GoogleVeoMixin
 from celeste.types import VideoContent
 
 from ...client import VideosClient
-from ...io import VideoInput
-from .parameters import GOOGLE_PARAMETER_MAPPERS
+from ...io import VideoFinishReason, VideoInput
+from ...parameters import VideoParameters
+from .interactions import GoogleInteractionsVideosClient
+from .models import GOOGLE_OMNI_MODELS, GOOGLE_VEO_MODELS
+from .parameters import (
+    GOOGLE_INTERACTIONS_PARAMETER_MAPPERS,
+    GOOGLE_VEO_PARAMETER_MAPPERS,
+)
+from .veo import GoogleVeoVideosClient
+
+_VEO_MODEL_IDS = frozenset(m.id for m in GOOGLE_VEO_MODELS)
+_OMNI_MODEL_IDS = frozenset(m.id for m in GOOGLE_OMNI_MODELS)
 
 
-class GoogleVideosClient(GoogleVeoMixin, VideosClient):
-    """Google client for video generation."""
+class GoogleVideosClient(VideosClient):
+    """Google videos client (selects the Veo or Interactions backend by model id)."""
 
-    _generate_endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
+    _strategy: GoogleVeoVideosClient | GoogleInteractionsVideosClient | None = None
+
+    def model_post_init(self, __context: object) -> None:
+        """Initialize the backend client based on model id."""
+        super().model_post_init(__context)
+
+        StrategyClass: type[VideosClient]
+        if self.model.id in _VEO_MODEL_IDS:
+            StrategyClass = GoogleVeoVideosClient
+        elif self.model.id in _OMNI_MODEL_IDS:
+            StrategyClass = GoogleInteractionsVideosClient
+        else:
+            msg = f"Unknown Google videos model: {self.model.id}"
+            raise ValueError(msg)
+
+        strategy = StrategyClass(
+            modality=self.modality,
+            model=self.model,
+            provider=self.provider,
+            auth=self.auth,
+            base_url=self.base_url,
+        )
+        object.__setattr__(self, "_strategy", strategy)
+
+        if strategy._generate_endpoint is not None:
+            object.__setattr__(self, "_generate_endpoint", strategy._generate_endpoint)
+        if strategy._edit_endpoint is not None:
+            object.__setattr__(self, "_edit_endpoint", strategy._edit_endpoint)
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[VideoContent]]:
-        return GOOGLE_PARAMETER_MAPPERS
+        return [
+            *GOOGLE_VEO_PARAMETER_MAPPERS,
+            *GOOGLE_INTERACTIONS_PARAMETER_MAPPERS,
+        ]
 
     def _init_request(self, inputs: VideoInput) -> dict[str, Any]:
-        """Initialize request from Google Veo API format."""
-        return {
-            "instances": [{"prompt": inputs.prompt}],
-        }
+        return self._strategy._init_request(inputs)  # type: ignore[union-attr]
+
+    def _build_request(
+        self,
+        inputs: VideoInput,
+        **parameters: Unpack[VideoParameters],
+    ) -> dict[str, Any]:
+        return self._strategy._build_request(inputs, **parameters)  # type: ignore[union-attr]
+
+    def _transform_output(
+        self, content: VideoContent, **parameters: Unpack[VideoParameters]
+    ) -> VideoContent:
+        return self._strategy._transform_output(content, **parameters)  # type: ignore[union-attr]
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        return self._strategy._build_metadata(response_data)  # type: ignore[union-attr]
+
+    def _parse_usage(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
+        return self._strategy._parse_usage(response_data)  # type: ignore[union-attr]
 
     def _parse_content(
         self,
         response_data: dict[str, Any],
-    ) -> VideoArtifact:
-        """Parse content from response."""
-        video_data = super()._parse_content(response_data)
-        # Handle inline base64 response (Vertex can return bytesBase64Encoded)
-        if "bytesBase64Encoded" in video_data:
-            mime_type = video_data.get("mimeType", VideoMimeType.MP4)
-            return VideoArtifact(
-                data=video_data["bytesBase64Encoded"], mime_type=mime_type
-            )
-        return VideoArtifact(url=video_data.get("uri"))
+    ) -> VideoContent:
+        return self._strategy._parse_content(response_data)  # type: ignore[union-attr]
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
+        return self._strategy._parse_finish_reason(response_data)  # type: ignore[union-attr]
+
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[VideoParameters],
+    ) -> dict[str, Any]:
+        return await self._strategy._make_request(  # type: ignore[union-attr]
+            request_body,
+            endpoint=endpoint,
+            extra_headers=extra_headers,
+            **parameters,
+        )
 
     async def download_content(self, artifact: VideoArtifact) -> VideoArtifact:
-        """Download video content from GCS URL.
-
-        Args:
-            artifact: VideoArtifact with URL or inline data to download.
-
-        Returns:
-            VideoArtifact with downloaded bytes data.
-        """
-        if artifact.data is not None:
-            return artifact
-
-        if artifact.url is None:
-            msg = "Artifact has no URL or data to download"
-            raise ValueError(msg)
-
-        video_bytes = await super().download_content(artifact.url)
-        return VideoArtifact(
-            data=video_bytes,
-            mime_type=artifact.mime_type,
-        )
+        return await self._strategy.download_content(artifact)  # type: ignore[union-attr]
 
 
 __all__ = ["GoogleVideosClient"]

--- a/src/celeste/modalities/videos/providers/google/interactions.py
+++ b/src/celeste/modalities/videos/providers/google/interactions.py
@@ -1,0 +1,80 @@
+"""Google videos client (Interactions API — Gemini Omni)."""
+
+from typing import Any
+
+from celeste.artifacts import VideoArtifact
+from celeste.mime_types import VideoMimeType
+from celeste.parameters import ParameterMapper
+from celeste.providers.google.interactions import config
+from celeste.providers.google.interactions.client import (
+    GoogleInteractionsClient as GoogleInteractionsMixin,
+)
+from celeste.providers.google.utils import build_content_part
+from celeste.types import VideoContent
+
+from ...client import VideosClient
+from ...io import VideoInput
+from .parameters import GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
+
+
+class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
+    """Google videos client (Interactions API)."""
+
+    _generate_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
+    _edit_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[VideoContent]]:
+        return GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
+
+    def _init_request(self, inputs: VideoInput) -> dict[str, Any]:
+        """Initialize request for Omni video generation/edit."""
+        request: dict[str, Any] = {"response_format": {"type": "video"}}
+        if inputs.video is None:
+            request["input"] = inputs.prompt
+            return request
+        request["input"] = [
+            build_content_part(inputs.video, "video"),
+            {"type": "text", "text": inputs.prompt},
+        ]
+        request["generation_config"] = {"video_config": {"task": "edit"}}
+        return request
+
+    def _parse_content(
+        self,
+        response_data: dict[str, Any],
+    ) -> VideoArtifact:
+        """Parse the video artifact from the model_output step."""
+        steps = super()._parse_content(response_data)
+        for step in steps:
+            if step.get("type") != "model_output":
+                continue
+            for part in step.get("content", []):
+                if part.get("type") != "video":
+                    continue
+                mime_type = VideoMimeType(part.get("mime_type", "video/mp4"))
+                if part.get("data"):
+                    return VideoArtifact(data=part["data"], mime_type=mime_type)
+                if part.get("uri"):
+                    return VideoArtifact(url=part["uri"], mime_type=mime_type)
+        msg = "No video content in response"
+        raise ValueError(msg)
+
+    async def download_content(self, artifact: VideoArtifact) -> VideoArtifact:
+        """Download video content from the response URI."""
+        if artifact.data is not None:
+            return artifact
+
+        if artifact.url is None:
+            msg = "Artifact has no URL or data to download"
+            raise ValueError(msg)
+
+        headers = self.auth.get_headers()
+        response = await self.http_client.get(
+            artifact.url, headers=headers, follow_redirects=True
+        )
+        self._handle_error_response(response)
+        return VideoArtifact(data=response.content, mime_type=artifact.mime_type)
+
+
+__all__ = ["GoogleInteractionsVideosClient"]

--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -1,6 +1,6 @@
 """Google models for videos modality."""
 
-from celeste.constraints import Choice, ImageConstraint, ImagesConstraint
+from celeste.constraints import Choice, ImageConstraint, ImagesConstraint, Range
 from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import ImageMimeType
 from celeste.models import Model
@@ -14,7 +14,8 @@ GOOGLE_SUPPORTED_MIME_TYPES = [
     ImageMimeType.WEBP,
 ]
 
-MODELS: list[Model] = [
+# Veo API models (predictLongRunning)
+GOOGLE_VEO_MODELS: list[Model] = [
     Model(
         id="veo-3.1-generate-preview",
         provider=Provider.GOOGLE,
@@ -74,4 +75,32 @@ MODELS: list[Model] = [
             ),
         },
     ),
+]
+
+# Interactions API models (Gemini Omni)
+GOOGLE_OMNI_MODELS: list[Model] = [
+    Model(
+        id="gemini-omni-flash-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini Omni Flash (Preview)",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.DURATION: Range(min=3, max=10),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.LAST_FRAME: ImageConstraint(),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
+        },
+    ),
+]
+
+MODELS: list[Model] = [
+    *GOOGLE_VEO_MODELS,
+    *GOOGLE_OMNI_MODELS,
+]
+
+__all__ = [
+    "GOOGLE_OMNI_MODELS",
+    "GOOGLE_VEO_MODELS",
+    "MODELS",
 ]

--- a/src/celeste/modalities/videos/providers/google/parameters.py
+++ b/src/celeste/modalities/videos/providers/google/parameters.py
@@ -1,72 +1,126 @@
 """Google parameter mappers for videos."""
 
 from celeste.parameters import ParameterMapper
-from celeste.providers.google.veo.parameters import (
-    AspectRatioMapper as _AspectRatioMapper,
+from celeste.providers.google.interactions.parameters import (
+    AspectRatioMapper as _InteractionsAspectRatioMapper,
+)
+from celeste.providers.google.interactions.parameters import (
+    DurationMapper as _InteractionsDurationMapper,
+)
+from celeste.providers.google.interactions.parameters import (
+    FirstFrameMapper as _InteractionsFirstFrameMapper,
+)
+from celeste.providers.google.interactions.parameters import (
+    LastFrameMapper as _InteractionsLastFrameMapper,
+)
+from celeste.providers.google.interactions.parameters import (
+    ReferenceImagesMapper as _InteractionsReferenceImagesMapper,
 )
 from celeste.providers.google.veo.parameters import (
-    DurationSecondsMapper as _DurationSecondsMapper,
+    AspectRatioMapper as _VeoAspectRatioMapper,
 )
 from celeste.providers.google.veo.parameters import (
-    FirstFrameMapper as _FirstFrameMapper,
+    DurationSecondsMapper as _VeoDurationSecondsMapper,
 )
 from celeste.providers.google.veo.parameters import (
-    LastFrameMapper as _LastFrameMapper,
+    FirstFrameMapper as _VeoFirstFrameMapper,
 )
 from celeste.providers.google.veo.parameters import (
-    ReferenceImagesMapper as _ReferenceImagesMapper,
+    LastFrameMapper as _VeoLastFrameMapper,
 )
 from celeste.providers.google.veo.parameters import (
-    ResolutionMapper as _ResolutionMapper,
+    ReferenceImagesMapper as _VeoReferenceImagesMapper,
+)
+from celeste.providers.google.veo.parameters import (
+    ResolutionMapper as _VeoResolutionMapper,
 )
 from celeste.types import VideoContent
 
 from ...parameters import VideoParameter
 
 
-class AspectRatioMapper(_AspectRatioMapper):
+class VeoAspectRatioMapper(_VeoAspectRatioMapper):
     """Map aspect_ratio to Google Veo's aspectRatio parameter."""
 
     name = VideoParameter.ASPECT_RATIO
 
 
-class ResolutionMapper(_ResolutionMapper):
+class VeoResolutionMapper(_VeoResolutionMapper):
     """Map resolution to Google Veo's resolution parameter."""
 
     name = VideoParameter.RESOLUTION
 
 
-class DurationMapper(_DurationSecondsMapper):
+class VeoDurationMapper(_VeoDurationSecondsMapper):
     """Map duration to Google Veo's durationSeconds parameter."""
 
     name = VideoParameter.DURATION
 
 
-class ReferenceImagesMapper(_ReferenceImagesMapper):
+class VeoReferenceImagesMapper(_VeoReferenceImagesMapper):
     """Map reference_images to Google Veo's referenceImages parameter."""
 
     name = VideoParameter.REFERENCE_IMAGES
 
 
-class FirstFrameMapper(_FirstFrameMapper):
+class VeoFirstFrameMapper(_VeoFirstFrameMapper):
     """Map first_frame to Google Veo's image parameter."""
 
     name = VideoParameter.FIRST_FRAME
 
 
-class LastFrameMapper(_LastFrameMapper):
+class VeoLastFrameMapper(_VeoLastFrameMapper):
     """Map last_frame to Google Veo's lastFrame parameter."""
 
     name = VideoParameter.LAST_FRAME
 
 
-GOOGLE_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
-    AspectRatioMapper(),
-    ResolutionMapper(),
-    DurationMapper(),
-    ReferenceImagesMapper(),
-    FirstFrameMapper(),
-    LastFrameMapper(),
+GOOGLE_VEO_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
+    VeoAspectRatioMapper(),
+    VeoResolutionMapper(),
+    VeoDurationMapper(),
+    VeoReferenceImagesMapper(),
+    VeoFirstFrameMapper(),
+    VeoLastFrameMapper(),
 ]
 
-__all__ = ["GOOGLE_PARAMETER_MAPPERS"]
+
+class InteractionsAspectRatioMapper(_InteractionsAspectRatioMapper[VideoContent]):
+    """Map aspect_ratio to Google Interactions response_format.aspect_ratio."""
+
+    name = VideoParameter.ASPECT_RATIO
+
+
+class InteractionsDurationMapper(_InteractionsDurationMapper):
+    """Map duration to Google Interactions response_format.duration."""
+
+    name = VideoParameter.DURATION
+
+
+class InteractionsFirstFrameMapper(_InteractionsFirstFrameMapper):
+    """Map first_frame to Google Interactions input content."""
+
+    name = VideoParameter.FIRST_FRAME
+
+
+class InteractionsLastFrameMapper(_InteractionsLastFrameMapper):
+    """Map last_frame to Google Interactions input content."""
+
+    name = VideoParameter.LAST_FRAME
+
+
+class InteractionsReferenceImagesMapper(_InteractionsReferenceImagesMapper):
+    """Map reference_images to Google Interactions input content."""
+
+    name = VideoParameter.REFERENCE_IMAGES
+
+
+GOOGLE_INTERACTIONS_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
+    InteractionsAspectRatioMapper(),
+    InteractionsDurationMapper(),
+    InteractionsFirstFrameMapper(),
+    InteractionsLastFrameMapper(),
+    InteractionsReferenceImagesMapper(),
+]
+
+__all__ = ["GOOGLE_INTERACTIONS_PARAMETER_MAPPERS", "GOOGLE_VEO_PARAMETER_MAPPERS"]

--- a/src/celeste/modalities/videos/providers/google/veo.py
+++ b/src/celeste/modalities/videos/providers/google/veo.py
@@ -1,0 +1,69 @@
+"""Google videos client (Veo predictLongRunning API)."""
+
+from typing import Any
+
+from celeste.artifacts import VideoArtifact
+from celeste.mime_types import VideoMimeType
+from celeste.parameters import ParameterMapper
+from celeste.providers.google.veo import config
+from celeste.providers.google.veo.client import GoogleVeoClient as GoogleVeoMixin
+from celeste.types import VideoContent
+
+from ...client import VideosClient
+from ...io import VideoInput
+from .parameters import GOOGLE_VEO_PARAMETER_MAPPERS
+
+
+class GoogleVeoVideosClient(GoogleVeoMixin, VideosClient):
+    """Google videos client (Veo API)."""
+
+    _generate_endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[VideoContent]]:
+        return GOOGLE_VEO_PARAMETER_MAPPERS
+
+    def _init_request(self, inputs: VideoInput) -> dict[str, Any]:
+        """Initialize request from Google Veo API format."""
+        return {
+            "instances": [{"prompt": inputs.prompt}],
+        }
+
+    def _parse_content(
+        self,
+        response_data: dict[str, Any],
+    ) -> VideoArtifact:
+        """Parse content from response."""
+        video_data = super()._parse_content(response_data)
+        # Handle inline base64 response (Vertex can return bytesBase64Encoded)
+        if "bytesBase64Encoded" in video_data:
+            mime_type = video_data.get("mimeType", VideoMimeType.MP4)
+            return VideoArtifact(
+                data=video_data["bytesBase64Encoded"], mime_type=mime_type
+            )
+        return VideoArtifact(url=video_data.get("uri"))
+
+    async def download_content(self, artifact: VideoArtifact) -> VideoArtifact:
+        """Download video content from GCS URL.
+
+        Args:
+            artifact: VideoArtifact with URL or inline data to download.
+
+        Returns:
+            VideoArtifact with downloaded bytes data.
+        """
+        if artifact.data is not None:
+            return artifact
+
+        if artifact.url is None:
+            msg = "Artifact has no URL or data to download"
+            raise ValueError(msg)
+
+        video_bytes = await super().download_content(artifact.url)
+        return VideoArtifact(
+            data=video_bytes,
+            mime_type=artifact.mime_type,
+        )
+
+
+__all__ = ["GoogleVeoVideosClient"]

--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -5,13 +5,13 @@ from typing import Any, ClassVar, get_args, get_origin
 
 from pydantic import BaseModel, TypeAdapter
 
-from celeste.exceptions import InvalidToolError
+from celeste.exceptions import InvalidToolError, ValidationError
 from celeste.mime_types import AudioMimeType
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.google.utils import build_content_part
 from celeste.tools import Tool
-from celeste.types import AudioContent, ImageContent, TextContent
+from celeste.types import AudioContent, ImageContent, TextContent, VideoContent
 
 from .tools import TOOL_MAPPERS
 
@@ -271,7 +271,7 @@ class ResponseFormatMapper(ParameterMapper[TextContent]):
         return result
 
 
-class AspectRatioMapper(ParameterMapper[ImageContent]):
+class AspectRatioMapper[Content](ParameterMapper[Content]):
     """Map aspect_ratio to Google Interactions response_format.aspect_ratio field."""
 
     def map(
@@ -350,6 +350,116 @@ class MediaContentMapper[Content](ParameterMapper[Content]):
         return request
 
 
+def _flat_input_parts(request: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize request input to a flat content-parts list (video task shape)."""
+    current_input = request.get("input")
+    if isinstance(current_input, str):
+        parts: list[dict[str, Any]] = [{"type": "text", "text": current_input}]
+    elif isinstance(current_input, list):
+        parts = current_input
+    else:
+        parts = []
+    request["input"] = parts
+    return parts
+
+
+def _set_video_task(request: dict[str, Any], task: str) -> None:
+    """Set generation_config.video_config.task."""
+    request.setdefault("generation_config", {}).setdefault("video_config", {})[
+        "task"
+    ] = task
+
+
+class DurationMapper(ParameterMapper[VideoContent]):
+    """Map duration to Google Interactions response_format.duration field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform duration into provider request."""
+        if isinstance(value, str):
+            value = int(value)
+
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        response_format = request.setdefault("response_format", {"type": "video"})
+        response_format["duration"] = f"{validated_value}s"
+        return request
+
+
+class FirstFrameMapper(ParameterMapper[VideoContent]):
+    """Map first_frame to a leading image part with video_config.task image_to_video."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform first_frame into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        parts = _flat_input_parts(request)
+        request["input"] = [build_content_part(validated_value, "image"), *parts]
+        _set_video_task(request, "image_to_video")
+        return request
+
+
+class LastFrameMapper(ParameterMapper[VideoContent]):
+    """Map last_frame to the second image part with video_config.task image_to_video."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform last_frame into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        parts = _flat_input_parts(request)
+        if not parts or parts[0].get("type") != "image":
+            msg = "last_frame requires first_frame to be provided"
+            raise ValidationError(msg)
+        request["input"] = [
+            parts[0],
+            build_content_part(validated_value, "image"),
+            *parts[1:],
+        ]
+        _set_video_task(request, "image_to_video")
+        return request
+
+
+class ReferenceImagesMapper(ParameterMapper[VideoContent]):
+    """Map reference_images to leading image parts with video_config.task reference_to_video."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform reference_images into provider request."""
+        validated_value = self._validate_value(value, model)
+        if not validated_value:
+            return request
+
+        parts = _flat_input_parts(request)
+        image_parts = [build_content_part(img, "image") for img in validated_value]
+        request["input"] = [*image_parts, *parts]
+        _set_video_task(request, "reference_to_video")
+        return request
+
+
 class VoiceMapper(ParameterMapper[AudioContent]):
     """Map voice to Google Interactions generation_config.speech_config voice field."""
 
@@ -419,10 +529,14 @@ class AudioMimeTypeMapper(ParameterMapper[AudioContent]):
 __all__ = [
     "AspectRatioMapper",
     "AudioMimeTypeMapper",
+    "DurationMapper",
+    "FirstFrameMapper",
     "ImageSizeMapper",
     "LanguageMapper",
+    "LastFrameMapper",
     "MaxOutputTokensMapper",
     "MediaContentMapper",
+    "ReferenceImagesMapper",
     "ResponseFormatMapper",
     "SeedMapper",
     "TemperatureMapper",

--- a/tests/integration_tests/videos/test_edit.py
+++ b/tests/integration_tests/videos/test_edit.py
@@ -1,0 +1,25 @@
+import pytest
+
+from celeste import Modality, Provider, create_client
+from celeste.artifacts import VideoArtifact
+from celeste.modalities.videos import VideoOutput
+
+pytestmark = pytest.mark.slow
+
+MODELS = [
+    (Provider.GOOGLE, "gemini-omni-flash-preview"),
+]
+
+
+@pytest.mark.parametrize(("provider", "model"), MODELS)
+async def test_edit(provider: Provider, model: str) -> None:
+    client = create_client(modality=Modality.VIDEOS, provider=provider, model=model)
+
+    generated = await client.generate(prompt="A red ball bouncing on a white floor")
+    source = await client.download_content(generated.content)
+
+    response = await client.edit(video=source, prompt="Make the ball blue")
+
+    assert isinstance(response, VideoOutput)
+    assert isinstance(response.content, VideoArtifact)
+    assert response.content.has_content

--- a/tests/integration_tests/videos/test_generate.py
+++ b/tests/integration_tests/videos/test_generate.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.slow
     [
         (Provider.OPENAI, "sora-2", {"duration": 4, "resolution": "720p"}),
         (Provider.GOOGLE, "veo-3.1-fast-generate-preview", {"duration": 4}),
+        (Provider.GOOGLE, "gemini-omni-flash-preview", {}),
         (
             Provider.BYTEPLUS,
             "seedance-1-0-pro-250528",

--- a/tests/unit_tests/test_dispatcher_delegation.py
+++ b/tests/unit_tests/test_dispatcher_delegation.py
@@ -66,7 +66,7 @@ def _hook_names(modality_base: type[ModalityClient]) -> set[str]:
 
 def test_registry_discovers_known_dispatchers() -> None:
     names = {d.__name__ for d in _dispatchers()}
-    assert {"GoogleTextClient", "GoogleImagesClient"} <= names
+    assert {"GoogleTextClient", "GoogleImagesClient", "GoogleVideosClient"} <= names
 
 
 @pytest.mark.parametrize("dispatcher", _dispatchers(), ids=lambda d: d.__name__)

--- a/tests/unit_tests/test_google_videos_interactions.py
+++ b/tests/unit_tests/test_google_videos_interactions.py
@@ -1,0 +1,148 @@
+"""Unit tests for Google videos provider Veo/Interactions dispatch and wire shape."""
+
+import pytest
+from pydantic import SecretStr
+
+from celeste import Model
+from celeste.artifacts import ImageArtifact, VideoArtifact
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.mime_types import ImageMimeType, VideoMimeType
+from celeste.modalities.videos.io import VideoInput
+from celeste.modalities.videos.providers.google.client import GoogleVideosClient
+from celeste.modalities.videos.providers.google.interactions import (
+    GoogleInteractionsVideosClient,
+)
+from celeste.modalities.videos.providers.google.veo import GoogleVeoVideosClient
+
+IMAGE = ImageArtifact(data=b"img", mime_type=ImageMimeType.PNG)
+
+
+def _model(model_id: str) -> Model:
+    return Model(
+        id=model_id,
+        provider=Provider.GOOGLE,
+        display_name=model_id,
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+    )
+
+
+def _client(model_id: str) -> GoogleVideosClient:
+    return GoogleVideosClient(
+        model=_model(model_id),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+
+
+def test_veo_model_dispatches_to_veo_strategy() -> None:
+    client = _client("veo-3.1-generate-preview")
+    assert isinstance(client._strategy, GoogleVeoVideosClient)
+    assert client._generate_endpoint == client._strategy._generate_endpoint
+    assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+def test_omni_model_dispatches_to_interactions_strategy() -> None:
+    client = _client("gemini-omni-flash-preview")
+    assert isinstance(client._strategy, GoogleInteractionsVideosClient)
+    assert client._generate_endpoint == client._strategy._generate_endpoint
+    assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+def test_unknown_model_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown Google videos model"):
+        _client("veo-99-unknown")
+
+
+def test_interactions_init_request_generate_is_string_input() -> None:
+    client = _client("gemini-omni-flash-preview")
+
+    request = client._init_request(VideoInput(prompt="a rolling marble"))
+
+    assert request == {
+        "input": "a rolling marble",
+        "response_format": {"type": "video"},
+    }
+
+
+def test_interactions_init_request_edit_sends_video_part_and_task() -> None:
+    client = _client("gemini-omni-flash-preview")
+
+    request = client._init_request(
+        VideoInput(
+            prompt="make the mirror ripple",
+            video=VideoArtifact(data=b"vid", mime_type=VideoMimeType.MP4),
+        )
+    )
+
+    assert request["input"] == [
+        {"type": "video", "data": "dmlk", "mime_type": "video/mp4"},
+        {"type": "text", "text": "make the mirror ripple"},
+    ]
+    assert request["generation_config"] == {"video_config": {"task": "edit"}}
+    assert request["response_format"] == {"type": "video"}
+
+
+def test_interactions_build_request_first_and_last_frame() -> None:
+    client = _client("gemini-omni-flash-preview")
+
+    request = client._build_request(
+        VideoInput(prompt="animate this"),
+        first_frame=IMAGE,
+        last_frame=IMAGE,
+        aspect_ratio="9:16",
+    )
+
+    parts = request["input"]
+    assert [p["type"] for p in parts] == ["image", "image", "text"]
+    assert parts[-1] == {"type": "text", "text": "animate this"}
+    assert request["generation_config"]["video_config"]["task"] == "image_to_video"
+    assert request["response_format"]["aspect_ratio"] == "9:16"
+
+
+def test_interactions_build_request_reference_images() -> None:
+    client = _client("gemini-omni-flash-preview")
+
+    request = client._build_request(
+        VideoInput(prompt="a cat with yarn"),
+        reference_images=[IMAGE, IMAGE],
+    )
+
+    parts = request["input"]
+    assert [p["type"] for p in parts] == ["image", "image", "text"]
+    assert request["generation_config"]["video_config"]["task"] == "reference_to_video"
+
+
+@pytest.mark.parametrize(
+    ("part", "data", "url"),
+    [
+        ({"type": "video", "mime_type": "video/mp4", "data": "dmlk"}, b"vid", None),
+        (
+            {"type": "video", "mime_type": "video/mp4", "uri": "https://f/x"},
+            None,
+            "https://f/x",
+        ),
+    ],
+)
+def test_interactions_parse_content_video_variants(
+    part: dict, data: bytes | None, url: str | None
+) -> None:
+    client = GoogleInteractionsVideosClient(
+        model=_model("gemini-omni-flash-preview"),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+
+    artifact = client._parse_content(
+        {"status": "completed", "steps": [{"type": "model_output", "content": [part]}]}
+    )
+
+    assert isinstance(artifact, VideoArtifact)
+    assert artifact.data == data
+    assert artifact.url == url
+    assert artifact.mime_type == VideoMimeType.MP4
+
+
+def test_dispatcher_forwards_download_content() -> None:
+    client = _client("gemini-omni-flash-preview")
+    assert "download_content" in type(client).__dict__

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -23,6 +23,7 @@ from celeste.modalities.text.providers.moonshot import parameters as moonshot
 from celeste.modalities.text.providers.openai import parameters as openai
 from celeste.modalities.videos.parameters import VideoParameter
 from celeste.modalities.videos.providers.byteplus import parameters as byteplus
+from celeste.modalities.videos.providers.google import parameters as google_videos
 from celeste.modalities.videos.providers.xai import parameters as xai
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
@@ -33,6 +34,8 @@ IMAGES_VERTEX = google_images.GOOGLE_VERTEX_PARAMETER_MAPPERS
 IMAGES_INTERACTIONS = google_images.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 IMAGES_IMAGEN = google_images.GOOGLE_IMAGEN_PARAMETER_MAPPERS
 AUDIO_GOOGLE = google_audio.GOOGLE_PARAMETER_MAPPERS
+VIDEOS_VEO = google_videos.GOOGLE_VEO_PARAMETER_MAPPERS
+VIDEOS_INTERACTIONS = google_videos.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 OPEN = openai.OPENAI_PARAMETER_MAPPERS
 CHAT = chat.CHATCOMPLETIONS_PARAMETER_MAPPERS
 ANTHROPIC = anthropic.ANTHROPIC_PARAMETER_MAPPERS
@@ -129,6 +132,37 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
             ("response_format", "mime_type"),
             "audio/mp3",
         ),
+        (VIDEOS_VEO, V.ASPECT_RATIO, "16:9", ("parameters", "aspectRatio"), "16:9"),
+        (VIDEOS_VEO, V.RESOLUTION, "1080p", ("parameters", "resolution"), "1080p"),
+        (VIDEOS_VEO, V.DURATION, 6, ("parameters", "durationSeconds"), 6),
+        (
+            VIDEOS_INTERACTIONS,
+            V.ASPECT_RATIO,
+            "9:16",
+            ("response_format", "aspect_ratio"),
+            "9:16",
+        ),
+        (
+            VIDEOS_INTERACTIONS,
+            V.DURATION,
+            5,
+            ("response_format", "duration"),
+            "5s",
+        ),
+        (
+            VIDEOS_INTERACTIONS,
+            V.FIRST_FRAME,
+            LOCAL_IMAGE,
+            ("generation_config", "video_config", "task"),
+            "image_to_video",
+        ),
+        (
+            VIDEOS_INTERACTIONS,
+            V.REFERENCE_IMAGES,
+            [LOCAL_IMAGE],
+            ("generation_config", "video_config", "task"),
+            "reference_to_video",
+        ),
         (
             GOOGLE_INTERACTIONS,
             T.TEMPERATURE,
@@ -198,6 +232,8 @@ def test_scalar_parameters_use_provider_wire_shape(
         IMAGES_VERTEX,
         IMAGES_IMAGEN,
         AUDIO_GOOGLE,
+        VIDEOS_VEO,
+        VIDEOS_INTERACTIONS,
         OPEN,
         CHAT,
         ANTHROPIC,
@@ -293,6 +329,15 @@ def test_google_media_precedes_text_content() -> None:
                 {"type": "image", "uri": IMAGE.url},
             ],
         ),
+        (
+            VIDEOS_INTERACTIONS,
+            V.REFERENCE_IMAGES,
+            {"input": "describe"},
+            [
+                {"type": "image", "uri": IMAGE.url},
+                {"type": "text", "text": "describe"},
+            ],
+        ),
     ],
 )
 def test_google_interactions_media_joins_input_content(
@@ -302,6 +347,17 @@ def test_google_interactions_media_joins_input_content(
     expected_input: list[dict[str, Any]],
 ) -> None:
     assert _map(mappers, name, [IMAGE], request_body)["input"] == expected_input
+
+
+def test_google_veo_frames_land_in_instances() -> None:
+    request = _map(VIDEOS_VEO, V.FIRST_FRAME, LOCAL_IMAGE)
+    request = _map(VIDEOS_VEO, V.LAST_FRAME, LOCAL_IMAGE, request)
+    request = _map(VIDEOS_VEO, V.REFERENCE_IMAGES, [LOCAL_IMAGE], request)
+
+    instance = request["instances"][0]
+    assert instance["image"]["bytesBase64Encoded"] == LOCAL_IMAGE.get_base64()
+    assert instance["lastFrame"]["mimeType"] == "image/png"
+    assert instance["referenceImages"][0]["referenceType"] == "asset"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds the second wire backend to the videos modality: Gemini Omni Flash over the Interactions API, alongside Veo (which Interactions does not serve). Playbook route 3, mirroring the images split. Closes #319.

## Architecture
- `client.py` → `veo.py` (`GoogleVeoVideosClient`, unchanged behavior incl. the ADC `_build_url` branch and polling); new `interactions.py` backend (`GoogleInteractionsVideosClient`); new dispatcher `client.py` selecting by model-id family only (`_VEO_MODEL_IDS` / `_OMNI_MODEL_IDS` — auth is not an axis: Veo handles ADC internally, Omni is api-key).
- The delegation guard's state rules force `_build_metadata` (`_content_fields`: `{"response"}` vs `{"steps"}`) and `_transform_output` (different mapper lists) — both forwarded; `download_content` is outside the guard's hook sweep, so it gets a manual forward plus a bespoke assert.
- Mapper sets fully backend-tokened (`Veo*` + `GOOGLE_VEO_PARAMETER_MAPPERS`, `Interactions*` + `GOOGLE_INTERACTIONS_PARAMETER_MAPPERS`); catalog partitions as `GOOGLE_VEO_MODELS` / `GOOGLE_OMNI_MODELS`.

## All four documented tasks
- **text_to_video**: plain string input (per the guide's samples).
- **image_to_video**: `first_frame` / `last_frame` — flat parts, media first, text last; position is semantics (first image = start frame, second = end frame, verbatim from the reference); last-frame-requires-first guard mirrors the Veo wire precedent.
- **reference_to_video**: `reference_images` → leading image parts + task.
- **edit**: `client.edit(video=..., prompt=...)` — inline base64 `video` part (documented as accepted) + `task:"edit"`.

New wire mappers live in the Interactions package (video-task shapes differ from the images/audio `MediaContentMapper` semantics, which are untouched). `VideoUsage` gains input/output/reasoning/cached token fields — Omni returns full usage and `Usage` drops unknown keys.

## Live probes (implementation-time, per plan)
- **Generate through celeste: green live** (33.6 s, real video, usage parsed).
- **Duration format settled live**: `response_format.duration: "5"` → 400; `"5s"` → 200 and honored (29 752 output tokens ÷ 5 792 ≈ 5.1 s) → the mapper writes `f"{seconds}s"`, catalog constrains `Range(3, 10)`.
- **Edit wire shape accepted; execution blocked regionally**: two innocuous prompts hit the documented EEA/CH/UK restriction on editing *uploaded* videos (generation unaffected). `tests/integration_tests/videos/test_edit.py` is correct for non-EEA keys — same class of environment-gated test as Claude-on-Vertex.
- A 3 s 720p output measured ~2.8 MB inline — under the 4 MB uri threshold; default inline delivery kept, with the `uri` output variant parsed and downloadable for larger outputs.
- `streaming` stays False: the guide recommends `stream=false` for video and shows no SSE sample.

## Provider doc conflicts (recorded per house rule)
- Edit input-video part: Python/JS samples use a Files-API `document`+`uri` part while REST uses `video`+inline base64 — and the reference's `DocumentContent` mime enum (pdf/csv) doesn't cover video; celeste emits the schema-faithful `VideoContent` shape (`type:"video"`, data/uri, mime).
- `VideoResponseFormat.duration` exists in the schema but no official sample sets it (live probe settled the format).
- A re-GET of a stored interaction returns inline data even for `delivery:"uri"` creations (uri only on creation) — irrelevant to stateless celeste, recorded.
- The guide's sample video responses omit `usage`, which the resource schema documents (and live returns).

## Intentionally not built
Stateful `previous_interaction_id` multi-turn editing — celeste is stateless by design; the docs' own edit-with-attached-video path is the stateless analogue (with the noted EEA caveat on uploaded-video edits).

## Tests
Dispatch/payload/parse suite mirroring the images file (incl. endpoint-copy asserts and the `download_content` forward assert); delegation-guard canary gains `GoogleVideosClient`; both google-videos mapper lists join the wire-contract matrix (closing the Veo gap) with the flat-input media-order case; integration rows for omni generate (live-green) and the generate→edit round trip.

`make ci` green; rebased on #325.