### PR TITLE
feat(videos): add BFL FLUX 3 provider

### DIFF
--- a/.agents/skills/celeste-python/references/public-api.md
+++ b/.agents/skills/celeste-python/references/public-api.md
@@ -34,6 +34,7 @@ Available namespace families include:
 - `celeste.audio.analyze`
 - `celeste.audio.embed`
 - `celeste.videos.generate`
+- `celeste.videos.enhance_draft`
 - `celeste.videos.analyze`
 - `celeste.videos.embed`
 - `celeste.documents.analyze`

--- a/.agents/skills/celeste-python/references/repo-map.md
+++ b/.agents/skills/celeste-python/references/repo-map.md
@@ -18,6 +18,7 @@ Use domain namespaces for normal app code:
 - `celeste.audio.analyze(...)`
 - `celeste.audio.embed(...)`
 - `celeste.videos.generate(...)`
+- `celeste.videos.enhance_draft(...)`
 - `celeste.videos.analyze(...)`
 - `celeste.videos.embed(...)`
 - `celeste.documents.analyze(...)`
@@ -49,7 +50,7 @@ Core enums live in `src/celeste/core.py`:
 - `Provider`: backend vendor or local provider.
 - `Protocol`: wire-compatible API format such as `openresponses` or `chatcompletions`.
 - `Modality`: output/client family such as text, images, videos, audio, embeddings.
-- `Operation`: action such as generate, edit, analyze, speak, transcribe, embed, upscale.
+- `Operation`: action such as generate, edit, analyze, speak, transcribe, embed, upscale, enhance.
 - `Domain`: resource the user works with, used by namespace routing.
 - `InputType`: optional media input categories.
 - `Parameter`: common parameter names shared across modalities.

--- a/src/celeste/core.py
+++ b/src/celeste/core.py
@@ -62,6 +62,7 @@ class Operation(StrEnum):
     TRANSCRIBE = "transcribe"
     EMBED = "embed"
     UPSCALE = "upscale"
+    ENHANCE = "enhance"
     SEGMENT = "segment"
 
 
@@ -134,6 +135,7 @@ DOMAIN_OPERATION_TO_MODALITY: dict[tuple[Domain, Operation], Modality] = {
     (Domain.AUDIO, Operation.TRANSCRIBE): Modality.AUDIO,
     (Domain.AUDIO, Operation.ANALYZE): Modality.TEXT,
     (Domain.VIDEOS, Operation.GENERATE): Modality.VIDEOS,
+    (Domain.VIDEOS, Operation.ENHANCE): Modality.VIDEOS,
     (Domain.VIDEOS, Operation.ANALYZE): Modality.TEXT,
     (Domain.VIDEOS, Operation.EMBED): Modality.EMBEDDINGS,
     (Domain.DOCUMENTS, Operation.ANALYZE): Modality.TEXT,

--- a/src/celeste/modalities/videos/__init__.py
+++ b/src/celeste/modalities/videos/__init__.py
@@ -1,19 +1,28 @@
 """Celeste Videos modality."""
 
 from .client import VideosClient
+from .constraints import VideoKeyframesConstraint
 from .io import (
     VideoChunk,
+    VideoDraftCache,
     VideoFinishReason,
     VideoInput,
     VideoOutput,
     VideoUsage,
 )
-from .parameters import VideoParameter, VideoParameters
+from .parameters import (
+    VideoKeyframe,
+    VideoParameter,
+    VideoParameters,
+)
 
 __all__ = [
     "VideoChunk",
+    "VideoDraftCache",
     "VideoFinishReason",
     "VideoInput",
+    "VideoKeyframe",
+    "VideoKeyframesConstraint",
     "VideoOutput",
     "VideoParameter",
     "VideoParameters",

--- a/src/celeste/modalities/videos/client.py
+++ b/src/celeste/modalities/videos/client.py
@@ -9,14 +9,21 @@ from celeste.client import ModalityClient
 from celeste.core import Modality
 from celeste.types import VideoContent
 
-from .io import VideoChunk, VideoFinishReason, VideoInput, VideoOutput, VideoUsage
+from .io import (
+    VideoChunk,
+    VideoDraftCache,
+    VideoFinishReason,
+    VideoInput,
+    VideoOutput,
+    VideoUsage,
+)
 from .parameters import VideoParameters
 
 
 class VideosClient(
     ModalityClient[VideoInput, VideoOutput, VideoParameters, VideoContent, VideoChunk]
 ):
-    """Base videos client with generate/edit operations."""
+    """Base videos client with generate, edit, and draft enhancement operations."""
 
     modality: Modality = Modality.VIDEOS
     _usage_class = VideoUsage
@@ -24,6 +31,7 @@ class VideosClient(
 
     _generate_endpoint: ClassVar[str | None] = None
     _edit_endpoint: ClassVar[str | None] = None
+    _enhance_endpoint: ClassVar[str | None] = None
 
     @classmethod
     def _output_class(cls) -> type[VideoOutput]:
@@ -54,6 +62,20 @@ class VideosClient(
         inputs = VideoInput(prompt=prompt, video=video)
         return await self._predict(inputs, endpoint=self._edit_endpoint, **parameters)
 
+    async def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Render a cached video draft at full quality."""
+        if self._enhance_endpoint is None:
+            msg = f"Model {self.model.id} does not support draft enhancement"
+            raise NotImplementedError(msg)
+        inputs = VideoInput(draft_cache=draft_cache)
+        return await self._predict(
+            inputs, endpoint=self._enhance_endpoint, **parameters
+        )
+
     @property
     def sync(self) -> "VideosSyncNamespace":
         """Sync namespace for videos operations."""
@@ -63,7 +85,7 @@ class VideosClient(
 class VideosSyncNamespace:
     """Sync namespace for videos operations.
 
-    Provides `client.sync.generate()`.
+    Provides `client.sync.generate()` and `client.sync.enhance_draft()`.
     """
 
     def __init__(self, client: VideosClient) -> None:
@@ -87,6 +109,14 @@ class VideosSyncNamespace:
         return async_to_sync(self._client._predict)(
             inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
         )
+
+    def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Blocking full-quality render of a cached video draft."""
+        return async_to_sync(self._client.enhance_draft)(draft_cache, **parameters)
 
 
 __all__ = [

--- a/src/celeste/modalities/videos/constraints.py
+++ b/src/celeste/modalities/videos/constraints.py
@@ -1,0 +1,53 @@
+"""Constraint models for the videos modality."""
+
+from typing import ClassVar
+
+from celeste.artifacts import ImageArtifact
+from celeste.constraints import Constraint
+from celeste.exceptions import ConstraintViolationError
+
+from .parameters import VideoKeyframe
+
+
+class VideoKeyframesConstraint(Constraint):
+    """Validate ordered, uniformly timed or untimed video keyframes."""
+
+    _artifact_type: ClassVar[type] = ImageArtifact
+
+    max_count: int
+    max_timestamp: float
+
+    def __call__(self, value: object) -> list[VideoKeyframe]:
+        """Validate keyframe count, types, and optional timestamps."""
+        if not isinstance(value, list) or not value:
+            msg = "Must contain at least one VideoKeyframe"
+            raise ConstraintViolationError(msg)
+        if len(value) > self.max_count:
+            msg = f"Must have at most {self.max_count} keyframes, got {len(value)}"
+            raise ConstraintViolationError(msg)
+        if not all(isinstance(item, VideoKeyframe) for item in value):
+            msg = "Every keyframe must be a VideoKeyframe"
+            raise ConstraintViolationError(msg)
+
+        keyframes = list(value)
+        timestamps = [item.timestamp for item in keyframes]
+        timed = [timestamp is not None for timestamp in timestamps]
+        if any(timed) and not all(timed):
+            msg = "Keyframes must be either all timed or all untimed"
+            raise ConstraintViolationError(msg)
+        if all(timed):
+            numeric = [
+                float(timestamp) for timestamp in timestamps if timestamp is not None
+            ]
+            if any(
+                timestamp < 0 or timestamp > self.max_timestamp for timestamp in numeric
+            ):
+                msg = f"Keyframe timestamps must be between 0 and {self.max_timestamp}"
+                raise ConstraintViolationError(msg)
+            if numeric != sorted(numeric):
+                msg = "Keyframe timestamps must be in ascending order"
+                raise ConstraintViolationError(msg)
+        return keyframes
+
+
+__all__ = ["VideoKeyframesConstraint"]

--- a/src/celeste/modalities/videos/io.py
+++ b/src/celeste/modalities/videos/io.py
@@ -2,15 +2,23 @@
 
 from pydantic import Field
 
-from celeste.artifacts import VideoArtifact
+from celeste.artifacts import Artifact, VideoArtifact
 from celeste.io import Chunk, FinishReason, Input, Output, Usage
+from celeste.mime_types import ApplicationMimeType
+
+
+class VideoDraftCache(Artifact):
+    """Opaque provider state used to render a prior video draft."""
+
+    mime_type: ApplicationMimeType | None = ApplicationMimeType.OCTET_STREAM
 
 
 class VideoInput(Input):
-    """Input for video generation and edit operations."""
+    """Input for video generation, editing, and draft enhancement."""
 
-    prompt: str
+    prompt: str | None = None
     video: VideoArtifact | None = None  # For edit operations
+    draft_cache: VideoDraftCache | None = None
 
 
 class VideoFinishReason(FinishReason):
@@ -32,6 +40,8 @@ class VideoUsage(Usage):
     reasoning_tokens: int | None = None
     cached_tokens: int | None = None
     billed_units: float | None = None
+    input_mp: float | None = None
+    output_mp: float | None = None
 
 
 class VideoOutput(Output[VideoArtifact]):
@@ -39,6 +49,12 @@ class VideoOutput(Output[VideoArtifact]):
 
     usage: VideoUsage = Field(default_factory=VideoUsage)
     finish_reason: VideoFinishReason | None = None
+
+    @property
+    def draft_cache(self) -> VideoDraftCache | None:
+        """Return reusable draft state when the provider supplied it."""
+        value = self.metadata.get("draft_cache")
+        return value if isinstance(value, VideoDraftCache) else None
 
 
 class VideoChunk(Chunk[VideoArtifact]):
@@ -50,6 +66,7 @@ class VideoChunk(Chunk[VideoArtifact]):
 
 __all__ = [
     "VideoChunk",
+    "VideoDraftCache",
     "VideoFinishReason",
     "VideoInput",
     "VideoOutput",

--- a/src/celeste/modalities/videos/models.py
+++ b/src/celeste/modalities/videos/models.py
@@ -2,6 +2,7 @@
 
 from celeste.models import Model
 
+from .providers.bfl.models import MODELS as BFL_MODELS
 from .providers.byteplus.models import MODELS as BYTEPLUS_MODELS
 from .providers.google.models import MODELS as GOOGLE_MODELS
 from .providers.openai.models import MODELS as OPENAI_MODELS
@@ -12,4 +13,5 @@ MODELS: list[Model] = [
     *GOOGLE_MODELS,
     *OPENAI_MODELS,
     *XAI_MODELS,
+    *BFL_MODELS,
 ]

--- a/src/celeste/modalities/videos/parameters.py
+++ b/src/celeste/modalities/videos/parameters.py
@@ -3,10 +3,17 @@
 from enum import StrEnum
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
-from celeste.artifacts import ImageArtifact
+from celeste.artifacts import ImageArtifact, VideoArtifact
 from celeste.parameters import Parameters
+
+
+class VideoKeyframe(BaseModel):
+    """An image pinned to an optional timestamp on a video timeline."""
+
+    image: ImageArtifact
+    timestamp: float | None = None
 
 
 class VideoParameter(StrEnum):
@@ -18,6 +25,11 @@ class VideoParameter(StrEnum):
     REFERENCE_IMAGES = "reference_images"
     FIRST_FRAME = "first_frame"
     LAST_FRAME = "last_frame"
+    KEYFRAMES = "keyframes"
+    START_VIDEO = "start_video"
+    GENERATE_AUDIO = "generate_audio"
+    SAFETY_TOLERANCE = "safety_tolerance"
+    DRAFT = "draft"
 
 
 class VideoParameters(Parameters, total=False):
@@ -27,7 +39,10 @@ class VideoParameters(Parameters, total=False):
         str, Field(description="Output video dimensions or aspect ratio.")
     ]
     resolution: Annotated[str, Field(description="Vertical resolution tier.")]
-    duration: Annotated[int, Field(description="Clip length in seconds.")]
+    duration: Annotated[
+        int | str,
+        Field(description="Clip length in seconds, or a provider-supported mode."),
+    ]
     reference_images: Annotated[
         list[ImageArtifact],
         Field(description="Additional images conditioning the video."),
@@ -38,9 +53,27 @@ class VideoParameters(Parameters, total=False):
     last_frame: Annotated[
         ImageArtifact, Field(description="Image to use as the video's last frame.")
     ]
+    keyframes: Annotated[
+        list[VideoKeyframe],
+        Field(description="Ordered images optionally pinned to timeline timestamps."),
+    ]
+    start_video: Annotated[
+        VideoArtifact,
+        Field(description="Existing video whose final frames start the generation."),
+    ]
+    generate_audio: Annotated[
+        bool, Field(description="Generate synchronized audio with the video.")
+    ]
+    safety_tolerance: Annotated[
+        int, Field(description="Provider safety tolerance level.")
+    ]
+    draft: Annotated[
+        bool, Field(description="Generate a fast preview with reusable draft state.")
+    ]
 
 
 __all__ = [
+    "VideoKeyframe",
     "VideoParameter",
     "VideoParameters",
 ]

--- a/src/celeste/modalities/videos/providers/__init__.py
+++ b/src/celeste/modalities/videos/providers/__init__.py
@@ -3,12 +3,14 @@
 from celeste.core import Provider
 
 from ..client import VideosClient
+from .bfl import BFLVideosClient
 from .byteplus import BytePlusVideosClient
 from .google import GoogleVideosClient
 from .openai import OpenAIVideosClient
 from .xai import XAIVideosClient
 
 PROVIDERS: dict[Provider, type[VideosClient]] = {
+    Provider.BFL: BFLVideosClient,
     Provider.BYTEPLUS: BytePlusVideosClient,
     Provider.GOOGLE: GoogleVideosClient,
     Provider.OPENAI: OpenAIVideosClient,

--- a/src/celeste/modalities/videos/providers/bfl/__init__.py
+++ b/src/celeste/modalities/videos/providers/bfl/__init__.py
@@ -1,0 +1,6 @@
+"""BFL provider for the videos modality."""
+
+from .client import BFLVideosClient
+from .models import MODELS
+
+__all__ = ["MODELS", "BFLVideosClient"]

--- a/src/celeste/modalities/videos/providers/bfl/client.py
+++ b/src/celeste/modalities/videos/providers/bfl/client.py
@@ -1,0 +1,65 @@
+"""BFL videos client."""
+
+from typing import Any
+
+from celeste.artifacts import VideoArtifact
+from celeste.exceptions import ValidationError
+from celeste.mime_types import VideoMimeType
+from celeste.parameters import ParameterMapper
+from celeste.providers.bfl.utils import encode_artifact
+from celeste.providers.bfl.videos import config
+from celeste.providers.bfl.videos.client import BFLVideosClient as BFLVideosMixin
+from celeste.types import VideoContent
+
+from ...client import VideosClient
+from ...io import VideoDraftCache, VideoFinishReason, VideoInput
+from .parameters import BFL_PARAMETER_MAPPERS
+
+
+class BFLVideosClient(BFLVideosMixin, VideosClient):
+    """BFL client for FLUX 3 video generation and draft enhancement."""
+
+    _generate_endpoint = config.BFLVideosEndpoint.CREATE_VIDEO
+    _enhance_endpoint = config.BFLVideosEndpoint.CREATE_VIDEO
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[VideoContent]]:
+        return BFL_PARAMETER_MAPPERS
+
+    def _init_request(self, inputs: VideoInput) -> dict[str, Any]:
+        """Build a mode-discriminated FLUX 3 request."""
+        if inputs.draft_cache is not None:
+            return {
+                "mode": "draft_enhance",
+                "draft_cache": encode_artifact(inputs.draft_cache),
+            }
+        if inputs.prompt is None:
+            msg = "FLUX 3 video generation requires a prompt"
+            raise ValidationError(msg)
+        return {"mode": "t2v", "prompt": inputs.prompt}
+
+    def _parse_content(self, response_data: dict[str, Any]) -> VideoArtifact:
+        """Parse the signed MP4 URL from a ready BFL result."""
+        result = super()._parse_content(response_data)
+        sample_url = result.get("sample")
+        if not sample_url:
+            msg = f"No video URL in {self.provider} response"
+            raise ValueError(msg)
+        return VideoArtifact(url=sample_url, mime_type=VideoMimeType.MP4)
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Lift reusable draft state into typed video output metadata."""
+        metadata = super()._build_metadata(response_data)
+        result = response_data.get("result")
+        if isinstance(result, dict):
+            draft_cache = result.get("draft_cache")
+            if isinstance(draft_cache, str) and draft_cache:
+                metadata["draft_cache"] = VideoDraftCache(url=draft_cache)
+        return metadata
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> VideoFinishReason:
+        """Map a ready BFL task to the unified completion reason."""
+        return VideoFinishReason(reason="COMPLETE")
+
+
+__all__ = ["BFLVideosClient"]

--- a/src/celeste/modalities/videos/providers/bfl/models.py
+++ b/src/celeste/modalities/videos/providers/bfl/models.py
@@ -1,0 +1,43 @@
+"""BFL models for the videos modality."""
+
+from celeste.constraints import (
+    Bool,
+    Choice,
+    ImageConstraint,
+    Range,
+    VideoConstraint,
+)
+from celeste.core import Modality, Operation, Provider
+from celeste.models import Model
+
+from ...constraints import VideoKeyframesConstraint
+from ...parameters import VideoParameter
+
+MODELS: list[Model] = [
+    Model(
+        id="flux-3-video",
+        provider=Provider.BFL,
+        display_name="FLUX 3 Video",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.ENHANCE}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(
+                options=["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+            ),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
+            VideoParameter.DURATION: Choice(options=["auto", *range(5, 21)]),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.LAST_FRAME: ImageConstraint(),
+            VideoParameter.KEYFRAMES: VideoKeyframesConstraint(
+                max_count=10,
+                max_timestamp=20,
+            ),
+            VideoParameter.START_VIDEO: VideoConstraint(),
+            VideoParameter.GENERATE_AUDIO: Bool(),
+            VideoParameter.SAFETY_TOLERANCE: Range(min=0, max=4, step=1),
+            VideoParameter.DRAFT: Bool(),
+        },
+        streaming=False,
+    )
+]
+
+__all__ = ["MODELS"]

--- a/src/celeste/modalities/videos/providers/bfl/parameters.py
+++ b/src/celeste/modalities/videos/providers/bfl/parameters.py
@@ -1,0 +1,88 @@
+"""BFL parameter mappers for the videos modality."""
+
+from celeste.parameters import ParameterMapper
+from celeste.providers.bfl.videos.parameters import (
+    AspectRatioMapper as _AspectRatioMapper,
+)
+from celeste.providers.bfl.videos.parameters import DraftMapper as _DraftMapper
+from celeste.providers.bfl.videos.parameters import DurationMapper as _DurationMapper
+from celeste.providers.bfl.videos.parameters import (
+    FirstFrameMapper as _FirstFrameMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    GenerateAudioMapper as _GenerateAudioMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    KeyframesMapper as _KeyframesMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    LastFrameMapper as _LastFrameMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    ResolutionMapper as _ResolutionMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    SafetyToleranceMapper as _SafetyToleranceMapper,
+)
+from celeste.providers.bfl.videos.parameters import (
+    StartVideoMapper as _StartVideoMapper,
+)
+from celeste.types import VideoContent
+
+from ...parameters import VideoParameter
+
+
+class AspectRatioMapper(_AspectRatioMapper):
+    name = VideoParameter.ASPECT_RATIO
+
+
+class DurationMapper(_DurationMapper):
+    name = VideoParameter.DURATION
+
+
+class ResolutionMapper(_ResolutionMapper):
+    name = VideoParameter.RESOLUTION
+
+
+class GenerateAudioMapper(_GenerateAudioMapper):
+    name = VideoParameter.GENERATE_AUDIO
+
+
+class DraftMapper(_DraftMapper):
+    name = VideoParameter.DRAFT
+
+
+class FirstFrameMapper(_FirstFrameMapper):
+    name = VideoParameter.FIRST_FRAME
+
+
+class LastFrameMapper(_LastFrameMapper):
+    name = VideoParameter.LAST_FRAME
+
+
+class KeyframesMapper(_KeyframesMapper):
+    name = VideoParameter.KEYFRAMES
+
+
+class StartVideoMapper(_StartVideoMapper):
+    name = VideoParameter.START_VIDEO
+
+
+class SafetyToleranceMapper(_SafetyToleranceMapper):
+    name = VideoParameter.SAFETY_TOLERANCE
+
+
+BFL_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
+    AspectRatioMapper(),
+    DurationMapper(),
+    ResolutionMapper(),
+    GenerateAudioMapper(),
+    DraftMapper(),
+    FirstFrameMapper(),
+    LastFrameMapper(),
+    KeyframesMapper(),
+    StartVideoMapper(),
+    SafetyToleranceMapper(),
+]
+
+__all__ = ["BFL_PARAMETER_MAPPERS"]

--- a/src/celeste/namespaces/domains.py
+++ b/src/celeste/namespaces/domains.py
@@ -24,7 +24,7 @@ from celeste.modalities.segmentation.parameters import SegmentationParameters
 from celeste.modalities.text.io import TextOutput
 from celeste.modalities.text.parameters import TextParameters
 from celeste.modalities.text.streaming import TextStream
-from celeste.modalities.videos.io import VideoOutput
+from celeste.modalities.videos.io import VideoDraftCache, VideoOutput
 from celeste.modalities.videos.parameters import VideoParameters
 from celeste.types import (
     AudioContent,
@@ -1268,6 +1268,27 @@ class SyncVideosNamespace:
         )
         return client.sync.generate(prompt, **params)
 
+    def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **params: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Blocking full-quality render of a cached video draft."""
+        client = create_client(
+            modality=Modality.VIDEOS,
+            operation=Operation.ENHANCE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return client.sync.enhance_draft(draft_cache, **params)
+
     def analyze(
         self,
         video: VideoContent,
@@ -1321,7 +1342,7 @@ class SyncVideosNamespace:
 class VideosNamespace:
     """celeste.videos.* namespace.
 
-    Provides video generation and analysis operations.
+    Provides video generation, draft enhancement, and analysis operations.
     """
 
     async def generate(
@@ -1356,6 +1377,27 @@ class VideosNamespace:
             auth=auth,
         )
         return await client.generate(prompt, **parameters)
+
+    async def enhance_draft(
+        self,
+        draft_cache: VideoDraftCache,
+        *,
+        model: str,
+        provider: Provider | None = None,
+        api_key: str | SecretStr | None = None,
+        auth: Authentication | None = None,
+        **parameters: Unpack[VideoParameters],
+    ) -> VideoOutput:
+        """Render a cached video draft at full quality."""
+        client = create_client(
+            modality=Modality.VIDEOS,
+            operation=Operation.ENHANCE,
+            model=model,
+            provider=provider,
+            api_key=api_key,
+            auth=auth,
+        )
+        return await client.enhance_draft(draft_cache, **parameters)
 
     async def analyze(
         self,

--- a/src/celeste/providers/api_references.md
+++ b/src/celeste/providers/api_references.md
@@ -29,6 +29,7 @@ This document contains the official API reference documentation links for all pr
 | **BytePlus** | Images | [Images API Reference](https://docs.byteplus.com/en/docs/ModelArk/1541523) | ✅ |
 | **BytePlus** | Videos | [Videos API Reference](https://docs.byteplus.com/en/docs/ModelArk/1520757) | ✅ |
 | **BFL** | Images | [Images API Reference](https://docs.bfl.ml/flux_2/flux2_text_to_image) | ✅ |
+| **BFL** | Videos | [FLUX 3 Video API Reference](https://docs.bfl.ai/api-reference/utility/generate-a-video-with-flux-3) | — |
 | **Topaz Labs** | Image | [Image API Reference](https://developer.topazlabs.com/reference/api-endpoints/image) | — |
 | **Topaz Labs** | Enhance | [Enhance](https://developer.topazlabs.com/reference/api-endpoints/image/enhance) | — |
 | **Topaz Labs** | Tool | [Tool](https://developer.topazlabs.com/reference/api-endpoints/image/tool) | — |
@@ -41,8 +42,8 @@ This document contains the official API reference documentation links for all pr
 
 ## Summary
 
-- **Total APIs:** 32 provider-API combinations
-- **Validated:** 21 ✅ · 11 pending (—)
+- **Total APIs:** 33 provider-API combinations
+- **Validated:** 21 ✅ · 12 pending (—)
 - **Naming convention:** Method names only (Provider column provides context)
 - **Link strategy:** Specific method/endpoint pages when available, general API reference pages otherwise
 

--- a/src/celeste/providers/bfl/client.py
+++ b/src/celeste/providers/bfl/client.py
@@ -1,0 +1,133 @@
+"""Shared BFL asynchronous API client."""
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from typing import Any, ClassVar
+
+from celeste.client import APIMixin
+from celeste.core import UsageField
+from celeste.exceptions import StreamingNotSupportedError
+from celeste.io import FinishReason
+from celeste.mime_types import ApplicationMimeType
+
+_BASE_URL = "https://api.bfl.ai"
+_TERMINAL_FAILURES = frozenset(
+    {
+        "Error",
+        "Failed",
+        "Request Moderated",
+        "Content Moderated",
+        "Task not found",
+    }
+)
+
+
+class BFLAsyncClient(APIMixin):
+    """Shared submit-and-poll implementation for BFL APIs."""
+
+    _content_fields: ClassVar[set[str]] = {"result"}
+    _default_endpoint: ClassVar[str]
+    _operation_label: ClassVar[str] = "generation"
+    _polling_interval: ClassVar[float]
+    _polling_timeout: ClassVar[float]
+
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Any,
+    ) -> dict[str, Any]:
+        """Submit a BFL job and poll its returned URL until completion."""
+        headers = {
+            **self._json_headers(extra_headers),
+            "Accept": ApplicationMimeType.JSON,
+        }
+        endpoint = (endpoint or self._default_endpoint).format(model_id=self.model.id)
+        submit_response = await self.http_client.post(
+            f"{_BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
+        self._handle_error_response(submit_response)
+        submit_data: dict[str, Any] = submit_response.json()
+        polling_url = submit_data.get("polling_url")
+        if not isinstance(polling_url, str) or not polling_url:
+            msg = f"No polling_url in {self.provider} response"
+            raise ValueError(msg)
+
+        poll_headers = self._merge_headers(
+            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            extra_headers,
+        )
+        started = time.monotonic()
+        while time.monotonic() - started < self._polling_timeout:
+            poll_response = await self.http_client.get(
+                polling_url,
+                headers=poll_headers,
+            )
+            self._handle_error_response(poll_response)
+            poll_data: dict[str, Any] = poll_response.json()
+            status = poll_data.get("status")
+            if status == "Ready":
+                return {**poll_data, "_submit_metadata": submit_data}
+            if status in _TERMINAL_FAILURES:
+                detail = poll_data.get("error") or poll_data.get("details") or status
+                msg = f"{self.provider} {self._operation_label} failed ({status}): {detail}"
+                raise ValueError(msg)
+            await asyncio.sleep(self._polling_interval)
+
+        msg = f"{self.provider} polling timed out after {self._polling_timeout} seconds"
+        raise TimeoutError(msg)
+
+    def _make_stream_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Reject SSE streaming, which BFL's asynchronous APIs do not expose."""
+        raise StreamingNotSupportedError(model_id=self.model.id)
+
+    @staticmethod
+    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
+        """Map BFL credits and megapixels to unified usage fields."""
+        return {
+            UsageField.BILLED_UNITS: _float_or_none(usage_data.get("cost")),
+            UsageField.INPUT_MP: _float_or_none(usage_data.get("input_mp")),
+            UsageField.OUTPUT_MP: _float_or_none(usage_data.get("output_mp")),
+        }
+
+    def _parse_usage(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
+        """Prefer settled poll usage and fall back to submission estimates."""
+        usage_data = dict(response_data.get("_submit_metadata", {}))
+        for field in ("cost", "input_mp", "output_mp"):
+            if response_data.get(field) is not None:
+                usage_data[field] = response_data[field]
+        return self.map_usage_fields(usage_data)
+
+    def _parse_content(self, response_data: dict[str, Any]) -> Any:
+        """Return the non-empty BFL result object."""
+        result = response_data.get("result")
+        if not result:
+            msg = "No result in response"
+            raise ValueError(msg)
+        return result
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
+        """Return an empty finish reason because BFL only exposes task status."""
+        return FinishReason(reason=None)
+
+
+def _float_or_none(value: object) -> float | None:
+    """Convert an optional numeric BFL usage value to float."""
+    return float(value) if value is not None else None
+
+
+__all__ = ["BFLAsyncClient"]

--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -1,158 +1,17 @@
 """BFL Images API client mixin."""
 
-import asyncio
-import time
-from collections.abc import AsyncIterator
-from typing import Any, ClassVar
-
-from celeste.client import APIMixin
-from celeste.core import UsageField
-from celeste.exceptions import StreamingNotSupportedError
-from celeste.io import FinishReason
-from celeste.mime_types import ApplicationMimeType
+from celeste.providers.bfl.client import BFLAsyncClient
 
 from . import config
 
 
-class BFLImagesClient(APIMixin):
-    """Mixin for BFL Images API operations.
+class BFLImagesClient(BFLAsyncClient):
+    """Mixin for BFL Images API operations."""
 
-    Provides shared implementation:
-    - _make_request() - HTTP POST with async polling pattern
-    - _parse_finish_reason() - Map BFL status to FinishReason
-
-    The BFL API uses async polling:
-    1. POST to /v1/{model_id} to submit job
-    2. Poll GET polling_url until Ready/Failed
-    3. Return final response with merged metadata
-
-    Usage:
-        class BFLImagesClient(BFLImagesMixin, ImagesClient):
-            def _parse_content(self, response_data):
-                result = response_data.get("result", {})
-                # Extract image from result["sample"]...
-    """
-
-    _content_fields: ClassVar[set[str]] = {"result"}
-
-    async def _make_request(
-        self,
-        request_body: dict[str, Any],
-        *,
-        endpoint: str | None = None,
-        extra_headers: dict[str, str] | None = None,
-        **parameters: Any,
-    ) -> dict[str, Any]:
-        """Make HTTP request with async polling for BFL image generation.
-
-        Handles the complete async polling workflow:
-        1. Submit job to /v1/{model_id}
-        2. Poll polling_url until Ready/Failed
-        3. Return response with _submit_metadata for usage parsing
-        """
-        headers = {
-            **self._json_headers(extra_headers),
-            "Accept": ApplicationMimeType.JSON,
-        }
-
-        if endpoint is None:
-            endpoint = config.BFLImagesEndpoint.CREATE_IMAGE
-        endpoint = endpoint.format(model_id=self.model.id)
-
-        # Phase 1: Submit job
-        submit_response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
-
-        self._handle_error_response(submit_response)
-        submit_data = submit_response.json()
-        polling_url = submit_data.get("polling_url")
-
-        if not polling_url:
-            msg = f"No polling_url in {self.provider} response"
-            raise ValueError(msg)
-
-        # Phase 2: Poll for completion
-        start_time = time.monotonic()
-        poll_headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
-            extra_headers,
-        )
-
-        while True:
-            elapsed = time.monotonic() - start_time
-            if elapsed >= config.POLLING_TIMEOUT:
-                msg = f"{self.provider} polling timed out after {config.POLLING_TIMEOUT} seconds"
-                raise TimeoutError(msg)
-
-            poll_response = await self.http_client.get(
-                polling_url,
-                headers=poll_headers,
-            )
-
-            self._handle_error_response(poll_response)
-            poll_data = poll_response.json()
-            status = poll_data.get("status")
-
-            if status == "Ready":
-                # Merge submit metadata into final response for usage parsing
-                return {
-                    **poll_data,
-                    "_submit_metadata": submit_data,
-                }
-            elif status in ("Error", "Failed"):
-                error_msg = poll_data.get("error", "Unknown error")
-                msg = f"{self.provider} image generation failed: {error_msg}"
-                raise ValueError(msg)
-
-            await asyncio.sleep(config.POLLING_INTERVAL)
-
-    def _make_stream_request(
-        self,
-        request_body: dict[str, Any],
-        *,
-        endpoint: str | None = None,
-        extra_headers: dict[str, str] | None = None,
-        **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """BFL Images API does not support SSE streaming in this client."""
-        raise StreamingNotSupportedError(model_id=self.model.id)
-
-    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
-        """BFL provides status but not structured finish reasons."""
-        return FinishReason(reason=None)
-
-    @staticmethod
-    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
-        """Map BFL usage fields to unified names.
-
-        Shared by client and streaming across all capabilities.
-        """
-        cost = usage_data.get("cost")
-        input_mp = usage_data.get("input_mp")
-        output_mp = usage_data.get("output_mp")
-        return {
-            UsageField.BILLED_UNITS: float(cost) if cost is not None else None,
-            UsageField.INPUT_MP: float(input_mp) if input_mp is not None else None,
-            UsageField.OUTPUT_MP: float(output_mp) if output_mp is not None else None,
-        }
-
-    def _parse_usage(
-        self, response_data: dict[str, Any]
-    ) -> dict[str, int | float | None]:
-        """Extract usage data from BFL response."""
-        submit_metadata = response_data.get("_submit_metadata", {})
-        return BFLImagesClient.map_usage_fields(submit_metadata)
-
-    def _parse_content(self, response_data: dict[str, Any]) -> Any:
-        """Parse result from response."""
-        result = response_data.get("result", {})
-        if not result:
-            msg = "No result in response"
-            raise ValueError(msg)
-        return result
+    _default_endpoint = config.BFLImagesEndpoint.CREATE_IMAGE
+    _operation_label = "image generation"
+    _polling_interval = config.POLLING_INTERVAL
+    _polling_timeout = config.POLLING_TIMEOUT
 
 
 __all__ = ["BFLImagesClient"]

--- a/src/celeste/providers/bfl/images/config.py
+++ b/src/celeste/providers/bfl/images/config.py
@@ -9,8 +9,6 @@ class BFLImagesEndpoint(StrEnum):
     CREATE_IMAGE = "/v1/{model_id}"
 
 
-BASE_URL = "https://api.bfl.ai"
-
 # Polling Configuration
 POLLING_INTERVAL = 0.5  # seconds between polling attempts
 POLLING_TIMEOUT = 120.0  # 2 minutes timeout

--- a/src/celeste/providers/bfl/images/utils.py
+++ b/src/celeste/providers/bfl/images/utils.py
@@ -1,9 +1,9 @@
 """BFL Images API utilities."""
 
-import base64
 from typing import Any
 
 from celeste.artifacts import ImageArtifact
+from celeste.providers.bfl.utils import encode_artifact
 
 
 def encode_image(image: ImageArtifact) -> str:
@@ -11,18 +11,7 @@ def encode_image(image: ImageArtifact) -> str:
 
     BFL API accepts either a URL or base64-encoded image data.
     """
-    if image.url:
-        return image.url
-    elif image.data:
-        if isinstance(image.data, bytes):
-            return base64.b64encode(image.data).decode("utf-8")
-        return image.data
-    elif image.path:
-        with open(image.path, "rb") as f:
-            return base64.b64encode(f.read()).decode("utf-8")
-    else:
-        msg = "ImageArtifact must have url, data, or path"
-        raise ValueError(msg)
+    return encode_artifact(image)
 
 
 def add_reference_images(

--- a/src/celeste/providers/bfl/utils.py
+++ b/src/celeste/providers/bfl/utils.py
@@ -1,0 +1,13 @@
+"""Shared BFL artifact utilities."""
+
+from celeste.artifacts import Artifact
+
+
+def encode_artifact(artifact: Artifact) -> str:
+    """Return an artifact URL or raw base64 content for BFL requests."""
+    if artifact.url:
+        return artifact.url
+    return artifact.get_base64()
+
+
+__all__ = ["encode_artifact"]

--- a/src/celeste/providers/bfl/videos/__init__.py
+++ b/src/celeste/providers/bfl/videos/__init__.py
@@ -1,0 +1,1 @@
+"""BFL Videos API provider package."""

--- a/src/celeste/providers/bfl/videos/client.py
+++ b/src/celeste/providers/bfl/videos/client.py
@@ -1,0 +1,17 @@
+"""BFL Videos API client mixin."""
+
+from celeste.providers.bfl.client import BFLAsyncClient
+
+from . import config
+
+
+class BFLVideosClient(BFLAsyncClient):
+    """Mixin for BFL Videos API operations."""
+
+    _default_endpoint = config.BFLVideosEndpoint.CREATE_VIDEO
+    _operation_label = "video generation"
+    _polling_interval = config.POLLING_INTERVAL
+    _polling_timeout = config.POLLING_TIMEOUT
+
+
+__all__ = ["BFLVideosClient"]

--- a/src/celeste/providers/bfl/videos/config.py
+++ b/src/celeste/providers/bfl/videos/config.py
@@ -1,0 +1,15 @@
+"""Configuration for the BFL Videos API."""
+
+from enum import StrEnum
+
+
+class BFLVideosEndpoint(StrEnum):
+    """Endpoints for the BFL Videos API."""
+
+    CREATE_VIDEO = "/v1/flux-3-video"
+
+
+POLLING_INTERVAL = 2.0
+POLLING_TIMEOUT = 300.0
+
+__all__ = ["POLLING_INTERVAL", "POLLING_TIMEOUT", "BFLVideosEndpoint"]

--- a/src/celeste/providers/bfl/videos/parameters.py
+++ b/src/celeste/providers/bfl/videos/parameters.py
@@ -1,0 +1,147 @@
+"""BFL Videos API parameter mappers."""
+
+from typing import Any
+
+from celeste.exceptions import ValidationError
+from celeste.models import Model
+from celeste.parameters import FieldMapper, ParameterMapper
+from celeste.providers.bfl.utils import encode_artifact
+
+
+class AspectRatioMapper[Content](FieldMapper[Content]):
+    """Map aspect_ratio to the BFL aspect_ratio field."""
+
+    field = "aspect_ratio"
+
+
+class DurationMapper[Content](FieldMapper[Content]):
+    """Map duration to the BFL duration field."""
+
+    field = "duration"
+
+
+class ResolutionMapper[Content](ParameterMapper[Content]):
+    """Map unified resolution tiers to BFL resolution classes."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform resolution into BFL's hd/fhd value."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is not None:
+            request["resolution"] = {"720p": "hd", "1080p": "fhd"}[validated_value]
+        return request
+
+
+class GenerateAudioMapper[Content](FieldMapper[Content]):
+    """Map generate_audio to the BFL generate_audio field."""
+
+    field = "generate_audio"
+
+
+class DraftMapper[Content](FieldMapper[Content]):
+    """Map draft to the BFL draft field."""
+
+    field = "draft"
+
+
+class FirstFrameMapper[Content](ParameterMapper[Content]):
+    """Map first_frame to the first BFL keyframe."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform first_frame into a BFL keyframes list."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        _select_media_mode(request, "i2v")
+        request["keyframes"] = [encode_artifact(validated_value)]
+        return request
+
+
+class LastFrameMapper[Content](ParameterMapper[Content]):
+    """Append last_frame to BFL keyframes."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform last_frame into the final BFL keyframe."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        keyframes = request.get("keyframes")
+        if not isinstance(keyframes, list) or not keyframes:
+            msg = "last_frame requires first_frame to be provided"
+            raise ValidationError(msg)
+        keyframes.append(encode_artifact(validated_value))
+        return request
+
+
+class KeyframesMapper[Content](ParameterMapper[Content]):
+    """Map typed keyframes to BFL image or timestamp-image values."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform VideoKeyframe values into BFL keyframes."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        if "keyframes" in request:
+            msg = "keyframes cannot be combined with first_frame or last_frame"
+            raise ValidationError(msg)
+        _select_media_mode(request, "i2v")
+
+        timed = validated_value[0].timestamp is not None
+        request["keyframes"] = [
+            [keyframe.timestamp, encode_artifact(keyframe.image)]
+            if timed
+            else encode_artifact(keyframe.image)
+            for keyframe in validated_value
+        ]
+        return request
+
+
+class StartVideoMapper[Content](ParameterMapper[Content]):
+    """Map start_video to BFL video continuation input."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Transform start_video into the BFL start_video field."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        _select_media_mode(request, "v2v")
+        request["start_video"] = encode_artifact(validated_value)
+        return request
+
+
+class SafetyToleranceMapper[Content](FieldMapper[Content]):
+    """Map safety_tolerance to the BFL field."""
+
+    field = "safety_tolerance"
+
+
+def _select_media_mode(request: dict[str, Any], mode: str) -> None:
+    """Select one mutually exclusive BFL media generation mode."""
+    current = request.get("mode")
+    if current not in {None, "t2v", mode}:
+        msg = f"{mode} inputs cannot be combined with {current} inputs"
+        raise ValidationError(msg)
+    request["mode"] = mode
+
+
+__all__ = [
+    "AspectRatioMapper",
+    "DraftMapper",
+    "DurationMapper",
+    "FirstFrameMapper",
+    "GenerateAudioMapper",
+    "KeyframesMapper",
+    "LastFrameMapper",
+    "ResolutionMapper",
+    "SafetyToleranceMapper",
+    "StartVideoMapper",
+]

--- a/tests/integration_tests/videos/test_generate.py
+++ b/tests/integration_tests/videos/test_generate.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.slow
             {"duration": 2, "resolution": "480p"},
         ),
         (Provider.XAI, "grok-imagine-video", {"duration": 2}),
+        (Provider.BFL, "flux-3-video", {"duration": 5, "resolution": "720p"}),
     ],
 )
 async def test_generate(


### PR DESCRIPTION
## Summary

- add first-class video keyframes, video continuation, and draft enhancement to the shared video modality
- extract BFL's asynchronous submit-and-poll protocol into a shared provider transport
- register the BFL `flux-3-video` model and support text-to-video, image keyframes, video continuation, synchronized audio, safety controls, draft generation, and draft enhancement
- support FLUX 3's `duration="auto"` contract and add the model to the existing video integration matrix

## Why

FLUX 3 exposes one discriminated endpoint for text, image, video-continuation, and draft-enhancement workflows. Celeste should expose those as typed video semantics rather than requiring callers to construct BFL request bodies through `extra_body`. The shared BFL transport also avoids duplicating polling, failure handling, usage mapping, and artifact encoding across image and video clients.

## Impact

Users can discover and call FLUX 3 through `celeste.videos` and `create_client`. Existing video providers remain gated by their own model operations and parameter constraints.

## Validation

- `make ci`: 584 tests passed
- focused FLUX 3 request-shape assertions passed
- authenticated existing video integration case: 1 passed, 5 deselected
- no provider unit tests added
