### PR TITLE
feat(openai): register chat-latest text model

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -152,6 +152,22 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="chat-latest",
+        provider=Provider.OPENAI,
+        display_name="Chat Latest",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="gpt-5.1",
         provider=Provider.OPENAI,
         display_name="GPT-5.1",


### PR DESCRIPTION
## Summary

- Register the current OpenAI `chat-latest` alias in the text-model catalog.
- Advertise its documented 128K max output, streaming, function calling, structured output, web search, image input, and Responses API-compatible behavior.

## Evidence

- https://developers.openai.com/api/docs/models/chat-latest
- https://developers.openai.com/api/docs/changelog

OpenAI documents `chat-latest` as the regularly updated ChatGPT Instant alias and lists it for the Responses API.

## Validation

- 585 unit tests passed.
- Ruff lint and format checks passed.
- Mypy passed for source and tests.
- Bandit passed.
- Repository commit and pre-push hooks passed, including coverage.