### PR TITLE
fix(openai): support transparent GPT Image 2 backgrounds

### DIFF
--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -92,7 +92,9 @@ MODELS: list[Model] = [
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
-            ImageParameter.BACKGROUND: Choice(options=["opaque", "auto"]),
+            ImageParameter.BACKGROUND: Choice(
+                options=["transparent", "opaque", "auto"]
+            ),
             ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },


### PR DESCRIPTION
## Summary

- add `transparent` to the GPT Image 2 background constraint
- expose the Aug 20, 2026 preview capability through the existing OpenAI background mapper

Change families: capabilities and limits; parameters.

## Official evidence

OpenAI documents transparent backgrounds for `gpt-image-2` and `gpt-image-2-2026-04-21` on `/v1/images/generations`, `/v1/images/edits`, and the Responses image-generation tool. Requests use `background=transparent` with PNG or WebP output.

- https://developers.openai.com/api/docs/changelog
- https://developers.openai.com/api/docs/guides/image-generation
- https://developers.openai.com/api/reference/resources/images/methods/generate
- https://developers.openai.com/api/reference/resources/images/methods/edit

Celeste already maps `background` and constrains output formats; only the GPT Image 2 model constraint was stale. No pricing or Chat change is required.

## Validation

- `uv run pytest tests/unit_tests/test_models.py -q`: 11 passed
- `make ci`: lint, format, mypy, Bandit, and 585 unit tests passed
- pre-commit and pre-push hooks passed

No dependent PRs.