### PR TITLE
feat(xai): register Grok 4.6 text model

### DIFF
--- a/src/celeste/modalities/text/providers/xai/models.py
+++ b/src/celeste/modalities/text/providers/xai/models.py
@@ -47,6 +47,23 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="grok-4.6",
+        provider=Provider.XAI,
+        display_name="Grok 4.6",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["low", "medium", "high", "xhigh"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch, XSearch, CodeExecution]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+        },
+    ),
+    Model(
         id="grok-4.5",
         provider=Provider.XAI,
         display_name="Grok 4.5",


### PR DESCRIPTION
## Summary

Registers `grok-4.6` (released 2026-08-12) in the xAI text model catalog, mirroring the `grok-4.5` entry with the new `xhigh` reasoning effort level.

Values verified against xAI's docs ([model page](https://docs.x.ai/developers/grok-4-6), [reasoning guide](https://docs.x.ai/developers/model-capabilities/text/reasoning), [announcement](https://x.ai/news/grok-4-6)):

- `reasoning_effort`: `low | medium | high | xhigh` (high default; `xhigh` available on grok-4.6 and later) — mapped via the existing `THINKING_BUDGET` choice
- Text + image input; function calling, structured outputs, and hosted web search, X search, and code execution tools
- 500K context, knowledge cutoff 2026-02-01; no completion cap is documented, so `MAX_TOKENS` is omitted per the catalog rules

## Caveats

- Docs-verified only — no live authenticated call was made (no keys in the session environment). `streaming=True` matches every xAI sibling on the same openresponses transport but has not been proven through celeste's streaming path for this id.

## Test plan

- `make ci` green (585 unit tests)
- No new tests: catalog-only addition, covered by the existing data-driven wire-contract matrix

Replaces #348 (same commit, correctly named branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1RJzeWKHU6d6Jtrk4NcGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1RJzeWKHU6d6Jtrk4NcGc)_