### PR TITLE
refactor(bfl): share asynchronous polling transport

### DIFF
--- a/src/celeste/providers/bfl/client.py
+++ b/src/celeste/providers/bfl/client.py
@@ -1,0 +1,133 @@
+"""Shared BFL asynchronous API client."""
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from typing import Any, ClassVar
+
+from celeste.client import APIMixin
+from celeste.core import UsageField
+from celeste.exceptions import StreamingNotSupportedError
+from celeste.io import FinishReason
+from celeste.mime_types import ApplicationMimeType
+
+_BASE_URL = "https://api.bfl.ai"
+_TERMINAL_FAILURES = frozenset(
+    {
+        "Error",
+        "Failed",
+        "Request Moderated",
+        "Content Moderated",
+        "Task not found",
+    }
+)
+
+
+class BFLAsyncClient(APIMixin):
+    """Shared submit-and-poll implementation for BFL APIs."""
+
+    _content_fields: ClassVar[set[str]] = {"result"}
+    _default_endpoint: ClassVar[str]
+    _operation_label: ClassVar[str] = "generation"
+    _polling_interval: ClassVar[float]
+    _polling_timeout: ClassVar[float]
+
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Any,
+    ) -> dict[str, Any]:
+        """Submit a BFL job and poll its returned URL until completion."""
+        headers = {
+            **self._json_headers(extra_headers),
+            "Accept": ApplicationMimeType.JSON,
+        }
+        endpoint = (endpoint or self._default_endpoint).format(model_id=self.model.id)
+        submit_response = await self.http_client.post(
+            f"{_BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
+        self._handle_error_response(submit_response)
+        submit_data: dict[str, Any] = submit_response.json()
+        polling_url = submit_data.get("polling_url")
+        if not isinstance(polling_url, str) or not polling_url:
+            msg = f"No polling_url in {self.provider} response"
+            raise ValueError(msg)
+
+        poll_headers = self._merge_headers(
+            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            extra_headers,
+        )
+        started = time.monotonic()
+        while time.monotonic() - started < self._polling_timeout:
+            poll_response = await self.http_client.get(
+                polling_url,
+                headers=poll_headers,
+            )
+            self._handle_error_response(poll_response)
+            poll_data: dict[str, Any] = poll_response.json()
+            status = poll_data.get("status")
+            if status == "Ready":
+                return {**poll_data, "_submit_metadata": submit_data}
+            if status in _TERMINAL_FAILURES:
+                detail = poll_data.get("error") or poll_data.get("details") or status
+                msg = f"{self.provider} {self._operation_label} failed ({status}): {detail}"
+                raise ValueError(msg)
+            await asyncio.sleep(self._polling_interval)
+
+        msg = f"{self.provider} polling timed out after {self._polling_timeout} seconds"
+        raise TimeoutError(msg)
+
+    def _make_stream_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Reject SSE streaming, which BFL's asynchronous APIs do not expose."""
+        raise StreamingNotSupportedError(model_id=self.model.id)
+
+    @staticmethod
+    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
+        """Map BFL credits and megapixels to unified usage fields."""
+        return {
+            UsageField.BILLED_UNITS: _float_or_none(usage_data.get("cost")),
+            UsageField.INPUT_MP: _float_or_none(usage_data.get("input_mp")),
+            UsageField.OUTPUT_MP: _float_or_none(usage_data.get("output_mp")),
+        }
+
+    def _parse_usage(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
+        """Prefer settled poll usage and fall back to submission estimates."""
+        usage_data = dict(response_data.get("_submit_metadata", {}))
+        for field in ("cost", "input_mp", "output_mp"):
+            if response_data.get(field) is not None:
+                usage_data[field] = response_data[field]
+        return self.map_usage_fields(usage_data)
+
+    def _parse_content(self, response_data: dict[str, Any]) -> Any:
+        """Return the non-empty BFL result object."""
+        result = response_data.get("result")
+        if not result:
+            msg = "No result in response"
+            raise ValueError(msg)
+        return result
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
+        """Return an empty finish reason because BFL only exposes task status."""
+        return FinishReason(reason=None)
+
+
+def _float_or_none(value: object) -> float | None:
+    """Convert an optional numeric BFL usage value to float."""
+    return float(value) if value is not None else None
+
+
+__all__ = ["BFLAsyncClient"]

--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -1,158 +1,17 @@
 """BFL Images API client mixin."""
 
-import asyncio
-import time
-from collections.abc import AsyncIterator
-from typing import Any, ClassVar
-
-from celeste.client import APIMixin
-from celeste.core import UsageField
-from celeste.exceptions import StreamingNotSupportedError
-from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
+from celeste.providers.bfl.client import BFLAsyncClient
 
 from . import config
 
 
-class BFLImagesClient(APIMixin):
-    """Mixin for BFL Images API operations.
+class BFLImagesClient(BFLAsyncClient):
+    """Mixin for BFL Images API operations."""
 
-    Provides shared implementation:
-    - _make_request() - HTTP POST with async polling pattern
-    - _parse_finish_reason() - Map BFL status to FinishReason
-
-    The BFL API uses async polling:
-    1. POST to /v1/{model_id} to submit job
-    2. Poll GET polling_url until Ready/Failed
-    3. Return final response with merged metadata
-
-    Usage:
-        class BFLImagesClient(BFLImagesMixin, ImagesClient):
-            def _parse_content(self, response_data):
-                result = response_data.get("result", {})
-                # Extract image from result["sample"]...
-    """
-
-    _content_fields: ClassVar[set[str]] = {"result"}
-
-    async def _make_request(
-        self,
-        request_body: dict[str, Any],
-        *,
-        endpoint: str | None = None,
-        extra_headers: dict[str, str] | None = None,
-        **parameters: Any,
-    ) -> dict[str, Any]:
-        """Make HTTP request with async polling for BFL image generation.
-
-        Handles the complete async polling workflow:
-        1. Submit job to /v1/{model_id}
-        2. Poll polling_url until Ready/Failed
-        3. Return response with _submit_metadata for usage parsing
-        """
-        headers = {
-            **self._json_headers(extra_headers),
-            "Accept": ApplicationMimeType.JSON,
-        }
-
-        if endpoint is None:
-            endpoint = config.BFLImagesEndpoint.CREATE_IMAGE
-        endpoint = endpoint.format(model_id=self.model.id)
-
-        # Phase 1: Submit job
-        submit_response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
-
-        self._handle_error_response(submit_response)
-        submit_data = submit_response.json()
-        polling_url = submit_data.get("polling_url")
-
-        if not polling_url:
-            msg = f"No polling_url in {self.provider} response"
-            raise ValueError(msg)
-
-        # Phase 2: Poll for completion
-        start_time = time.monotonic()
-        poll_headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
-            extra_headers,
-        )
-
-        while True:
-            elapsed = time.monotonic() - start_time
-            if elapsed >= config.POLLING_TIMEOUT:
-                msg = f"{self.provider} polling timed out after {config.POLLING_TIMEOUT} seconds"
-                raise TimeoutError(msg)
-
-            poll_response = await self.http_client.get(
-                polling_url,
-                headers=poll_headers,
-            )
-
-            self._handle_error_response(poll_response)
-            poll_data = poll_response.json()
-            status = poll_data.get("status")
-
-            if status == "Ready":
-                # Merge submit metadata into final response for usage parsing
-                return {
-                    **poll_data,
-                    "_submit_metadata": submit_data,
-                }
-            elif status in ("Error", "Failed"):
-                error_msg = poll_data.get("error", "Unknown error")
-                msg = f"{self.provider} image generation failed: {error_msg}"
-                raise ValueError(msg)
-
-            await asyncio.sleep(config.POLLING_INTERVAL)
-
-    def _make_stream_request(
-        self,
-        request_body: dict[str, Any],
-        *,
-        endpoint: str | None = None,
-        extra_headers: dict[str, str] | None = None,
-        **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """BFL Images API does not support SSE streaming in this client."""
-        raise StreamingNotSupportedError(model_id=self.model.id)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
-        """BFL provides status but not structured finish reasons."""
-        return FinishReason(reason=None)
-
-    @staticmethod
-    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
-        """Map BFL usage fields to unified names.
-
-        Shared by client and streaming across all capabilities.
-        """
-        cost = usage_data.get("cost")
-        input_mp = usage_data.get("input_mp")
-        output_mp = usage_data.get("output_mp")
-        return {
-            UsageField.BILLED_UNITS: float(cost) if cost is not None else None,
-            UsageField.INPUT_MP: float(input_mp) if input_mp is not None else None,
-            UsageField.OUTPUT_MP: float(output_mp) if output_mp is not None else None,
-        }
-
-    def _parse_usage(
-        self, response_data: dict[str, Any]
-    ) -> dict[str, int | float | None]:
-        """Extract usage data from BFL response."""
-        submit_metadata = response_data.get("_submit_metadata", {})
-        return BFLImagesClient.map_usage_fields(submit_metadata)
-
-    def _parse_content(self, response_data: dict[str, Any]) -> Any:
-        """Parse result from response."""
-        result = response_data.get("result", {})
-        if not result:
-            msg = "No result in response"
-            raise ValueError(msg)
-        return result
+    _default_endpoint = config.BFLImagesEndpoint.CREATE_IMAGE
+    _operation_label = "image generation"
+    _polling_interval = config.POLLING_INTERVAL
+    _polling_timeout = config.POLLING_TIMEOUT
 
 
 __all__ = ["BFLImagesClient"]

--- a/src/celeste/providers/bfl/images/config.py
+++ b/src/celeste/providers/bfl/images/config.py
@@ -9,8 +9,6 @@ class BFLImagesEndpoint(StrEnum):
     CREATE_IMAGE = "/v1/{model_id}"
 
 
-BASE_URL = "https://api.bfl.ai"
-
 # Polling Configuration
 POLLING_INTERVAL = 0.5  # seconds between polling attempts
 POLLING_TIMEOUT = 120.0  # 2 minutes timeout

--- a/src/celeste/providers/bfl/images/utils.py
+++ b/src/celeste/providers/bfl/images/utils.py
@@ -1,9 +1,9 @@
 """BFL Images API utilities."""
 
-import base64
 from typing import Any
 
 from celeste.artifacts import ImageArtifact
+from celeste.providers.bfl.utils import encode_artifact
 
 
 def encode_image(image: ImageArtifact) -> str:
@@ -11,18 +11,7 @@ def encode_image(image: ImageArtifact) -> str:
 
     BFL API accepts either a URL or base64-encoded image data.
     """
-    if image.url:
-        return image.url
-    elif image.data:
-        if isinstance(image.data, bytes):
-            return base64.b64encode(image.data).decode("utf-8")
-        return image.data
-    elif image.path:
-        with open(image.path, "rb") as f:
-            return base64.b64encode(f.read()).decode("utf-8")
-    else:
-        msg = "ImageArtifact must have url, data, or path"
-        raise ValueError(msg)
+    return encode_artifact(image)
 
 
 def add_reference_images(

--- a/src/celeste/providers/bfl/utils.py
+++ b/src/celeste/providers/bfl/utils.py
@@ -1,0 +1,13 @@
+"""Shared BFL artifact utilities."""
+
+from celeste.artifacts import Artifact
+
+
+def encode_artifact(artifact: Artifact) -> str:
+    """Return an artifact URL or raw base64 content for BFL requests."""
+    if artifact.url:
+        return artifact.url
+    return artifact.get_base64()
+
+
+__all__ = ["encode_artifact"]


### PR DESCRIPTION
## Summary

- extract BFL's asynchronous submit-and-poll flow into a shared provider client
- reuse shared artifact encoding for URL, in-memory, and path-backed artifacts
- keep the existing BFL image adapter on the shared transport

## Why

BFL image and video APIs use the same asynchronous job protocol. Keeping that protocol provider-wide avoids duplicating polling, failure handling, usage mapping, and artifact encoding in each modality.

## Impact

The image client retains its existing endpoints and polling configuration while gaining the complete documented terminal-status handling and settled usage fallback.

## Stack

Depends on #344.

## Validation

- repository pre-commit and pre-push checks
- `make ci` on the complete stack (584 tests passed)
