### PR TITLE
fix(google): validate mixed interaction tools

### DIFF
--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -177,6 +177,12 @@ class ToolChoiceMapper(ParameterMapper[TextContent]):
             }
         elif validated_value == "required":
             generation_config["tool_choice"] = "any"
+        elif (
+            validated_value == "auto"
+            and any(tool.get("type") == "function" for tool in request.get("tools", []))
+            and any(tool.get("type") != "function" for tool in request.get("tools", []))
+        ):
+            generation_config["tool_choice"] = "validated"
         else:
             generation_config["tool_choice"] = str(validated_value).lower()
         return request

--- a/tests/unit_tests/test_tool_choice.py
+++ b/tests/unit_tests/test_tool_choice.py
@@ -18,6 +18,7 @@ from celeste.modalities.text.providers.anthropic.parameters import (
     ANTHROPIC_PARAMETER_MAPPERS,
 )
 from celeste.modalities.text.providers.google.parameters import (
+    GOOGLE_INTERACTIONS_PARAMETER_MAPPERS,
     GOOGLE_VERTEX_PARAMETER_MAPPERS,
 )
 from celeste.modalities.text.providers.mistral.parameters import (
@@ -119,6 +120,30 @@ def test_choice_wire_format(
     expected: dict[str, Any],
 ) -> None:
     assert _map(mappers, value, provider) == expected
+
+
+@pytest.mark.parametrize(
+    ("tools", "expected"),
+    [
+        ([{"type": "google_search"}, {"name": "weather"}], "validated"),
+        ([{"name": "weather"}], "auto"),
+        ([{"type": "google_search"}], "auto"),
+    ],
+)
+def test_google_interactions_auto_choice_for_tool_mix(
+    tools: list[object], expected: str
+) -> None:
+    request: dict[str, Any] = {}
+    parameters: dict[Any, object] = {
+        TextParameter.TOOLS: tools,
+        TextParameter.TOOL_CHOICE: ToolChoice.AUTO,
+    }
+    model = Model(id="test", provider=Provider.GOOGLE, display_name="test")
+
+    for mapper in GOOGLE_INTERACTIONS_PARAMETER_MAPPERS:
+        request = mapper.map(request, parameters.get(mapper.name), model)
+
+    assert request["generation_config"]["tool_choice"] == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- map generic `ToolChoice.AUTO` to Google Interactions `validated` when a request combines a built-in tool with a custom function
- preserve existing behavior for function-only and built-in-only requests
- keep the generic Celeste and Celeste9 tool-choice APIs unchanged

## Why

Google's mixed-tool circulation semantics require its provider-specific `validated` wire mode. That translation belongs in the Google Interactions adapter, where the already-mapped tool set is available, rather than in provider-agnostic Celeste9.

This is independent of Google's current `include_server_side_tool_invocations` rejection, tracked in https://github.com/googleapis/python-genai/issues/2761#issuecomment-5044546748.

## Validation

- `uv run ruff format --check src/celeste tests/`
- `uv run ruff check src/celeste tests/`
- `uv run mypy -p celeste`
- `uv run mypy tests/`
- `uv run pytest tests/unit_tests -q` — 503 passed
- repository push hooks, including coverage and Bandit