### PR TITLE
feat(google): register Gemini 3.5 Flash Lite and 3.6 Flash

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -186,4 +186,50 @@ MODELS: list[Model] = [
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
     ),
+    Model(
+        id="gemini-3.5-flash-lite",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.5 Flash Lite",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="gemini-3.6-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.6 Flash",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
 ]


### PR DESCRIPTION
## Summary
- Register `gemini-3.5-flash-lite` and `gemini-3.6-flash` in the Google text model catalog
- Constrain `max_tokens` to 65536 and `thinking_level` to `minimal|low|medium|high` per official docs
- Omit `temperature` — these GA models deprecate/ignore sampling parameters (`temperature` / `top_p` / `top_k`)

## Test plan
- [x] `make ci` in the feature worktree
- [ ] Smoke `list_models` / client create for both IDs
- [ ] Optional live generate + stream against both models


Made with [Cursor](https://cursor.com)