### PR TITLE
fix(google): map audio/mp4 to the Interactions m4a literal

### DIFF
--- a/src/celeste/providers/google/utils.py
+++ b/src/celeste/providers/google/utils.py
@@ -21,17 +21,27 @@ def build_media_part(artifact: Artifact) -> dict[str, Any]:
     return {"inline_data": {"mime_type": mime_str, "data": b64}}
 
 
+# The Interactions API names MPEG-4 audio "audio/m4a" and hard-rejects "audio/mp4"
+# (its own supported-values list; generateContent accepts both, so only this builder maps).
+_INTERACTIONS_MIME_LITERALS = {"audio/mp4": "audio/m4a"}
+
+
 def build_content_part(artifact: Artifact, part_type: str) -> dict[str, Any]:
     """Convert any media artifact to an Interactions API content part."""
     if artifact.url:
         part: dict[str, Any] = {"type": part_type, "uri": artifact.url}
         if artifact.mime_type:
-            part["mime_type"] = artifact.mime_type.value
+            part["mime_type"] = _interactions_mime(artifact.mime_type.value)
         return part
     media_bytes = artifact.get_bytes()
     b64 = base64.b64encode(media_bytes).decode("utf-8")
     mime = artifact.mime_type or detect_mime_type(media_bytes)
     part = {"type": part_type, "data": b64}
     if mime:
-        part["mime_type"] = mime.value
+        part["mime_type"] = _interactions_mime(mime.value)
     return part
+
+
+def _interactions_mime(literal: str) -> str:
+    """Translate a celeste mime literal to the Interactions API's vocabulary."""
+    return _INTERACTIONS_MIME_LITERALS.get(literal, literal)


### PR DESCRIPTION
Production dictation on chat has 500'd since the Interactions migration: the API hard-rejects `audio/mp4` — celeste's `AudioMimeType.M4A` value — while naming the same format `audio/m4a` in its supported list (`audio/wav, audio/mp3, audio/aiff, audio/aac, audio/ogg, audio/flac, audio/mpeg, audio/m4a, ...`). generateContent accepted both, so this only broke on the new wire.

`build_content_part` (the Interactions-only content builder in `providers/google/utils.py`) now translates celeste mime literals to the API's vocabulary via a one-entry map; `build_media_part` (generateContent/Vertex) is untouched.

**Live verification (2026-07-21)**
- Control probe, identical m4a bytes direct to the API: `audio/mp4` → 400 mime rejection; `audio/m4a` → passes mime validation.
- Through celeste's exact chat path: `celeste.audio.analyze(AudioArtifact(mime_type=AudioMimeType.M4A), model="gemini-3.1-flash-lite", output_schema=...)` → transcribed correctly (`"Bonjour, ceci est un test de dictée."`).
- `make ci` green (499 passed).

Note: `audio/webm` (Chrome MediaRecorder default) is genuinely unsupported by Interactions — that half of the incident is fixed on the chat side by recording mp4/ogg instead.