### PR TITLE
fix(google): send Interactions tool results as typed content blocks

### DIFF
--- a/src/celeste/modalities/text/providers/google/interactions.py
+++ b/src/celeste/modalities/text/providers/google/interactions.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from celeste.grounding import Grounding
-from celeste.messages import message_parts, request_messages, tool_result_object
+from celeste.messages import content_to_text, message_parts, request_messages
 from celeste.parameters import ParameterMapper
 from celeste.providers.google.interactions.client import (
     GoogleInteractionsClient as GoogleInteractionsMixin,
@@ -126,7 +126,9 @@ class GoogleInteractionsTextClient(GoogleInteractionsMixin, TextClient):
                         "type": "function_result",
                         "name": msg.name,
                         "call_id": msg.tool_call_id,
-                        "result": tool_result_object(msg),
+                        "result": [
+                            {"type": "text", "text": content_to_text(msg.content)}
+                        ],
                     }
                 )
                 continue

--- a/tests/integration_tests/text/test_tools.py
+++ b/tests/integration_tests/text/test_tools.py
@@ -1,6 +1,14 @@
 import pytest
 
-from celeste import Modality, Provider, ToolChoice, create_client
+from celeste import (
+    Message,
+    Modality,
+    Provider,
+    Role,
+    ToolChoice,
+    ToolResult,
+    create_client,
+)
 from celeste.modalities.text import TextChunk, TextOutput
 from celeste.tools import WebSearch, XSearch
 
@@ -87,6 +95,38 @@ async def test_function_tool_call(
     assert output.tool_calls
     assert output.tool_calls[0].name == "get_weather"
     assert "city" in output.tool_calls[0].arguments
+
+
+async def test_google_tool_result_replay() -> None:
+    client = create_client(
+        modality=Modality.TEXT, provider=Provider.GOOGLE, model="gemini-3.1-flash-lite"
+    )
+    prompt = "Use get_weather to check the weather in Paris."
+
+    first = await client.generate(
+        prompt=prompt,
+        tools=[WEATHER_TOOL],
+        max_tokens=500,
+        tool_choice=ToolChoice.REQUIRED,
+    )
+    assert first.tool_calls
+
+    output = await client.generate(
+        messages=[
+            Message(role=Role.USER, content=prompt),
+            first.message,
+            ToolResult(
+                content=[{"city": "Paris", "temperature_c": 21}],
+                tool_call_id=first.tool_calls[0].id,
+                name="get_weather",
+            ),
+        ],
+        tools=[WEATHER_TOOL],
+        max_tokens=500,
+    )
+
+    assert isinstance(output, TextOutput)
+    assert output.content
 
 
 async def test_x_search() -> None:

--- a/tests/unit_tests/test_text_tool_results.py
+++ b/tests/unit_tests/test_text_tool_results.py
@@ -106,19 +106,21 @@ def test_anthropic_tool_result_uses_pydantic_json_text() -> None:
     assert json.loads(tool_block["content"]) == output.model_dump(mode="json")
 
 
-def test_google_tool_result_uses_pydantic_json_object() -> None:
-    output = _artifact_output()
+def test_google_tool_result_wraps_json_in_text_block() -> None:
+    refs = [ArtifactRef(id="image-1", artifact_type=InputType.IMAGE)]
     client = GoogleTextClient(
         model=_text_model(Provider.GOOGLE),
         provider=Provider.GOOGLE,
         auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
     )
 
-    request = client._init_request(TextInput(messages=[_tool_result(output)]))
+    request = client._init_request(TextInput(messages=[_tool_result(refs)]))
 
     turn = request["input"][0]
     assert turn["type"] == "function_result"
-    assert turn["result"] == output.model_dump(mode="json")
+    assert turn["result"] == [
+        {"type": "text", "text": json.dumps([refs[0].model_dump(mode="json")])}
+    ]
 
 
 def test_cohere_tool_result_preserves_pydantic_shape() -> None:


### PR DESCRIPTION
## Problem

On the Interactions path, `function_result.result` is sent as raw tool-result JSON (`tool_result_object`). The Interactions API parses `result` as an array of typed content blocks, so any tool whose result is a list fails the whole request:

```
400 — The 'type' parameter is required at 'input[N].result[M]'.
```

A single-object result happens to slip through, which is the only shape the unit test covered; the integration suite only exercised the model → tool-call leg, never the tool-result → model replay leg, so this shipped with #321/#323.

## Fix

Wrap the serialized result in a single text block, reusing `content_to_text` — the same convention the Anthropic, ChatCompletions, and OpenResponses serializers use:

```python
"result": [{"type": "text", "text": content_to_text(msg.content)}]
```

Vertex (`functionResponse` Struct) and Cohere keep `tool_result_object` — untouched.

## Live verification

Probed `function_result.result` shapes against `gemini-3.1-flash-lite` and `gemini-3.5-flash` with a real first leg (genuine call id, signature echoed):

| shape | result |
|---|---|
| raw JSON list (current) | 400 `'type' parameter is required at 'input[2].result[1]'` |
| `[{"type": "text", "text": <json>}]` (this PR) | 200, model reads the data |
| plain JSON string / object | 200 (both) |

Known limitation: legacy Gemini 2.5 models reject block-shaped function results ("Multimodal function responses are not supported for this model").

## Tests

- `test_google_tool_result_wraps_json_in_text_block` — list-shaped content (the regression) asserts the block wrapper.
- `test_google_tool_result_replay` (integration) — covers the previously untested replay leg live on `gemini-3.1-flash-lite`; passes in ~4s.

`make ci` green.