### PR TITLE
chore: remove OpenSpec remnants

### DIFF
--- a/.agents/skills/celeste-python/SKILL.md
+++ b/.agents/skills/celeste-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: celeste-python
-description: Use whenever writing, modifying, reviewing, or debugging code involving Celeste, celeste-ai, celeste-python, import celeste, src/celeste, or withceleste app integrations. This includes providers, modalities, models, artifacts, MIME types, parameters, tools, multimodal messages, streaming, structured outputs, protocol/base URL support, OpenSpec changes, and tests. Always use this skill before inventing Celeste types, registries, model catalogs, provider abstractions, request/response shapes, or syntax.
+description: Use whenever writing, modifying, reviewing, or debugging code involving Celeste, celeste-ai, celeste-python, import celeste, src/celeste, or withceleste app integrations. This includes providers, modalities, models, artifacts, MIME types, parameters, tools, multimodal messages, streaming, structured outputs, protocol/base URL support, and tests. Always use this skill before inventing Celeste types, registries, model catalogs, provider abstractions, request/response shapes, or syntax.
 compatibility: Local celeste-python repository skill; no network required.
 ---
 
@@ -28,9 +28,8 @@ When sources disagree, follow this order:
 1. Current source code in `src/celeste/`
 2. Current tests and templates for existing behavior
 3. README examples and public exports
-4. Active OpenSpec artifacts for intended new behavior and acceptance criteria
-5. Notes such as `common_agent_mistakes.md`
-6. Model memory
+4. Notes such as `common_agent_mistakes.md`
+5. Model memory
 
 Treat `common_agent_mistakes.md` as advisory. Verify every warning against current code and the task context.
 

--- a/.agents/skills/celeste-python/references/repo-map.md
+++ b/.agents/skills/celeste-python/references/repo-map.md
@@ -213,8 +213,7 @@ When sources disagree, follow this order:
 1. Current source code in `src/celeste/`.
 2. Current tests and templates for existing behavior.
 3. README examples and public exports.
-4. OpenSpec artifacts for the active change's intended behavior and acceptance criteria.
-5. Notes such as `common_agent_mistakes.md`.
-6. Model memory.
+4. Notes such as `common_agent_mistakes.md`.
+5. Model memory.
 
 `common_agent_mistakes.md` is advisory. Keep useful warnings, but verify every rule against current code and task context.

--- a/.gitignore
+++ b/.gitignore
@@ -161,9 +161,6 @@ bandit-report.json
 scripts/
 assets/
 
-# openspec — local-only authoring scratchpad
-openspec/
-
 # Agent / IDE tooling
 .agents/
 .claude/


### PR DESCRIPTION
## Summary

- remove the obsolete local OpenSpec scratchpad ignore rule
- remove OpenSpec from the tracked Celeste coding skill and its source-of-truth hierarchy
- preserve the two real telemetry follow-ups in #352 and #353

The OpenSpec artifact tree and Codex, Claude, and Cursor integrations were local-only ignored files, so they were removed locally and do not appear in this diff.

## Validation

- pre-commit hooks passed
- pre-push test suite with coverage passed
- zero tracked OpenSpec mentions remain
