### PR TITLE
fix(groq): include usage in streamed chat completions

### DIFF
--- a/src/celeste/providers/groq/chat/client.py
+++ b/src/celeste/providers/groq/chat/client.py
@@ -1,6 +1,6 @@
 """Groq Chat API client mixin."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from celeste.protocols.chatcompletions import ChatCompletionsClient
 
@@ -13,10 +13,26 @@ class GroqChatClient(ChatCompletionsClient):
     Inherits shared Chat Completions implementation. Only overrides:
     - _default_base_url - Groq API base URL
     - _default_endpoint - Groq uses /openai/v1/chat/completions
+    - _build_request() - Requests usage in streaming responses
     """
 
     _default_base_url: ClassVar[str] = config.BASE_URL
     _default_endpoint: ClassVar[str] = config.GroqChatEndpoint.CREATE_CHAT_COMPLETION
+
+    def _build_request(
+        self,
+        inputs: Any,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Any,
+    ) -> dict[str, Any]:
+        """Request the terminal usage chunk required for streamed billing."""
+        request_body = super()._build_request(
+            inputs, extra_body=extra_body, streaming=streaming, **parameters
+        )
+        if streaming:
+            request_body["stream_options"] = {"include_usage": True}
+        return request_body
 
 
 __all__ = ["GroqChatClient"]

--- a/tests/unit_tests/test_stream_raw_response.py
+++ b/tests/unit_tests/test_stream_raw_response.py
@@ -1,16 +1,44 @@
-"""Streaming reconstructs metadata["raw_response"] so billing reads complete usage."""
+"""Streaming requests and raw responses preserve complete billing usage."""
 
 from collections.abc import AsyncIterator
 from typing import Any
 
+from pydantic import SecretStr
+
+from celeste.auth import AuthHeader
+from celeste.core import Provider
+from celeste.modalities.text.io import TextInput
 from celeste.modalities.text.protocols.chatcompletions import ChatCompletionsTextStream
 from celeste.modalities.text.protocols.openresponses import OpenResponsesTextStream
 from celeste.modalities.text.providers.anthropic.client import AnthropicTextStream
+from celeste.modalities.text.providers.groq.client import GroqTextClient
+from celeste.models import Model
 
 
 async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
     for item in items:
         yield item
+
+
+def test_groq_streaming_request_enables_terminal_usage() -> None:
+    client = GroqTextClient(
+        model=Model(
+            id="qwen/qwen3.8-27b",
+            provider=Provider.GROQ,
+            display_name="Qwen 3.8 27B",
+        ),
+        provider=Provider.GROQ,
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+    inputs = TextInput(prompt="Hello")
+
+    unary = client._build_request(inputs)
+    streaming = client._build_request(inputs, streaming=True)
+
+    assert "stream" not in unary
+    assert "stream_options" not in unary
+    assert streaming["stream"] is True
+    assert streaming["stream_options"] == {"include_usage": True}
 
 
 async def test_anthropic_stream_assembles_raw_response_with_complete_usage() -> None:

--- a/tests/unit_tests/test_text_modality_analyze_image.py
+++ b/tests/unit_tests/test_text_modality_analyze_image.py
@@ -133,18 +133,6 @@ def test_chat_completions_init_request_includes_image_url_block(
     assert content[-1] == {"type": "text", "text": "Describe the image"}
 
 
-def test_groq_streaming_request_includes_terminal_usage() -> None:
-    client = _client(GroqTextClient, Provider.GROQ, "qwen/qwen3.8-27b")
-    inputs = TextInput(prompt="Hello")
-    unary = client._build_request(inputs)
-    streaming = client._build_request(inputs, streaming=True)
-
-    assert "stream" not in unary
-    assert "stream_options" not in unary
-    assert streaming["stream"] is True
-    assert streaming["stream_options"] == {"include_usage": True}
-
-
 def test_anthropic_init_request_includes_image_source_block() -> None:
     client = _client(AnthropicTextClient, Provider.ANTHROPIC, "claude-sonnet-4-5")
 

--- a/tests/unit_tests/test_text_modality_analyze_image.py
+++ b/tests/unit_tests/test_text_modality_analyze_image.py
@@ -133,6 +133,18 @@ def test_chat_completions_init_request_includes_image_url_block(
     assert content[-1] == {"type": "text", "text": "Describe the image"}
 
 
+def test_groq_streaming_request_includes_terminal_usage() -> None:
+    client = _client(GroqTextClient, Provider.GROQ, "qwen/qwen3.8-27b")
+    inputs = TextInput(prompt="Hello")
+    unary = client._build_request(inputs)
+    streaming = client._build_request(inputs, streaming=True)
+
+    assert "stream" not in unary
+    assert "stream_options" not in unary
+    assert streaming["stream"] is True
+    assert streaming["stream_options"] == {"include_usage": True}
+
+
 def test_anthropic_init_request_includes_image_source_block() -> None:
     client = _client(AnthropicTextClient, Provider.ANTHROPIC, "claude-sonnet-4-5")
 


### PR DESCRIPTION
## Summary

- request Groq's terminal usage chunk on streamed Chat Completions with `stream_options.include_usage`
- leave unary requests unchanged
- cover both request shapes with a focused unit test

## Why

Groq streams only include complete token usage when the request opts into the terminal usage frame. Without it, Celeste cannot populate complete usage data for streamed responses.

The override stays in Groq's provider client rather than the shared Chat Completions protocol, since support for this option is provider-specific.

## Validation

- `make ci` — Ruff, formatting, mypy, Bandit, coverage, and **585 tests passed**
- focused request/stream tests — **14 passed**
- live `qwen/qwen3.8-27b` stream with `thinking_budget="none"` returned `OK`, typed **17 input / 2 output tokens**, and retained the original usage payload in `metadata.raw_response`

Official contract: [Groq Chat Completions API reference](https://console.groq.com/docs/api-reference)

Follow-up to #350; no model-catalog or shared-protocol changes are included.
