### PR TITLE
feat(videos): add continuation and draft groundwork

### DIFF
--- a/.agents/skills/celeste-python/references/public-api.md
+++ b/.agents/skills/celeste-python/references/public-api.md
@@ -34,6 +34,7 @@ Available namespace families include:
 - `celeste.audio.analyze`
 - `celeste.audio.embed`
 - `celeste.videos.generate`
+- `celeste.videos.enhance_draft`
 - `celeste.videos.analyze`
 - `celeste.videos.embed`
 - `celeste.documents.analyze`

--- a/.agents/skills/celeste-python/references/repo-map.md
+++ b/.agents/skills/celeste-python/references/repo-map.md
@@ -18,6 +18,7 @@ Use domain namespaces for normal app code:
 - `celeste.audio.analyze(...)`
 - `celeste.audio.embed(...)`
 - `celeste.videos.generate(...)`
+- `celeste.videos.enhance_draft(...)`
 - `celeste.videos.analyze(...)`
 - `celeste.videos.embed(...)`
 - `celeste.documents.analyze(...)`
@@ -49,7 +50,7 @@ Core enums live in `src/celeste/core.py`:
 - `Provider`: backend vendor or local provider.
 - `Protocol`: wire-compatible API format such as `openresponses` or `chatcompletions`.
 - `Modality`: output/client family such as text, images, videos, audio, embeddings.
-- `Operation`: action such as generate, edit, analyze, speak, transcribe, embed, upscale.
+- `Operation`: action such as generate, edit, analyze, speak, transcribe, embed, upscale, enhance.
 - `Domain`: resource the user works with, used by namespace routing.
 - `InputType`: optional media input categories.
 - `Parameter`: common parameter names shared across modalities.

--- a/src/celeste/core.py
+++ b/src/celeste/core.py
@@ -62,6 +62,7 @@ class Operation(StrEnum):
     TRANSCRIBE = "transcribe"
     EMBED = "embed"
     UPSCALE = "upscale"
+    ENHANCE = "enhance"
     SEGMENT = "segment"
 
 
@@ -134,6 +135,7 @@ DOMAIN_OPERATION_TO_MODALITY: dict[tuple[Domain, Operation], Modality] = {
     (Domain.AUDIO, Operation.TRANSCRIBE): Modality.AUDIO,
     (Domain.AUDIO, Operation.ANALYZE): Modality.TEXT,
     (Domain.VIDEOS, Operation.GENERATE): Modality.VIDEOS,
+    (Domain.VIDEOS, Operation.ENHANCE): Modality.VIDEOS,
     (Domain.VIDEOS, Operation.ANALYZE): Modality.TEXT,
     (Domain.VIDEOS, Operation.EMBED): Modality.EMBEDDINGS,
     (Domain.DOCUMENTS, Operation.ANALYZE): Modality.TEXT,

--- a/src/celeste/modalities/videos/__init__.py
+++ b/src/celeste/modalities/videos/__init__.py
@@ -1,19 +1,28 @@
 """Celeste Videos modality."""
 
 from .client import VideosClient
+from .constraints import VideoKeyframesConstraint
 from .io import (
     VideoChunk,
+    VideoDraftCache,
     VideoFinishReason,
     VideoInput,
     VideoOutput,
     VideoUsage,
 )
-from .parameters import VideoParameter, VideoParameters
+from .parameters import (
+    VideoKeyframe,
+    VideoParameter,
+    VideoParameters,
+)
 
 __all__ = [
     "VideoChunk",
+    "VideoDraftCache",
     "VideoFinishReason",
     "VideoInput",
+    "VideoKeyframe",
+    "VideoKeyframesConstraint",
     "VideoOutput",
     "VideoParameter",
     "VideoParameters",

--- a/src/celeste/modalities/videos/client.py
+++ b/src/celeste/modalities/videos/client.py
@@ -9,14 +9,21 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import VideoContent
 
-from .io import VideoChunk, VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from .io import (
+    VideoChunk,
+    VideoDraftCache,
+    VideoFinishReason,
+    VideoInput,
+    VideoOutput,
+    VideoUsage,
+)
 from .parameters import VideoParameters
 
 
 class VideosClient(
     ModalityClient[VideoInput, VideoOutput, VideoParameters, VideoContent, VideoChunk]
 ):
-    """Base videos client with generate/edit operations."""
+    """Base videos client with generate, edit, and draft enhancement operations."""
 
     modality: Modality = Modality.VIDEOS
     _usage_class = VideoUsage
@@ -24,6 +31,7 @@ class VideosClient(
 
     _generate_endpoint: ClassVar[str | None] = None
     _edit_endpoint: ClassVar[str | None] = None
+    _enhance_endpoint: ClassVar[str | None] = None
 
     @classmethod
     def _output_class(cls) -> type[VideoOutput]:
@@ -54,6 +62,20 @@ class VideosClient(
         inputs = VideoInput(prompt=prompt, video=video)
         return await self._predict(inputs, endpoint=self._edit_endpoint, **parameters)
 
+    async def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Render a cached video draft at full quality."""
+        if self._enhance_endpoint is None:
+            msg = f"Model {self.model.id} does not support draft enhancement"
+            raise NotImplementedError(msg)
+        inputs = VideoInput(draft_cache=draft_cache)
+        return await self._predict(
+            inputs, endpoint=self._enhance_endpoint, **parameters
+        )
+
     @property
     def sync(self) -> "VideosSyncNamespace":
         """Sync namespace for videos operations."""
@@ -63,7 +85,7 @@ class VideosClient(
 class VideosSyncNamespace:
     """Sync namespace for videos operations.
 
-    Provides `client.sync.generate()`.
+    Provides `client.sync.generate()` and `client.sync.enhance_draft()`.
     """
 
     def __init__(self, client: VideosClient) -> None:
@@ -87,6 +109,14 @@ class VideosSyncNamespace:
         return async_to_sync(self._client._predict)(
             inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
         )
+
+    def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Blocking full-quality render of a cached video draft."""
+        return async_to_sync(self._client.enhance_draft)(draft_cache, **parameters)
 
 
 __all__ = [

--- a/src/celeste/modalities/videos/constraints.py
+++ b/src/celeste/modalities/videos/constraints.py
@@ -1,0 +1,53 @@
+"""Constraint models for the videos modality."""
+
+from typing import ClassVar
+
+from celeste.artifacts import ImageArtifact
+from celeste.constraints import Constraint
+from celeste.exceptions import ConstraintViolationError
+
+from .parameters import VideoKeyframe
+
+
+class VideoKeyframesConstraint(Constraint):
+    """Validate ordered, uniformly timed or untimed video keyframes."""
+
+    _artifact_type: ClassVar[type] = ImageArtifact
+
+    max_count: int
+    max_timestamp: float
+
+    def __call__(self, value: object) -> list[VideoKeyframe]:
+        """Validate keyframe count, types, and optional timestamps."""
+        if not isinstance(value, list) or not value:
+            msg = "Must contain at least one VideoKeyframe"
+            raise ConstraintViolationError(msg)
+        if len(value) > self.max_count:
+            msg = f"Must have at most {self.max_count} keyframes, got {len(value)}"
+            raise ConstraintViolationError(msg)
+        if not all(isinstance(item, VideoKeyframe) for item in value):
+            msg = "Every keyframe must be a VideoKeyframe"
+            raise ConstraintViolationError(msg)
+
+        keyframes = list(value)
+        timestamps = [item.timestamp for item in keyframes]
+        timed = [timestamp is not None for timestamp in timestamps]
+        if any(timed) and not all(timed):
+            msg = "Keyframes must be either all timed or all untimed"
+            raise ConstraintViolationError(msg)
+        if all(timed):
+            numeric = [
+                float(timestamp) for timestamp in timestamps if timestamp is not None
+            ]
+            if any(
+                timestamp < 0 or timestamp > self.max_timestamp for timestamp in numeric
+            ):
+                msg = f"Keyframe timestamps must be between 0 and {self.max_timestamp}"
+                raise ConstraintViolationError(msg)
+            if numeric != sorted(numeric):
+                msg = "Keyframe timestamps must be in ascending order"
+                raise ConstraintViolationError(msg)
+        return keyframes
+
+
+__all__ = ["VideoKeyframesConstraint"]

--- a/src/celeste/modalities/videos/io.py
+++ b/src/celeste/modalities/videos/io.py
@@ -2,15 +2,23 @@
 
 from pydantic import Field
 
-from celeste.artifacts import VideoArtifact
+from celeste.artifacts import Artifact, VideoArtifact
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
+from celeste.mime_types import ApplicationMimeType
+
+
+class VideoDraftCache(Artifact):
+    """Opaque provider state used to render a prior video draft."""
+
+    mime_type: ApplicationMimeType | None = ApplicationMimeType.OCTET_STREAM
 
 
 class VideoInput(Input):
-    """Input for video generation and edit operations."""
+    """Input for video generation, editing, and draft enhancement."""
 
-    prompt: str
+    prompt: str | None = None
     video: VideoArtifact | None = None  # For edit operations
+    draft_cache: VideoDraftCache | None = None
 
 
 class VideoFinishReason(FinishReason):
@@ -32,6 +40,8 @@ class VideoUsage(Usage):
     reasoning_tokens: int | None = None
     cached_tokens: int | None = None
     billed_units: float | None = None
+    input_mp: float | None = None
+    output_mp: float | None = None
 
 
 class VideoOutput(Output[VideoArtifact]):
@@ -39,6 +49,12 @@ class VideoOutput(Output[VideoArtifact]):
 
     usage: VideoUsage = Field(default_factory=VideoUsage)
     finish_reason: VideoFinishReason | None = None
+
+    @property
+    def draft_cache(self) -> VideoDraftCache | None:
+        """Return reusable draft state when the provider supplied it."""
+        value = self.metadata.get("draft_cache")
+        return value if isinstance(value, VideoDraftCache) else None
 
 
 class VideoChunk(Chunk[VideoArtifact]):
@@ -50,6 +66,7 @@ class VideoChunk(Chunk[VideoArtifact]):
 
 __all__ = [
     "VideoChunk",
+    "VideoDraftCache",
     "VideoFinishReason",
     "VideoInput",
     "VideoOutput",

--- a/src/celeste/modalities/videos/parameters.py
+++ b/src/celeste/modalities/videos/parameters.py
@@ -3,10 +3,17 @@
 from enum import StrEnum
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
-from celeste.artifacts import ImageArtifact
+from celeste.artifacts import ImageArtifact, VideoArtifact
 from celeste.parameters import Parameters
+
+
+class VideoKeyframe(BaseModel):
+    """An image pinned to an optional timestamp on a video timeline."""
+
+    image: ImageArtifact
+    timestamp: float | None = None
 
 
 class VideoParameter(StrEnum):
@@ -18,6 +25,11 @@ class VideoParameter(StrEnum):
     REFERENCE_IMAGES = "reference_images"
     FIRST_FRAME = "first_frame"
     LAST_FRAME = "last_frame"
+    KEYFRAMES = "keyframes"
+    START_VIDEO = "start_video"
+    GENERATE_AUDIO = "generate_audio"
+    SAFETY_TOLERANCE = "safety_tolerance"
+    DRAFT = "draft"
 
 
 class VideoParameters(Parameters, total=False):
@@ -27,7 +39,10 @@ class VideoParameters(Parameters, total=False):
         str, Field(description="Output video dimensions or aspect ratio.")
     ]
     resolution: Annotated[str, Field(description="Vertical resolution tier.")]
-    duration: Annotated[int, Field(description="Clip length in seconds.")]
+    duration: Annotated[
+        int | str,
+        Field(description="Clip length in seconds, or a provider-supported mode."),
+    ]
     reference_images: Annotated[
         list[ImageArtifact],
         Field(description="Additional images conditioning the video."),
@@ -38,9 +53,27 @@ class VideoParameters(Parameters, total=False):
     last_frame: Annotated[
         ImageArtifact, Field(description="Image to use as the video's last frame.")
     ]
+    keyframes: Annotated[
+        list[VideoKeyframe],
+        Field(description="Ordered images optionally pinned to timeline timestamps."),
+    ]
+    start_video: Annotated[
+        VideoArtifact,
+        Field(description="Existing video whose final frames start the generation."),
+    ]
+    generate_audio: Annotated[
+        bool, Field(description="Generate synchronized audio with the video.")
+    ]
+    safety_tolerance: Annotated[
+        int, Field(description="Provider safety tolerance level.")
+    ]
+    draft: Annotated[
+        bool, Field(description="Generate a fast preview with reusable draft state.")
+    ]
 
 
 __all__ = [
+    "VideoKeyframe",
     "VideoParameter",
     "VideoParameters",
 ]

--- a/src/celeste/namespaces/domains.py
+++ b/src/celeste/namespaces/domains.py
@@ -24,7 +24,7 @@ from celeste.modalities.segmentation.parameters import SegmentationParameters
 from celeste.modalities.text.io import TextOutput
 from celeste.modalities.text.parameters import TextParameters
 from celeste.modalities.text.streaming import TextStream
-from celeste.modalities.videos.io import VideoOutput
+from celeste.modalities.videos.io import VideoDraftCache, VideoOutput
 from celeste.modalities.videos.parameters import VideoParameters
 from celeste.types import (
     AudioContent,
@@ -1268,6 +1268,27 @@ class SyncVideosNamespace:
         )
         return client.sync.generate(prompt, **params)
 
+    def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **params: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Blocking full-quality render of a cached video draft."""
+        client = create_client(
+            modality=Modality.VIDEOS,
+            operation=Operation.ENHANCE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return client.sync.enhance_draft(draft_cache, **params)
+
     def analyze(
         self,
         video: VideoContent,
@@ -1321,7 +1342,7 @@ class SyncVideosNamespace:
 class VideosNamespace:
     """celeste.videos.* namespace.
 
-    Provides video generation and analysis operations.
+    Provides video generation, draft enhancement, and analysis operations.
     """
 
     async def generate(
@@ -1356,6 +1377,27 @@ class VideosNamespace:
             auth=auth,
         )
         return await client.generate(prompt, **parameters)
+
+    async def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Render a cached video draft at full quality."""
+        client = create_client(
+            modality=Modality.VIDEOS,
+            operation=Operation.ENHANCE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return await client.enhance_draft(draft_cache, **parameters)
 
     async def analyze(
         self,


### PR DESCRIPTION
## Summary

- add a first-class video draft enhancement operation with async and sync namespace routing
- add typed video keyframes, continuation video input, draft cache state, and unified FLUX 3 video parameters
- allow provider-supported duration modes and document the expanded public video API

## Why

FLUX 3's documented keyframe, continuation, and draft workflows need provider-neutral Celeste types instead of requiring callers to pass BFL wire payloads through `extra_body`. This groundwork is separated from the provider integration per the repository's one-concern rule.

## Impact

Existing video providers remain gated by their model operations and parameter constraints. The new public surface is available only when a model advertises support.

## Validation

- repository pre-commit and pre-push checks
- `make ci` on the complete stack (584 tests passed)
