### PR TITLE
feat(google): register Gemini 3.7 Flash text model

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -245,9 +245,8 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=65536),
-            TextParameter.THINKING_LEVEL: Choice(
-                options=["minimal", "low", "medium", "high"]
-            ),
+            # 3.7 Flash rejects minimal with a validation error (Google model page).
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(
                 tools=[WebSearch, CodeExecution, UrlContext]
             ),

--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -237,4 +237,27 @@ MODELS: list[Model] = [
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
     ),
+    Model(
+        id="gemini-3.7-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.7 Flash",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["minimal", "low", "medium", "high"]
+            ),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
 ]


### PR DESCRIPTION
Adds gemini-3.7-flash to the Google text catalog per the Gemini API
docs (released 2026-08-13): thinking_level low|medium|high
(medium default), 64K max output tokens, built-in tools, structured
output, and full multimodal input support.