### PR TITLE
fix(google): Lyria music rejects response_format.mime_type — drop output_format

### DIFF
--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -85,7 +85,6 @@ MODELS: list[Model] = [
         display_name="Google Lyria 3 Clip (Preview)",
         operations={Modality.AUDIO: {Operation.GENERATE}},
         parameter_constraints={
-            AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
             AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),
@@ -95,7 +94,6 @@ MODELS: list[Model] = [
         display_name="Google Lyria 3 Pro (Preview)",
         operations={Modality.AUDIO: {Operation.GENERATE}},
         parameter_constraints={
-            AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS),
             AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),

--- a/tests/unit_tests/test_audio_voices.py
+++ b/tests/unit_tests/test_audio_voices.py
@@ -1,8 +1,12 @@
 import pytest
 
-from celeste.core import Provider
+from celeste.core import Modality, Operation, Provider
 from celeste.modalities.audio.constraints import VoiceConstraint
+from celeste.modalities.audio.parameters import AudioParameter
 from celeste.modalities.audio.providers.elevenlabs.voices import ELEVENLABS_VOICES
+from celeste.modalities.audio.providers.google.models import (
+    MODELS as GOOGLE_AUDIO_MODELS,
+)
 from celeste.modalities.audio.providers.google.voices import GOOGLE_VOICES
 from celeste.modalities.audio.providers.gradium.voices import GRADIUM_VOICES
 from celeste.modalities.audio.providers.openai.voices import OPENAI_VOICES
@@ -44,6 +48,21 @@ def test_provider_descriptions_match_published_metadata() -> None:
     )
     assert GOOGLE_VOICES[0].name == "Zephyr"
     assert GOOGLE_VOICES[0].description == "Bright"
+
+
+def test_google_generate_audio_models_reject_output_format() -> None:
+    """output_format is SPEAK-only: Google's Lyria (GENERATE) endpoint rejects
+    response_format.mime_type, so GENERATE audio models must not declare it."""
+    generate_models = [
+        m
+        for m in GOOGLE_AUDIO_MODELS
+        if Operation.GENERATE in m.operations.get(Modality.AUDIO, set())
+    ]
+    assert generate_models
+    assert all(
+        AudioParameter.OUTPUT_FORMAT not in m.parameter_constraints
+        for m in generate_models
+    )
 
 
 def test_voice_constraint_still_accepts_name_and_id() -> None:


### PR DESCRIPTION
## Problem

Music generation via Google **Lyria** fails whenever the model requests a format:

```
google API error: Audio mime_type is not supported in response_format.
```

Reproduced live on `lyria-3-clip-preview`.

## Root cause

PR #324 registered the two Lyria models by reusing the Google **TTS** constraint set verbatim — both declare `AudioParameter.OUTPUT_FORMAT: Choice(options=GOOGLE_SUPPORTED_FORMATS)` (a list literally commented "for Google TTS"). That surfaces `output_format` as a pickable field in the `generate_music` tool schema; when set, the shared `OutputFormatMapper` writes `response_format.mime_type`, which Google's Lyria (`GENERATE`) endpoint rejects. There is no working field to change Lyria's output today — it is MP3-only. #324's own body flagged `response_format.mime_type` as an unverified guess ("live serving decides"); live serving decided no.

## Fix

Drop `OUTPUT_FORMAT` from both Lyria models (`modalities/audio/providers/google/models.py`). The SPEAK-vs-GENERATE split is the invariant, and a param with no working wire representation on a backend gets no constraint there. Lyria now exposes only `reference_images`; bare `generate` keeps working (`response_format: {"type": "audio"}` is accepted). TTS models are untouched here.

## Verification

- Reproduced the 400 live pre-fix; `tests/integration_tests/audio/test_generate.py::test_generate` (bare Lyria) passes post-fix.
- New unit guard over the Google audio catalog: `GENERATE` models must not declare `OUTPUT_FORMAT` (covers future Lyria models too).
- `make ci` green.

## Diagnostic — separate follow-up, not fixed here

A live probe shows Google **TTS** (`SPEAK`, `gemini-3.1-flash-tts-preview`) **also** rejects `response_format.mime_type` — same error. So the whole `OutputFormatMapper` is dead for Google Interactions audio (both operations). Removing that mapper + the 3 TTS `OUTPUT_FORMAT` constraints + its wire-contract row + the now-unused `GOOGLE_SUPPORTED_FORMATS` is **provider-global cleanup** and belongs in its own PR; it has no prod impact (speech defaults to ElevenLabs). This PR is scoped to unblocking the music outage with a model-registration change only.