### PR TITLE
fix(google): constrain 3.5 Flash Lite / 3.6 Flash thinking to low|high

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -199,9 +199,9 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
-            TextParameter.THINKING_LEVEL: Choice(
-                options=["minimal", "low", "medium", "high"]
-            ),
+            # Live Interactions serving accepts only low|high; Google docs still list
+            # minimal|medium for this id (verified 2026-07-22).
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
             TextParameter.TOOLS: ToolSupport(
                 tools=[WebSearch, CodeExecution, UrlContext]
             ),
@@ -222,9 +222,9 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
-            TextParameter.THINKING_LEVEL: Choice(
-                options=["minimal", "low", "medium", "high"]
-            ),
+            # Live Interactions serving accepts only low|high; Google docs still list
+            # minimal|medium for this id (verified 2026-07-22).
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
             TextParameter.TOOLS: ToolSupport(
                 tools=[WebSearch, CodeExecution, UrlContext]
             ),


### PR DESCRIPTION
## Summary
- Live `celeste.text.generate` probe (2026-07-22): `gemini-3.5-flash-lite` and `gemini-3.6-flash` accept only `thinking_level` **low|high**; `minimal` and `medium` are rejected with \"Allowed values are: high, low.\"
- Docs still advertise `minimal|low|medium|high` — live serving wins.
- `gemini-3.5-flash` still accepts all four (left unchanged).

## Why chat cares
Chat's `_non_minimum_choice` prefers `medium` when present, so staging smoke on `gemini-3.5-flash-lite` was sending `medium` and failing after the catalog swap.

## Test plan
- [x] Live probe both models × {minimal,low,medium,high}
- [ ] CI green
- [ ] Follow-up: bump chat `celeste-ai` lock and redeploy


Made with [Cursor](https://cursor.com)