### PR TITLE
feat(groq): register Qwen 3.8 27B text model

### DIFF
--- a/src/celeste/modalities/text/providers/groq/models.py
+++ b/src/celeste/modalities/text/providers/groq/models.py
@@ -1,6 +1,13 @@
 """Groq models for text modality."""
 
-from celeste.constraints import Choice, ImagesConstraint, Range, Schema, ToolSupport
+from celeste.constraints import (
+    Choice,
+    ImagesConstraint,
+    Range,
+    Schema,
+    ToolChoiceSupport,
+    ToolSupport,
+)
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
 from celeste.tools import CodeExecution, WebSearch
@@ -8,6 +15,24 @@ from celeste.tools import CodeExecution, WebSearch
 from ...parameters import TextParameter
 
 MODELS: list[Model] = [
+    Model(
+        id="qwen/qwen3.8-27b",
+        provider=Provider.GROQ,
+        display_name="Qwen 3.8 27B",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0, step=0.01),
+            Parameter.MAX_TOKENS: Range(min=1, max=16384, step=1),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["none", "default", "low", "medium", "high"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(max_count=3),
+            TextParameter.TOOLS: ToolSupport(tools=[]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+        },
+    ),
     Model(
         id="qwen/qwen3.6-27b",
         provider=Provider.GROQ,


### PR DESCRIPTION
## Summary

Registers `qwen/qwen3.8-27b` in the Groq text model catalog.

Values were verified against the official [Groq model page](https://console.groq.com/docs/model/qwen/qwen3.8-27b), [API reference](https://console.groq.com/docs/api-reference), and [tool-use matrix](https://console.groq.com/docs/tool-use/overview):

- text and image input with up to 3 images; text output
- 16,384 max output tokens and temperature range 0–2
- reasoning effort: `none | default | low | medium | high`
- JSON Schema structured output, custom tool calling, and tool choice
- streaming generation and image analysis

## Caveats

- Docs-verified only; no credentialed Groq request was made.
- Groq also documents a 131,042-token context window, 20 MB file limit, ~450+ TPS, and $0.80/$4.00 per million input/output tokens. The current Celeste `Model` schema does not store those metadata fields.

## Validation

- `make lint`
- `make test` — 584 passed
- commit and pre-push hooks — Ruff, formatting, mypy, Bandit, and coverage suite passed

No new test was added for this catalog-only registration; the existing model registry and wire-contract coverage apply.