### PR TITLE
fix(google): route 3.5 Flash Lite / 3.6 Flash API-key via GenerateContent

### DIFF
--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -20,6 +20,16 @@ from .parameters import (
 )
 from .vertex import GoogleVertexTextClient
 
+# Interactions rejects mixing built-in tools with function calling for these ids and
+# does not accept tool_config.include_server_side_tool_invocations; GenerateContent
+# accepts the mix when includeServerSideToolInvocations is set (ToolsMapper).
+_GENERATE_CONTENT_API_KEY_MODELS = frozenset(
+    {
+        "gemini-3.5-flash-lite",
+        "gemini-3.6-flash",
+    }
+)
+
 
 class GoogleTextClient(TextClient):
     """Google text client (selects the Interactions or Vertex backend by auth)."""
@@ -30,9 +40,12 @@ class GoogleTextClient(TextClient):
         """Initialize the backend client based on auth type."""
         super().model_post_init(__context)
 
+        use_generate_content = isinstance(self.auth, GoogleADC) or (
+            self.model.id in _GENERATE_CONTENT_API_KEY_MODELS
+        )
         StrategyClass = (
             GoogleVertexTextClient
-            if isinstance(self.auth, GoogleADC)
+            if use_generate_content
             else GoogleInteractionsTextClient
         )
         strategy = StrategyClass(

--- a/tests/unit_tests/test_google_text_dispatch.py
+++ b/tests/unit_tests/test_google_text_dispatch.py
@@ -1,0 +1,46 @@
+"""Google text dispatcher: auth and model-id backend selection."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Provider
+from celeste.modalities.text.providers.google.client import GoogleTextClient
+from celeste.modalities.text.providers.google.interactions import (
+    GoogleInteractionsTextClient,
+)
+from celeste.modalities.text.providers.google.vertex import GoogleVertexTextClient
+from celeste.models import Model
+from celeste.providers.google.auth import GoogleADC
+
+
+def _client(model_id: str, *, adc: bool = False) -> GoogleTextClient:
+    auth = (
+        GoogleADC(project_id="p")
+        if adc
+        else AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix="")
+    )
+    return GoogleTextClient(
+        modality=Modality.TEXT,
+        model=Model(id=model_id, provider=Provider.GOOGLE, display_name=model_id),
+        provider=Provider.GOOGLE,
+        auth=auth,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_id", "adc", "backend"),
+    [
+        ("gemini-3.5-flash", False, GoogleInteractionsTextClient),
+        ("gemini-3.1-flash-lite", False, GoogleInteractionsTextClient),
+        ("gemini-3.5-flash-lite", False, GoogleVertexTextClient),
+        ("gemini-3.6-flash", False, GoogleVertexTextClient),
+        ("gemini-3.5-flash-lite", True, GoogleVertexTextClient),
+        ("gemini-3.6-flash", True, GoogleVertexTextClient),
+        ("gemini-3.5-flash", True, GoogleVertexTextClient),
+    ],
+)
+def test_google_text_dispatch(model_id: str, adc: bool, backend: type[object]) -> None:
+    assert isinstance(_client(model_id, adc=adc)._strategy, backend)


### PR DESCRIPTION
## Summary
Chat attaches native \`WebSearch\` plus function tools on every Google run. For \`gemini-3.5-flash-lite\` and \`gemini-3.6-flash\`, the Interactions API returns:

\`Please enable tool_config.include_server_side_tool_invocations...\`

but rejects \`tool_config\` as an unknown Interactions parameter. \`gemini-3.5-flash\` and older Flash ids still accept the mix on Interactions.

GenerateContent already supports the mix via \`toolConfig.includeServerSideToolInvocations\` (existing \`ToolsMapper\`). This PR selects the GenerateContent backend for API-key auth on those two model ids (ADC/Vertex path unchanged).

## Evidence
- Live Interactions: mix fails on 3.5-lite / 3.6; succeeds on 3.5-flash / 3.1-lite / 3.1-pro
- Live GenerateContent: mix succeeds with the flag for 3.5-lite / 3.6 (unary + stream)

## Test plan
- [x] \`tests/unit_tests/test_google_text_dispatch.py\`
- [x] Live unary + stream mix via \`GoogleTextClient\` for both ids
- [ ] CI green
- [ ] Follow-up: bump chat \`celeste-ai\` and redeploy staging smoke


Made with [Cursor](https://cursor.com)