### PR TITLE
fix(google): fall back for mixed interaction tools

### DIFF
--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -1,4 +1,4 @@
-"""Google text client (Interactions API; GoogleADC auth uses Vertex GenerateContent)."""
+"""Google text client dispatcher for Interactions and GenerateContent."""
 
 from collections.abc import AsyncIterator
 from typing import Any, Unpack
@@ -6,11 +6,11 @@ from typing import Any, Unpack
 from celeste.grounding import Grounding
 from celeste.parameters import ParameterMapper
 from celeste.providers.google.auth import GoogleADC
-from celeste.tools import ToolCall
+from celeste.tools import Tool, ToolCall
 from celeste.types import TextContent
 
 from ...client import TextClient
-from ...io import TextInput
+from ...io import TextInput, TextOutput
 from ...parameters import TextParameters
 from ...streaming import TextStream
 from .interactions import GoogleInteractionsTextClient
@@ -20,9 +20,26 @@ from .parameters import (
 )
 from .vertex import GoogleVertexTextClient
 
+# Remove with https://github.com/withceleste/celeste-python/issues/335.
+_GENERATE_CONTENT_MIXED_TOOL_FALLBACK_MODELS = {
+    "gemini-3.5-flash-lite",
+    "gemini-3.6-flash",
+}
+
+
+def _has_mixed_tools(tools: object) -> bool:
+    if not isinstance(tools, list):
+        return False
+    has_function = any(isinstance(tool, dict) and "name" in tool for tool in tools)
+    has_builtin = any(
+        isinstance(tool, Tool) or (isinstance(tool, dict) and "name" not in tool)
+        for tool in tools
+    )
+    return has_function and has_builtin
+
 
 class GoogleTextClient(TextClient):
-    """Google text client (selects the Interactions or Vertex backend by auth)."""
+    """Google text client selecting the backend by auth and request capabilities."""
 
     _strategy: GoogleInteractionsTextClient | GoogleVertexTextClient | None = None
 
@@ -43,6 +60,78 @@ class GoogleTextClient(TextClient):
             base_url=self.base_url,
         )
         object.__setattr__(self, "_strategy", strategy)
+
+    def _generate_content_fallback(
+        self, tools: object
+    ) -> GoogleVertexTextClient | None:
+        if (
+            isinstance(self._strategy, GoogleInteractionsTextClient)
+            and self.model.id in _GENERATE_CONTENT_MIXED_TOOL_FALLBACK_MODELS
+            and _has_mixed_tools(tools)
+        ):
+            return GoogleVertexTextClient(
+                modality=self.modality,
+                model=self.model,
+                provider=self.provider,
+                auth=self.auth,
+                base_url=self.base_url,
+            )
+        return None
+
+    async def _predict(
+        self,
+        inputs: TextInput,
+        *,
+        endpoint: str | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[TextParameters],
+    ) -> TextOutput:
+        fallback = self._generate_content_fallback(parameters.get("tools"))
+        if fallback is None:
+            return await super()._predict(
+                inputs,
+                endpoint=endpoint,
+                extra_body=extra_body,
+                extra_headers=extra_headers,
+                **parameters,
+            )
+        return await fallback._predict(
+            inputs,
+            endpoint=endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
+        )
+
+    def _stream(
+        self,
+        inputs: TextInput,
+        stream_class: type[TextStream],
+        *,
+        endpoint: str | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[TextParameters],
+    ) -> TextStream:
+        fallback = self._generate_content_fallback(parameters.get("tools"))
+        if fallback is None:
+            return super()._stream(
+                inputs,
+                stream_class,
+                endpoint=endpoint,
+                extra_body=extra_body,
+                extra_headers=extra_headers,
+                **parameters,
+            )
+        return fallback._stream(
+            inputs,
+            fallback._stream_class(),
+            endpoint=endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
+        )
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:

--- a/src/celeste/modalities/text/providers/google/vertex.py
+++ b/src/celeste/modalities/text/providers/google/vertex.py
@@ -1,4 +1,4 @@
-"""Google text client (GenerateContent API, used only for GoogleADC/Vertex auth)."""
+"""Google text client for the direct and Vertex GenerateContent APIs."""
 
 from typing import Any
 
@@ -44,7 +44,7 @@ from .parameters import GOOGLE_VERTEX_PARAMETER_MAPPERS
 
 
 class GoogleVertexTextStream(_GoogleGenerateContentStream, TextStream):
-    """Google streaming for text modality (Vertex / GenerateContent)."""
+    """Google GenerateContent streaming for the text modality."""
 
     def _aggregate_grounding(
         self, chunks: list, raw_events: list[dict[str, Any]]
@@ -77,7 +77,7 @@ class GoogleVertexTextStream(_GoogleGenerateContentStream, TextStream):
 
 
 class GoogleVertexTextClient(GoogleGenerateContentMixin, TextClient):
-    """Google text client (Vertex / GenerateContent)."""
+    """Google text client for GenerateContent, with auth-based URL routing."""
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:

--- a/tests/unit_tests/test_google_text_interactions_fallback.py
+++ b/tests/unit_tests/test_google_text_interactions_fallback.py
@@ -1,0 +1,112 @@
+"""Regression coverage for Google's temporary mixed-tool fallback."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from celeste import Model
+from celeste.auth import AuthHeader
+from celeste.core import Provider
+from celeste.modalities.text.io import TextInput, TextOutput
+from celeste.modalities.text.providers.google.client import GoogleTextClient
+from celeste.modalities.text.providers.google.interactions import (
+    GoogleInteractionsTextClient,
+)
+from celeste.modalities.text.providers.google.vertex import (
+    GoogleVertexTextClient,
+    GoogleVertexTextStream,
+)
+from celeste.modalities.text.streaming import TextStream
+from celeste.providers.google.auth import GoogleADC
+from celeste.tools import ToolChoice, ToolDefinition, WebSearch
+
+_FUNCTION_TOOL: dict[str, Any] = {
+    "name": "record_result",
+    "parameters": {"type": "object"},
+}
+_MIXED_TOOLS: list[ToolDefinition] = [WebSearch(), _FUNCTION_TOOL]
+
+
+def _client(
+    model_id: str,
+    auth: AuthHeader | GoogleADC | None = None,
+) -> GoogleTextClient:
+    return GoogleTextClient(
+        model=Model(id=model_id, provider=Provider.GOOGLE, display_name=model_id),
+        provider=Provider.GOOGLE,
+        auth=auth
+        or AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+
+
+@pytest.mark.parametrize("model_id", ["gemini-3.5-flash-lite", "gemini-3.6-flash"])
+def test_affected_mixed_requests_select_generate_content(model_id: str) -> None:
+    fallback = _client(model_id)._generate_content_fallback(_MIXED_TOOLS)
+
+    assert isinstance(fallback, GoogleVertexTextClient)
+    request = fallback._build_request(
+        TextInput(prompt="Search, then record the result."),
+        tools=_MIXED_TOOLS,
+        tool_choice=ToolChoice.AUTO,
+    )
+    assert request["toolConfig"] == {
+        "includeServerSideToolInvocations": True,
+        "functionCallingConfig": {"mode": "AUTO"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_id", "tools"),
+    [
+        ("gemini-3.6-flash", [WebSearch()]),
+        ("gemini-3.6-flash", [_FUNCTION_TOOL]),
+        ("gemini-3.5-flash", _MIXED_TOOLS),
+    ],
+)
+def test_other_requests_stay_on_interactions(
+    model_id: str, tools: list[ToolDefinition]
+) -> None:
+    client = _client(model_id)
+
+    assert isinstance(client._strategy, GoogleInteractionsTextClient)
+    assert client._generate_content_fallback(tools) is None
+
+
+def test_adc_needs_no_fallback() -> None:
+    client = _client("gemini-3.6-flash", GoogleADC(project_id="test"))
+
+    assert isinstance(client._strategy, GoogleVertexTextClient)
+    assert client._generate_content_fallback(_MIXED_TOOLS) is None
+
+
+@pytest.mark.asyncio
+async def test_unary_request_delegates_to_generate_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = TextOutput(content="ok")
+    predict = AsyncMock(return_value=expected)
+    monkeypatch.setattr(GoogleVertexTextClient, "_predict", predict)
+
+    output = await _client("gemini-3.6-flash").generate(
+        "Search, then record the result.", tools=_MIXED_TOOLS
+    )
+
+    assert output is expected
+    predict.assert_awaited_once()
+
+
+def test_stream_request_uses_generate_content_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = MagicMock(spec=TextStream)
+    stream = MagicMock(return_value=expected)
+    monkeypatch.setattr(GoogleVertexTextClient, "_stream", stream)
+
+    output = _client("gemini-3.6-flash").stream.generate(
+        "Search, then record the result.", tools=_MIXED_TOOLS
+    )
+
+    assert output is expected
+    assert stream.call_args.args[1] is GoogleVertexTextStream


### PR DESCRIPTION
## What changed

- route mixed built-in + function requests for `gemini-3.5-flash-lite` and `gemini-3.6-flash` through the existing GenerateContent text client
- keep built-in-only, function-only, other-model, and Google ADC routing unchanged
- select the fallback per operation so concurrent requests do not mutate shared strategy state, and use the matching GenerateContent stream class
- document the existing GenerateContent client's direct API-key support

## Why

Google Interactions currently rejects this exact mixed-tool combination and asks for `tool_config.include_server_side_tool_invocations`, but that field is not accepted by the Interactions API. GenerateContent accepts the documented equivalent and Celeste already maps it.

Upstream: https://github.com/googleapis/python-genai/issues/2761

Removal tracking: https://github.com/withceleste/celeste-python/issues/335

## Validation

- Ruff formatting and lint
- mypy for package and tests
- Bandit
- 511 unit tests
- live non-streaming, signed function-result replay, and SSE mixed-tool calls on both affected models
