### PR TITLE
feat(audio): wire Operation.TRANSCRIBE (Groq Whisper first)

### DIFF
--- a/src/celeste/core.py
+++ b/src/celeste/core.py
@@ -126,6 +126,7 @@ DOMAIN_OPERATION_TO_MODALITY: dict[tuple[Domain, Operation], Modality] = {
     (Domain.AUDIO, Operation.GENERATE): Modality.AUDIO,
     (Domain.AUDIO, Operation.EMBED): Modality.EMBEDDINGS,
     (Domain.AUDIO, Operation.SPEAK): Modality.AUDIO,
+    (Domain.AUDIO, Operation.TRANSCRIBE): Modality.AUDIO,
     (Domain.AUDIO, Operation.ANALYZE): Modality.TEXT,
     (Domain.VIDEOS, Operation.GENERATE): Modality.VIDEOS,
     (Domain.VIDEOS, Operation.ANALYZE): Modality.TEXT,

--- a/src/celeste/modalities/audio/client.py
+++ b/src/celeste/modalities/audio/client.py
@@ -4,19 +4,21 @@ from typing import Any, ClassVar, Unpack
 
 from asgiref.sync import async_to_sync
 
+from celeste import telemetry
 from celeste.client import ModalityClient
 from celeste.core import Modality
+from celeste.modalities.text.io import TextFinishReason, TextOutput, TextUsage
 from celeste.types import AudioContent
 
 from .io import AudioChunk, AudioFinishReason, AudioInput, AudioOutput, AudioUsage
-from .parameters import AudioParameters
+from .parameters import AudioParameter, AudioParameters
 from .streaming import AudioStream
 
 
 class AudioClient(
     ModalityClient[AudioInput, AudioOutput, AudioParameters, AudioContent, AudioChunk]
 ):
-    """Base audio client with speak and generate operations."""
+    """Base audio client with speak, generate, and transcribe operations."""
 
     modality: Modality = Modality.AUDIO
     _usage_class = AudioUsage
@@ -25,6 +27,7 @@ class AudioClient(
 
     _speak_endpoint: ClassVar[str | None] = None
     _generate_endpoint: ClassVar[str | None] = None
+    _transcribe_endpoint: ClassVar[str | None] = None
 
     @classmethod
     def _output_class(cls) -> type[AudioOutput]:
@@ -53,6 +56,54 @@ class AudioClient(
         return await self._predict(
             inputs, endpoint=self._generate_endpoint, **parameters
         )
+
+    async def transcribe(
+        self,
+        audio: AudioContent,
+        *,
+        prompt: str | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[AudioParameters],
+    ) -> TextOutput:
+        """Transcribe speech audio to text."""
+        if self._transcribe_endpoint is None:
+            msg = f"Model {self.model.id} does not support audio transcription"
+            raise NotImplementedError(msg)
+        inputs = AudioInput(audio=audio)
+        build_params: dict[str, Any] = dict(parameters)
+        if prompt is not None:
+            build_params[AudioParameter.PROMPT] = prompt
+        with telemetry.gen_ai_span(
+            model=self.model,
+            provider=self.provider,
+            protocol=self.protocol,
+            modality=self.modality,
+        ) as (span, request_attrs):
+            inputs, build_params = self._validate_artifacts(inputs, **build_params)
+            telemetry.add_input_event(span, inputs)
+            request_body = self._build_request(
+                inputs, extra_body=extra_body, **build_params
+            )
+            response_data = await self._make_request(
+                request_body,
+                endpoint=self._transcribe_endpoint,
+                extra_headers=extra_headers,
+            )
+            content = self._parse_content(response_data)
+            content = self._transform_output(content, **build_params)
+            raw_usage = self._parse_usage(response_data)
+            finish = self._parse_finish_reason(response_data)
+            output = TextOutput(
+                content=content,
+                usage=TextUsage(**raw_usage),
+                finish_reason=TextFinishReason(
+                    reason=finish.reason if finish else None
+                ),
+                metadata=self._build_metadata(response_data),
+            )
+            telemetry.record_output(span, output, request_attrs)
+            return output
 
     @property
     def stream(self) -> "AudioStreamNamespace":
@@ -126,6 +177,24 @@ class AudioSyncNamespace:
         return async_to_sync(self._client._predict)(
             inputs,
             endpoint=self._client._generate_endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
+        )
+
+    def transcribe(
+        self,
+        audio: AudioContent,
+        *,
+        prompt: str | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[AudioParameters],
+    ) -> TextOutput:
+        """Blocking speech transcription."""
+        return async_to_sync(self._client.transcribe)(
+            audio,
+            prompt=prompt,
             extra_body=extra_body,
             extra_headers=extra_headers,
             **parameters,

--- a/src/celeste/modalities/audio/io.py
+++ b/src/celeste/modalities/audio/io.py
@@ -4,12 +4,14 @@ from pydantic import Field
 
 from celeste.artifacts import AudioArtifact
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
+from celeste.types import AudioContent
 
 
 class AudioInput(Input):
     """Input for audio operations."""
 
-    text: str
+    text: str | None = None
+    audio: AudioContent | None = None
 
 
 class AudioFinishReason(FinishReason):

--- a/src/celeste/modalities/audio/models.py
+++ b/src/celeste/modalities/audio/models.py
@@ -5,11 +5,13 @@ from celeste.models import Model
 from .providers.elevenlabs.models import MODELS as ELEVENLABS_MODELS
 from .providers.google.models import MODELS as GOOGLE_MODELS
 from .providers.gradium.models import MODELS as GRADIUM_MODELS
+from .providers.groq.models import MODELS as GROQ_MODELS
 from .providers.openai.models import MODELS as OPENAI_MODELS
 
 MODELS: list[Model] = [
     *ELEVENLABS_MODELS,
     *GOOGLE_MODELS,
     *GRADIUM_MODELS,
+    *GROQ_MODELS,
     *OPENAI_MODELS,
 ]

--- a/src/celeste/modalities/audio/parameters.py
+++ b/src/celeste/modalities/audio/parameters.py
@@ -17,6 +17,9 @@ class AudioParameter(StrEnum):
     OUTPUT_FORMAT = "output_format"
     LANGUAGE = "language"
     REFERENCE_IMAGES = "reference_images"
+    PROMPT = "prompt"
+    TEMPERATURE = "temperature"
+    AUDIO = "audio"
 
 
 class AudioParameters(Parameters, total=False):
@@ -29,10 +32,17 @@ class AudioParameters(Parameters, total=False):
         float, Field(description="Playback speed multiplier (1.0 = normal).")
     ]
     output_format: Annotated[str, Field(description="Audio file format.")]
-    language: Annotated[str, Field(description="BCP-47 language tag, e.g. 'en-US'.")]
+    language: Annotated[
+        str,
+        Field(description="Language tag (ISO-639-1 for transcription, e.g. 'en')."),
+    ]
     reference_images: Annotated[
         list[ImageArtifact],
         Field(description="Additional images conditioning the audio."),
+    ]
+    temperature: Annotated[
+        float,
+        Field(description="Sampling temperature for transcription (0-1)."),
     ]
 
 

--- a/src/celeste/modalities/audio/providers/__init__.py
+++ b/src/celeste/modalities/audio/providers/__init__.py
@@ -6,11 +6,13 @@ from ..client import AudioClient
 from .elevenlabs import ElevenLabsAudioClient
 from .google import GoogleAudioClient
 from .gradium import GradiumAudioClient
+from .groq import GroqAudioClient
 from .openai import OpenAIAudioClient
 
 PROVIDERS: dict[Provider, type[AudioClient]] = {
     Provider.ELEVENLABS: ElevenLabsAudioClient,
     Provider.GOOGLE: GoogleAudioClient,
     Provider.GRADIUM: GradiumAudioClient,
+    Provider.GROQ: GroqAudioClient,
     Provider.OPENAI: OpenAIAudioClient,
 }

--- a/src/celeste/modalities/audio/providers/groq/__init__.py
+++ b/src/celeste/modalities/audio/providers/groq/__init__.py
@@ -1,0 +1,6 @@
+"""Groq provider for audio modality."""
+
+from .client import GroqAudioClient
+from .models import MODELS
+
+__all__ = ["MODELS", "GroqAudioClient"]

--- a/src/celeste/modalities/audio/providers/groq/client.py
+++ b/src/celeste/modalities/audio/providers/groq/client.py
@@ -1,0 +1,53 @@
+"""Groq audio client."""
+
+from typing import Any
+
+from celeste.artifacts import AudioArtifact
+from celeste.parameters import ParameterMapper
+from celeste.providers.groq.audio import config
+from celeste.providers.groq.audio.client import GroqAudioClient as GroqAudioMixin
+from celeste.types import AudioContent
+
+from ...client import AudioClient
+from ...io import AudioFinishReason, AudioInput
+from .parameters import GROQ_PARAMETER_MAPPERS
+
+
+class GroqAudioClient(GroqAudioMixin, AudioClient):
+    """Groq audio client (speech-to-text)."""
+
+    _transcribe_endpoint = config.GroqAudioEndpoint.CREATE_TRANSCRIPTION
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[AudioContent]]:
+        return GROQ_PARAMETER_MAPPERS
+
+    def _init_request(self, inputs: AudioInput) -> dict[str, Any]:
+        """Initialize multipart transcription request with audio file."""
+        audio = inputs.audio
+        if audio is None:
+            msg = "Audio input is required for transcription"
+            raise ValueError(msg)
+        if isinstance(audio, list):
+            if len(audio) != 1:
+                msg = "Groq transcription accepts exactly one audio file"
+                raise ValueError(msg)
+            artifact = audio[0]
+        else:
+            artifact = audio
+        if not isinstance(artifact, AudioArtifact):
+            msg = "Groq transcription requires an AudioArtifact"
+            raise ValueError(msg)
+        return {"file": artifact}
+
+    def _parse_content(self, response_data: dict[str, Any]) -> str:
+        """Extract transcript text from response."""
+        return super()._parse_content(response_data)
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> AudioFinishReason:
+        """Groq transcription does not provide finish reasons."""
+        _ = response_data
+        return AudioFinishReason(reason=None)
+
+
+__all__ = ["GroqAudioClient"]

--- a/src/celeste/modalities/audio/providers/groq/models.py
+++ b/src/celeste/modalities/audio/providers/groq/models.py
@@ -1,0 +1,46 @@
+"""Groq models for audio modality."""
+
+from celeste.constraints import AudioConstraint, Range
+from celeste.core import Modality, Operation, Provider
+from celeste.mime_types import AudioMimeType
+from celeste.models import Model
+
+from ...parameters import AudioParameter
+
+_GROQ_AUDIO_MIME_TYPES = [
+    AudioMimeType.FLAC,
+    AudioMimeType.MP3,
+    AudioMimeType.M4A,
+    AudioMimeType.OGG,
+    AudioMimeType.WAV,
+    AudioMimeType.WEBM,
+]
+
+MODELS: list[Model] = [
+    Model(
+        id="whisper-large-v3-turbo",
+        provider=Provider.GROQ,
+        display_name="Whisper Large V3 Turbo",
+        streaming=False,
+        operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
+        parameter_constraints={
+            AudioParameter.AUDIO: AudioConstraint(
+                supported_mime_types=_GROQ_AUDIO_MIME_TYPES
+            ),
+            AudioParameter.TEMPERATURE: Range(min=0.0, max=1.0),
+        },
+    ),
+    Model(
+        id="whisper-large-v3",
+        provider=Provider.GROQ,
+        display_name="Whisper Large V3",
+        streaming=False,
+        operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
+        parameter_constraints={
+            AudioParameter.AUDIO: AudioConstraint(
+                supported_mime_types=_GROQ_AUDIO_MIME_TYPES
+            ),
+            AudioParameter.TEMPERATURE: Range(min=0.0, max=1.0),
+        },
+    ),
+]

--- a/src/celeste/modalities/audio/providers/groq/parameters.py
+++ b/src/celeste/modalities/audio/providers/groq/parameters.py
@@ -1,0 +1,42 @@
+"""Groq parameter mappers for audio modality."""
+
+from celeste.parameters import ParameterMapper
+from celeste.providers.groq.audio.parameters import (
+    LanguageMapper as _LanguageMapper,
+)
+from celeste.providers.groq.audio.parameters import (
+    PromptMapper as _PromptMapper,
+)
+from celeste.providers.groq.audio.parameters import (
+    TemperatureMapper as _TemperatureMapper,
+)
+from celeste.types import AudioContent
+
+from ...parameters import AudioParameter
+
+
+class LanguageMapper(_LanguageMapper):
+    """Map language to Groq's language parameter."""
+
+    name = AudioParameter.LANGUAGE
+
+
+class PromptMapper(_PromptMapper):
+    """Map prompt to Groq's prompt parameter."""
+
+    name = AudioParameter.PROMPT
+
+
+class TemperatureMapper(_TemperatureMapper):
+    """Map temperature to Groq's temperature parameter."""
+
+    name = AudioParameter.TEMPERATURE
+
+
+GROQ_PARAMETER_MAPPERS: list[ParameterMapper[AudioContent]] = [
+    LanguageMapper(),
+    PromptMapper(),
+    TemperatureMapper(),
+]
+
+__all__ = ["GROQ_PARAMETER_MAPPERS"]

--- a/src/celeste/namespaces/domains.py
+++ b/src/celeste/namespaces/domains.py
@@ -836,6 +836,28 @@ class SyncAudioNamespace:
         )
         return client.sync.analyze(prompt, messages=messages, audio=audio, **params)
 
+    def transcribe(
+        self,
+        audio: AudioContent,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        prompt: str | None = None,
+        **params: Unpack[AudioParameters],
+    ) -> TextOutput:
+        """Blocking speech transcription."""
+        client = create_client(
+            modality=Modality.AUDIO,
+            operation=Operation.TRANSCRIBE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return client.sync.transcribe(audio, prompt=prompt, **params)
+
     def embed(
         self,
         audio: AudioContent,
@@ -866,7 +888,7 @@ class SyncAudioNamespace:
 class AudioNamespace:
     """celeste.audio.* namespace.
 
-    Provides text-to-speech, audio generation, and audio analysis operations.
+    Provides text-to-speech, audio generation, transcription, and analysis.
     """
 
     async def speak(
@@ -973,6 +995,41 @@ class AudioNamespace:
         return await client.analyze(
             prompt, messages=messages, audio=audio, **parameters
         )
+
+    async def transcribe(
+        self,
+        audio: AudioContent,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        prompt: str | None = None,
+        **parameters: Unpack[AudioParameters],
+    ) -> TextOutput:
+        """Transcribe speech audio to text.
+
+        Args:
+            audio: Audio or list of audio files to transcribe.
+            model: Model ID to use (required).
+            provider: Optional provider override.
+            api_key: Optional API key override.
+            auth: Optional Authentication object (e.g., GoogleADC for Vertex AI).
+            prompt: Optional spelling or style hint for the transcript.
+            **parameters: Additional model parameters (language, temperature).
+
+        Returns:
+            TextOutput with the transcript text.
+        """
+        client = create_client(
+            modality=Modality.AUDIO,
+            operation=Operation.TRANSCRIBE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return await client.transcribe(audio, prompt=prompt, **parameters)
 
     async def embed(
         self,

--- a/src/celeste/providers/api_references.md
+++ b/src/celeste/providers/api_references.md
@@ -19,6 +19,7 @@ This document contains the official API reference documentation links for all pr
 | **Cohere** | Chat | [Chat API Reference](https://docs.cohere.com/reference/chat) | ✅ |
 | **DeepSeek** | Chat | [Chat API Reference](https://api-docs.deepseek.com/api/create-chat-completion) | ✅ |
 | **Groq** | Chat | [Chat API Reference](https://console.groq.com/docs/api-reference#chat-create) | ✅ |
+| **Groq** | Audio | [Speech to Text](https://console.groq.com/docs/speech-to-text) | ✅ |
 | **Mistral** | Chat | [Chat API Reference](https://docs.mistral.ai/api/) | ✅ |
 | **Moonshot** | Chat | [Chat API Reference](https://platform.moonshot.ai/docs/api/chat) | ✅ |
 | **XAI** | Responses | [Responses API Reference](https://docs.x.ai/docs/api-reference#create-new-response) | ✅ |

--- a/src/celeste/providers/groq/audio/__init__.py
+++ b/src/celeste/providers/groq/audio/__init__.py
@@ -1,0 +1,1 @@
+"""Groq Audio API provider package."""

--- a/src/celeste/providers/groq/audio/client.py
+++ b/src/celeste/providers/groq/audio/client.py
@@ -1,0 +1,112 @@
+"""Groq Audio API client mixin."""
+
+from typing import Any, ClassVar
+
+from celeste.artifacts import AudioArtifact
+from celeste.client import APIMixin
+from celeste.io import FinishReason
+from celeste.mime_types import AudioMimeType
+from celeste.utils import detect_mime_type
+
+from . import config
+
+_MIME_TO_EXT: dict[str, str] = {
+    AudioMimeType.FLAC: "flac",
+    AudioMimeType.MP3: "mp3",
+    AudioMimeType.M4A: "m4a",
+    AudioMimeType.OGG: "ogg",
+    AudioMimeType.WAV: "wav",
+    AudioMimeType.WEBM: "webm",
+}
+
+
+class GroqAudioClient(APIMixin):
+    """Mixin for Groq Audio transcription API."""
+
+    _content_fields: ClassVar[set[str]] = {"text"}
+
+    def _build_request(
+        self,
+        inputs: Any,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Any,
+    ) -> dict[str, Any]:
+        """Build request with model ID."""
+        _ = streaming
+        request_body = super()._build_request(
+            inputs, extra_body=extra_body, streaming=False, **parameters
+        )
+        request_body["model"] = self.model.id
+        request_body.setdefault("response_format", "json")
+        return request_body
+
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Any,
+    ) -> dict[str, Any]:
+        """Make multipart transcription request to Groq Audio API."""
+        _ = parameters
+        if endpoint is None:
+            endpoint = config.GroqAudioEndpoint.CREATE_TRANSCRIPTION
+
+        audio = request_body.pop("file")
+        if not isinstance(audio, AudioArtifact):
+            msg = "Groq transcription requires a single AudioArtifact"
+            raise ValueError(msg)
+
+        audio_bytes = audio.get_bytes()
+        mime = audio.mime_type or detect_mime_type(audio_bytes)
+        mime_str = mime.value if mime else "application/octet-stream"
+        ext = _MIME_TO_EXT.get(mime, "wav") if mime is not None else "wav"
+
+        files = {"file": (f"audio.{ext}", audio_bytes, mime_str)}
+        data: dict[str, str] = {"model": str(request_body.pop("model"))}
+        for key, value in request_body.items():
+            if value is not None:
+                data[key] = str(value)
+
+        response = await self.http_client.post_multipart(
+            f"{config.BASE_URL}{endpoint}",
+            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            files=files,
+            data=data,
+        )
+        self._handle_error_response(response)
+        result: dict[str, Any] = response.json()
+        return result
+
+    def _parse_usage(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
+        """Extract usage data from Groq Audio API response."""
+        _ = response_data
+        return {}
+
+    def _parse_content(self, response_data: dict[str, Any]) -> str:
+        """Parse transcript text from Groq Audio API response."""
+        text = response_data.get("text")
+        if text is None:
+            msg = "No text in transcription response"
+            raise ValueError(msg)
+        return str(text)
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
+        """Groq Audio transcription does not provide finish reasons."""
+        _ = response_data
+        return FinishReason(reason=None)
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Keep language, duration, and x_groq in metadata when present."""
+        metadata = super()._build_metadata(response_data)
+        for key in ("language", "duration", "x_groq"):
+            if key in response_data:
+                metadata[key] = response_data[key]
+        return metadata
+
+
+__all__ = ["GroqAudioClient"]

--- a/src/celeste/providers/groq/audio/config.py
+++ b/src/celeste/providers/groq/audio/config.py
@@ -1,0 +1,12 @@
+"""Configuration for Groq Audio API."""
+
+from enum import StrEnum
+
+
+class GroqAudioEndpoint(StrEnum):
+    """Endpoints for Groq Audio API."""
+
+    CREATE_TRANSCRIPTION = "/openai/v1/audio/transcriptions"
+
+
+BASE_URL = "https://api.groq.com"

--- a/src/celeste/providers/groq/audio/parameters.py
+++ b/src/celeste/providers/groq/audio/parameters.py
@@ -1,0 +1,64 @@
+"""Groq Audio API parameter mappers."""
+
+from typing import Any
+
+from celeste.models import Model
+from celeste.parameters import ParameterMapper
+
+
+class LanguageMapper[Content](ParameterMapper[Content]):
+    """Map language to Groq language field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform language into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        request["language"] = validated_value
+        return request
+
+
+class PromptMapper[Content](ParameterMapper[Content]):
+    """Map prompt to Groq prompt field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform prompt into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        request["prompt"] = validated_value
+        return request
+
+
+class TemperatureMapper[Content](ParameterMapper[Content]):
+    """Map temperature to Groq temperature field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform temperature into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        request["temperature"] = validated_value
+        return request
+
+
+__all__ = [
+    "LanguageMapper",
+    "PromptMapper",
+    "TemperatureMapper",
+]

--- a/src/celeste/types.py
+++ b/src/celeste/types.py
@@ -14,7 +14,7 @@ from celeste.artifacts import (
 from celeste.core import InputType
 
 type JsonValue = (
-    str | int | float | bool | None | dict[str, JsonValue] | list[JsonValue]
+    str | int | float | bool | dict[str, JsonValue] | list[JsonValue] | None
 )
 
 type TextContent = str | JsonValue | BaseModel | list[BaseModel]

--- a/tests/integration_tests/audio/test_transcribe.py
+++ b/tests/integration_tests/audio/test_transcribe.py
@@ -1,0 +1,30 @@
+"""Integration tests for audio transcription."""
+
+import pytest
+
+from celeste import Modality, Operation, Provider, create_client
+from celeste.artifacts import AudioArtifact
+from celeste.modalities.text.io import TextOutput
+
+MODELS = [
+    (Provider.GROQ, "whisper-large-v3-turbo"),
+    (Provider.GROQ, "whisper-large-v3"),
+]
+
+
+@pytest.mark.parametrize(("provider", "model"), MODELS)
+async def test_transcribe(
+    provider: Provider, model: str, test_audio: AudioArtifact
+) -> None:
+    client = create_client(
+        modality=Modality.AUDIO,
+        operation=Operation.TRANSCRIBE,
+        provider=provider,
+        model=model,
+    )
+
+    response = await client.transcribe(test_audio)
+
+    assert isinstance(response, TextOutput)
+    assert isinstance(response.content, str)
+    assert response.content.strip()

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -14,6 +14,7 @@ from celeste.core import Domain, Modality, Operation, infer_modality
         (Domain.IMAGES, Operation.EDIT, Modality.IMAGES),
         (Domain.AUDIO, Operation.GENERATE, Modality.AUDIO),
         (Domain.AUDIO, Operation.SPEAK, Modality.AUDIO),
+        (Domain.AUDIO, Operation.TRANSCRIBE, Modality.AUDIO),
         (Domain.VIDEOS, Operation.GENERATE, Modality.VIDEOS),
         (Domain.DOCUMENTS, Operation.ANALYZE, Modality.TEXT),
     ],

--- a/tests/unit_tests/test_groq_audio_transcribe.py
+++ b/tests/unit_tests/test_groq_audio_transcribe.py
@@ -1,0 +1,44 @@
+"""Unit tests for Groq audio transcription request building."""
+
+from pydantic import SecretStr
+
+from celeste.artifacts import AudioArtifact
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.mime_types import AudioMimeType
+from celeste.modalities.audio.io import AudioInput
+from celeste.modalities.audio.providers.groq.client import GroqAudioClient
+from celeste.models import Model
+
+
+def _client() -> GroqAudioClient:
+    return GroqAudioClient(
+        model=Model(
+            id="whisper-large-v3-turbo",
+            provider=Provider.GROQ,
+            display_name="Whisper Large V3 Turbo",
+            operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
+        ),
+        auth=AuthHeader(secret=SecretStr("test")),
+        provider=Provider.GROQ,
+    )
+
+
+def test_init_request_puts_audio_artifact_as_file() -> None:
+    audio = AudioArtifact(data=b"fake-audio", mime_type=AudioMimeType.MP3)
+    request = _client()._init_request(AudioInput(audio=audio))
+    assert request == {"file": audio}
+
+
+def test_build_request_adds_model_and_default_response_format() -> None:
+    audio = AudioArtifact(data=b"fake-audio", mime_type=AudioMimeType.WAV)
+    client = _client()
+    request = client._build_request(AudioInput(audio=audio), language="en")
+    assert request["file"] is audio
+    assert request["model"] == "whisper-large-v3-turbo"
+    assert request["response_format"] == "json"
+    assert request["language"] == "en"
+
+
+def test_parse_content_returns_transcript_text() -> None:
+    assert _client()._parse_content({"text": "hello world"}) == "hello world"

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -7,6 +7,7 @@ from celeste.artifacts import ImageArtifact
 from celeste.mime_types import AudioMimeType, ImageMimeType
 from celeste.modalities.audio.parameters import AudioParameter
 from celeste.modalities.audio.providers.google import parameters as google_audio
+from celeste.modalities.audio.providers.groq import parameters as groq_audio
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.bfl import parameters as bfl
 from celeste.modalities.images.providers.google import parameters as google_images
@@ -34,6 +35,7 @@ IMAGES_VERTEX = google_images.GOOGLE_VERTEX_PARAMETER_MAPPERS
 IMAGES_INTERACTIONS = google_images.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 IMAGES_IMAGEN = google_images.GOOGLE_IMAGEN_PARAMETER_MAPPERS
 AUDIO_GOOGLE = google_audio.GOOGLE_PARAMETER_MAPPERS
+AUDIO_GROQ = groq_audio.GROQ_PARAMETER_MAPPERS
 VIDEOS_VEO = google_videos.GOOGLE_VEO_PARAMETER_MAPPERS
 VIDEOS_INTERACTIONS = google_videos.GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 OPEN = openai.OPENAI_PARAMETER_MAPPERS
@@ -211,6 +213,9 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (MOONSHOT, T.MAX_TOKENS, 120, ("max_completion_tokens",), 120),
         (MOONSHOT, T.THINKING_BUDGET, "max", ("reasoning_effort",), "max"),
         (GROQ, T.THINKING_BUDGET, "default", ("reasoning_effort",), "default"),
+        (AUDIO_GROQ, AP.LANGUAGE, "en", ("language",), "en"),
+        (AUDIO_GROQ, AP.PROMPT, "Celeste", ("prompt",), "Celeste"),
+        (AUDIO_GROQ, AP.TEMPERATURE, 0.0, ("temperature",), 0.0),
         (XAI, V.FIRST_FRAME, IMAGE, ("image", "url"), IMAGE.url),
     ],
 )
@@ -232,6 +237,7 @@ def test_scalar_parameters_use_provider_wire_shape(
         IMAGES_VERTEX,
         IMAGES_IMAGEN,
         AUDIO_GOOGLE,
+        AUDIO_GROQ,
         VIDEOS_VEO,
         VIDEOS_INTERACTIONS,
         OPEN,


### PR DESCRIPTION
## Summary

`Operation.TRANSCRIBE` existed in the enum but was never wired. This PR lands dedicated speech-to-text as a first-class audio operation — distinct from `audio.analyze` (multimodal chat → text) and from TTS (`speak` / `generate`).

### Routing

`(Domain.AUDIO, Operation.TRANSCRIBE) → Modality.AUDIO`

STT uses provider ASR wire formats (multipart file upload), not chat completions. Keeping it on the audio modality avoids forcing Whisper through the text client path.

### Public API

```python
output = await celeste.audio.transcribe(
    audio,  # AudioArtifact | list[AudioArtifact]
    model="whisper-large-v3-turbo",
    prompt="Celeste",  # optional Whisper spelling/style hint (not the transcript input)
    language="en",
)
# TextOutput — content is the transcript string
```

Sync: `celeste.audio.sync.transcribe(...)`.

`AudioClient.transcribe` returns `TextOutput` (audio in → text out). It does not go through `_predict`'s `AudioOutput` assembly; the request/parse loop lives on the audio client for this cross-modality result.

### Groq (first provider)

- Wire: `POST /openai/v1/audio/transcriptions` (multipart)
- Models: `whisper-large-v3-turbo`, `whisper-large-v3`
- Params: `language`, `prompt`, `temperature` (+ audio MIME constraints)

### Also

- `AudioInput` gains optional `audio` (text remains for TTS)
- Audio parameters: `PROMPT`, `TEMPERATURE`, `AUDIO`
- Domain namespace async + sync surfaces
- Unit wire contracts + live integration tests

### Out of scope

- Streaming transcription / translations endpoint
- Additional STT providers (OpenAI Whisper, Deepgram, …)
- Remapping `TRANSCRIBE` → `Modality.TEXT`
- Chat-app migration onto `audio.transcribe`

## Test plan

- [x] `make ci`
- [x] `pytest tests/integration_tests/audio/test_transcribe.py` with `GROQ_API_KEY`
- [ ] Review routing vs `audio.analyze` in the PR diff (`core.py` + namespaces)
- [ ] Manual: `celeste.audio.transcribe(audio, model="whisper-large-v3-turbo")` → non-empty `TextOutput.content`