### PR TITLE
fix(google): complete image operation support

### DIFF
--- a/src/celeste/modalities/images/parameters.py
+++ b/src/celeste/modalities/images/parameters.py
@@ -16,6 +16,7 @@ class ImageParameter(StrEnum):
     NUM_IMAGES = "num_images"
     PARTIAL_IMAGES = "partial_images"
     QUALITY = "quality"
+    UPSCALE_FACTOR = "upscale_factor"
     WATERMARK = "watermark"
     REFERENCE_IMAGES = "reference_images"
     PROMPT_UPSAMPLING = "prompt_upsampling"
@@ -59,6 +60,9 @@ class ImageParameters(Parameters, total=False):
         int, Field(description="Number of progressive partial outputs to stream.")
     ]
     quality: Annotated[str, Field(description="Output quality tier.")]
+    upscale_factor: Annotated[
+        str, Field(description="Scale multiplier for image upscaling.")
+    ]
     watermark: Annotated[bool, Field(description="Embed a watermark in the output.")]
     reference_images: Annotated[
         list[ImageArtifact],

--- a/src/celeste/modalities/images/providers/google/client.py
+++ b/src/celeste/modalities/images/providers/google/client.py
@@ -9,17 +9,23 @@ from celeste.types import ImageContent
 from ...client import ImagesClient
 from ...io import ImageFinishReason, ImageInput
 from ...parameters import ImageParameters
-from .imagen import GoogleImagenImagesClient
+from .imagen import GoogleImagenImagesClient, GoogleImagenUpscaleImagesClient
 from .interactions import GoogleInteractionsImagesClient
-from .models import GOOGLE_GEMINI_MODELS, GOOGLE_IMAGEN_MODELS
+from .models import (
+    GOOGLE_GEMINI_MODELS,
+    GOOGLE_IMAGEN_MODELS,
+    GOOGLE_IMAGEN_UPSCALE_MODELS,
+)
 from .parameters import (
     GOOGLE_IMAGEN_PARAMETER_MAPPERS,
+    GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS,
     GOOGLE_INTERACTIONS_PARAMETER_MAPPERS,
     GOOGLE_VERTEX_PARAMETER_MAPPERS,
 )
 from .vertex import GoogleVertexImagesClient
 
 _IMAGEN_MODEL_IDS = frozenset(m.id for m in GOOGLE_IMAGEN_MODELS)
+_IMAGEN_UPSCALE_MODEL_IDS = frozenset(m.id for m in GOOGLE_IMAGEN_UPSCALE_MODELS)
 _GEMINI_MODEL_IDS = frozenset(m.id for m in GOOGLE_GEMINI_MODELS)
 
 
@@ -28,6 +34,7 @@ class GoogleImagesClient(ImagesClient):
 
     _strategy: (
         GoogleImagenImagesClient
+        | GoogleImagenUpscaleImagesClient
         | GoogleInteractionsImagesClient
         | GoogleVertexImagesClient
         | None
@@ -38,7 +45,9 @@ class GoogleImagesClient(ImagesClient):
         super().model_post_init(__context)
 
         StrategyClass: type[ImagesClient]
-        if self.model.id in _IMAGEN_MODEL_IDS:
+        if self.model.id in _IMAGEN_UPSCALE_MODEL_IDS:
+            StrategyClass = GoogleImagenUpscaleImagesClient
+        elif self.model.id in _IMAGEN_MODEL_IDS:
             StrategyClass = GoogleImagenImagesClient
         elif self.model.id in _GEMINI_MODEL_IDS:
             StrategyClass = (
@@ -72,6 +81,7 @@ class GoogleImagesClient(ImagesClient):
             *GOOGLE_INTERACTIONS_PARAMETER_MAPPERS,
             *GOOGLE_VERTEX_PARAMETER_MAPPERS,
             *GOOGLE_IMAGEN_PARAMETER_MAPPERS,
+            *GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS,
         ]
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:

--- a/src/celeste/modalities/images/providers/google/imagen.py
+++ b/src/celeste/modalities/images/providers/google/imagen.py
@@ -5,6 +5,8 @@ from typing import Any, Unpack
 from celeste.artifacts import ImageArtifact
 from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
+from celeste.providers.google.imagen import config
 from celeste.providers.google.imagen.client import (
     GoogleImagenClient as GoogleImagenMixin,
 )
@@ -13,7 +15,10 @@ from celeste.types import ImageContent
 from ...client import ImagesClient
 from ...io import ImageInput
 from ...parameters import ImageParameters
-from .parameters import GOOGLE_IMAGEN_PARAMETER_MAPPERS
+from .parameters import (
+    GOOGLE_IMAGEN_PARAMETER_MAPPERS,
+    GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS,
+)
 
 
 class GoogleImagenImagesClient(GoogleImagenMixin, ImagesClient):
@@ -39,9 +44,9 @@ class GoogleImagenImagesClient(GoogleImagenMixin, ImagesClient):
 
         images: list[ImageArtifact] = []
         for prediction in predictions:
-            base64_data = prediction.get("bytesBase64Encoded")
-            if not base64_data:
+            if not self._is_image_prediction(prediction):
                 continue
+            base64_data = prediction.get("bytesBase64Encoded")
             mime_type = ImageMimeType(prediction.get("mimeType", "image/png"))
             images.append(ImageArtifact(data=base64_data, mime_type=mime_type))
 
@@ -68,4 +73,52 @@ class GoogleImagenImagesClient(GoogleImagenMixin, ImagesClient):
         return content
 
 
-__all__ = ["GoogleImagenImagesClient"]
+class GoogleImagenUpscaleImagesClient(GoogleImagenImagesClient):
+    """Imagen 4 upscaling client on Vertex AI."""
+
+    _upscale_endpoint = config.GoogleImagenEndpoint.CREATE_IMAGE
+
+    def model_post_init(self, __context: object) -> None:
+        """Require the Cloud-only regional Vertex AI serving route."""
+        super().model_post_init(__context)
+        if not isinstance(self.auth, GoogleADC):
+            raise ValueError("Imagen 4 upscaling requires GoogleADC authentication")
+        if self.auth.location == "global":
+            raise ValueError(
+                "Imagen 4 upscaling requires a regional GoogleADC location"
+            )
+
+    @classmethod
+    def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
+        return GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS
+
+    def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
+        """Build an Imagen upscale Predict request."""
+        image = inputs.image
+        if image is None:
+            raise ValueError("Imagen 4 upscaling requires an input image")
+
+        if image.url:
+            if not image.url.startswith("gs://"):
+                raise ValueError("Imagen 4 upscaling image URLs must use gs://")
+            image_data = {"gcsUri": image.url}
+        else:
+            image_data = {"bytesBase64Encoded": image.get_base64()}
+
+        return {
+            "instances": [{"prompt": "Upscale the image", "image": image_data}],
+            "parameters": {"mode": "upscale"},
+        }
+
+    def _build_request(
+        self,
+        inputs: ImageInput,
+        **parameters: Unpack[ImageParameters],
+    ) -> dict[str, Any]:
+        """Require the provider's mandatory upscale factor."""
+        if parameters.get("upscale_factor") is None:
+            raise ValueError("Imagen 4 upscaling requires upscale_factor")
+        return super()._build_request(inputs, **parameters)
+
+
+__all__ = ["GoogleImagenImagesClient", "GoogleImagenUpscaleImagesClient"]

--- a/src/celeste/modalities/images/providers/google/interactions.py
+++ b/src/celeste/modalities/images/providers/google/interactions.py
@@ -27,6 +27,17 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
     def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
         return GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Retain executed search count without retaining queries or results."""
+        metadata = super()._build_metadata(response_data)
+        if "steps" in response_data:
+            metadata["raw_response"]["grounding_query_count"] = sum(
+                len(step.get("arguments", {}).get("queries", []))
+                for step in response_data["steps"]
+                if step.get("type") == "google_search_call"
+            )
+        return metadata
+
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
         """Initialize request for Gemini image generation/edit."""
         parts: list[dict[str, Any]] = []
@@ -53,7 +64,7 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
             for step in steps
             if step.get("type") == "model_output"
             for part in step.get("content", [])
-            if part.get("type") == "image"
+            if part.get("type") == "image" and (part.get("data") or part.get("uri"))
         )
         return {**usage, UsageField.NUM_IMAGES: num_images}
 
@@ -72,10 +83,14 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
                 if part.get("type") != "image":
                     continue
                 base64_data = part.get("data")
-                if not base64_data:
+                uri = part.get("uri")
+                if not base64_data and not uri:
                     continue
-                mime_type = ImageMimeType(part.get("mime_type", "image/png"))
-                artifacts.append(ImageArtifact(data=base64_data, mime_type=mime_type))
+                mime_value = part.get("mime_type")
+                mime_type = ImageMimeType(mime_value) if mime_value else None
+                artifacts.append(
+                    ImageArtifact(data=base64_data, url=uri, mime_type=mime_type)
+                )
 
         if not artifacts:
             return ImageArtifact()

--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -49,6 +49,19 @@ GOOGLE_IMAGEN_MODELS: list[Model] = [
     ),
 ]
 
+# Vertex AI Imagen upscale models (GoogleADC only)
+GOOGLE_IMAGEN_UPSCALE_MODELS: list[Model] = [
+    Model(
+        id="imagen-4.0-upscale-preview",
+        provider=Provider.GOOGLE,
+        display_name="Imagen 4 Upscale",
+        operations={Modality.IMAGES: {Operation.UPSCALE}},
+        parameter_constraints={
+            ImageParameter.UPSCALE_FACTOR: Choice(options=["x2", "x3", "x4"]),
+        },
+    ),
+]
+
 # Gemini API models (contents[].parts[] → candidates[])
 GOOGLE_GEMINI_MODELS: list[Model] = [
     Model(
@@ -136,12 +149,16 @@ GOOGLE_GEMINI_MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Choice(
                 options=[
                     "1:1",
+                    "1:4",
+                    "1:8",
                     "2:3",
                     "3:2",
                     "3:4",
+                    "4:1",
                     "4:3",
                     "4:5",
                     "5:4",
+                    "8:1",
                     "9:16",
                     "16:9",
                     "21:9",
@@ -157,11 +174,13 @@ GOOGLE_GEMINI_MODELS: list[Model] = [
 # Unified model list for registration
 MODELS: list[Model] = [
     *GOOGLE_IMAGEN_MODELS,
+    *GOOGLE_IMAGEN_UPSCALE_MODELS,
     *GOOGLE_GEMINI_MODELS,
 ]
 
 __all__ = [
     "GOOGLE_GEMINI_MODELS",
     "GOOGLE_IMAGEN_MODELS",
+    "GOOGLE_IMAGEN_UPSCALE_MODELS",
     "MODELS",
 ]

--- a/src/celeste/modalities/images/providers/google/parameters.py
+++ b/src/celeste/modalities/images/providers/google/parameters.py
@@ -22,6 +22,9 @@ from celeste.providers.google.imagen.parameters import (
 from celeste.providers.google.imagen.parameters import (
     SampleCountMapper as _ImagenSampleCountMapper,
 )
+from celeste.providers.google.imagen.parameters import (
+    UpscaleFactorMapper as _ImagenUpscaleFactorMapper,
+)
 from celeste.providers.google.interactions.parameters import (
     AspectRatioMapper as _InteractionsAspectRatioMapper,
 )
@@ -61,6 +64,17 @@ GOOGLE_IMAGEN_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     ImagenAspectRatioMapper(),
     ImagenQualityMapper(),
     ImagenNumImagesMapper(),
+]
+
+
+class ImagenUpscaleFactorMapper(_ImagenUpscaleFactorMapper):
+    """Map upscale_factor to Imagen parameters.upscaleConfig.upscaleFactor."""
+
+    name = ImageParameter.UPSCALE_FACTOR
+
+
+GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
+    ImagenUpscaleFactorMapper(),
 ]
 
 
@@ -130,6 +144,7 @@ GOOGLE_INTERACTIONS_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
 
 __all__ = [
     "GOOGLE_IMAGEN_PARAMETER_MAPPERS",
+    "GOOGLE_IMAGEN_UPSCALE_PARAMETER_MAPPERS",
     "GOOGLE_INTERACTIONS_PARAMETER_MAPPERS",
     "GOOGLE_VERTEX_PARAMETER_MAPPERS",
 ]

--- a/src/celeste/modalities/images/providers/google/vertex.py
+++ b/src/celeste/modalities/images/providers/google/vertex.py
@@ -6,6 +6,7 @@ from celeste.artifacts import ImageArtifact
 from celeste.core import UsageField
 from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
 from celeste.providers.google.generate_content import config
 from celeste.providers.google.generate_content.client import (
     GoogleGenerateContentClient as GoogleGenerateContentMixin,
@@ -17,15 +18,49 @@ from ...client import ImagesClient
 from ...io import ImageFinishReason, ImageInput
 from .parameters import GOOGLE_VERTEX_PARAMETER_MAPPERS
 
+_GLOBAL_ONLY_MODEL_IDS = frozenset(
+    {
+        "gemini-3-pro-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-lite-image",
+    }
+)
+
 
 class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
     """Google images client (Vertex / GenerateContent)."""
 
     _edit_endpoint = config.GoogleGenerateContentEndpoint.GENERATE_CONTENT
 
+    def model_post_init(self, __context: object) -> None:
+        """Enforce model-specific Vertex AI location availability."""
+        super().model_post_init(__context)
+        if (
+            self.model.id in _GLOBAL_ONLY_MODEL_IDS
+            and isinstance(self.auth, GoogleADC)
+            and self.auth.location != "global"
+        ):
+            raise ValueError(
+                f"{self.model.id} is only available in the global Vertex AI location"
+            )
+
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
         return GOOGLE_VERTEX_PARAMETER_MAPPERS
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Preserve billing metadata without retaining generated image content."""
+        metadata = super()._build_metadata(response_data)
+        web_query_count = 0
+        image_query_count = 0
+        for candidate in response_data.get("candidates", []):
+            grounding_metadata = candidate.get("groundingMetadata", {})
+            web_query_count += len(grounding_metadata.get("webSearchQueries") or [])
+            image_query_count += len(grounding_metadata.get("imageSearchQueries") or [])
+        if web_query_count or image_query_count:
+            metadata["raw_response"]["grounding_web_query_count"] = web_query_count
+            metadata["raw_response"]["grounding_image_query_count"] = image_query_count
+        return metadata
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
         """Initialize request for Gemini image generation/edit."""
@@ -51,13 +86,21 @@ class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
         """Parse usage from response."""
         usage = super()._parse_usage(response_data)
         candidates = response_data.get("candidates", [])
-        return {**usage, UsageField.NUM_IMAGES: len(candidates)}
+        num_images = sum(
+            1
+            for candidate in candidates
+            for part in candidate.get("content", {}).get("parts", [])
+            if not part.get("thought") and part.get("inlineData", {}).get("data")
+        )
+        return {**usage, UsageField.NUM_IMAGES: num_images}
 
     def _parse_content(
         self,
         response_data: dict[str, Any],
     ) -> ImageContent:
         """Parse image artifacts from Gemini candidates."""
+        if not response_data.get("candidates") and "promptFeedback" in response_data:
+            return ImageArtifact()
         candidates = super()._parse_content(response_data)
         artifacts: list[ImageArtifact] = []
 
@@ -84,8 +127,17 @@ class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
         """Parse finish reason from response."""
         finish_reason = super()._parse_finish_reason(response_data)
         candidates = response_data.get("candidates", [])
-        finish_message = candidates[0].get("finishMessage") if candidates else None
-        return ImageFinishReason(reason=finish_reason.reason, message=finish_message)
+        if candidates:
+            finish_message = candidates[0].get("finishMessage")
+            return ImageFinishReason(
+                reason=finish_reason.reason, message=finish_message
+            )
+
+        prompt_feedback = response_data.get("promptFeedback", {})
+        return ImageFinishReason(
+            reason=prompt_feedback.get("blockReason"),
+            message=prompt_feedback.get("blockReasonMessage"),
+        )
 
 
 __all__ = ["GoogleVertexImagesClient"]

--- a/src/celeste/providers/google/imagen/client.py
+++ b/src/celeste/providers/google/imagen/client.py
@@ -89,7 +89,21 @@ class GoogleImagenClient(APIMixin):
         raise StreamingNotSupportedError(model_id=self.model.id)
 
     @staticmethod
-    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
+    def _is_image_prediction(prediction: dict[str, Any]) -> bool:
+        """Return whether a prediction contains a generated image artifact."""
+        return bool(prediction.get("bytesBase64Encoded"))
+
+    @classmethod
+    def _count_image_predictions(cls, predictions: list[dict[str, Any]]) -> int:
+        """Count successful images, excluding RAI-filtered predictions."""
+        return sum(
+            1 for prediction in predictions if cls._is_image_prediction(prediction)
+        )
+
+    @classmethod
+    def map_usage_fields(
+        cls, usage_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
         """Map Google Imagen usage fields to unified names.
 
         Shared by client and streaming across all capabilities.
@@ -97,7 +111,7 @@ class GoogleImagenClient(APIMixin):
         """
         predictions = usage_data.get("predictions", [])
         return {
-            UsageField.NUM_IMAGES: len(predictions),
+            UsageField.NUM_IMAGES: cls._count_image_predictions(predictions),
         }
 
     def _parse_usage(
@@ -106,6 +120,14 @@ class GoogleImagenClient(APIMixin):
         """Extract usage data from Imagen API response."""
         predictions = response_data.get("predictions", [])
         return GoogleImagenClient.map_usage_fields({"predictions": predictions})
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Retain successful output count without retaining image payloads."""
+        metadata = super()._build_metadata(response_data)
+        metadata["raw_response"]["num_images"] = self._count_image_predictions(
+            response_data.get("predictions", [])
+        )
+        return metadata
 
     def _parse_content(self, response_data: dict[str, Any]) -> Any:
         """Parse predictions from response.

--- a/src/celeste/providers/google/imagen/parameters.py
+++ b/src/celeste/providers/google/imagen/parameters.py
@@ -61,8 +61,29 @@ class ImageSizeMapper(ParameterMapper[ImageContent]):
         return request
 
 
+class UpscaleFactorMapper(ParameterMapper[ImageContent]):
+    """Map upscale_factor to Google Imagen parameters.upscaleConfig."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform upscale_factor into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        request.setdefault("parameters", {}).setdefault("upscaleConfig", {})[
+            "upscaleFactor"
+        ] = validated_value
+        return request
+
+
 __all__ = [
     "AspectRatioMapper",
     "ImageSizeMapper",
     "SampleCountMapper",
+    "UpscaleFactorMapper",
 ]

--- a/tests/unit_tests/test_google_image_models.py
+++ b/tests/unit_tests/test_google_image_models.py
@@ -1,0 +1,32 @@
+"""Unit tests for Google image model metadata."""
+
+from celeste.constraints import Choice
+from celeste.modalities.images.parameters import ImageParameter
+from celeste.modalities.images.providers.google.models import GOOGLE_GEMINI_MODELS
+
+
+def test_flash_lite_supports_all_documented_aspect_ratios() -> None:
+    model = next(
+        model
+        for model in GOOGLE_GEMINI_MODELS
+        if model.id == "gemini-3.1-flash-lite-image"
+    )
+    constraint = model.parameter_constraints[ImageParameter.ASPECT_RATIO]
+
+    assert isinstance(constraint, Choice)
+    assert constraint.options == [
+        "1:1",
+        "1:4",
+        "1:8",
+        "2:3",
+        "3:2",
+        "3:4",
+        "4:1",
+        "4:3",
+        "4:5",
+        "5:4",
+        "8:1",
+        "9:16",
+        "16:9",
+        "21:9",
+    ]

--- a/tests/unit_tests/test_google_imagen_upscale.py
+++ b/tests/unit_tests/test_google_imagen_upscale.py
@@ -1,0 +1,143 @@
+"""Unit tests for Google Imagen 4 upscaling."""
+
+import pytest
+from pydantic import SecretStr
+
+from celeste.artifacts import ImageArtifact
+from celeste.auth import AuthHeader
+from celeste.constraints import Choice
+from celeste.core import Modality, Operation, Provider
+from celeste.mime_types import ImageMimeType
+from celeste.modalities.images.io import ImageInput
+from celeste.modalities.images.parameters import ImageParameter
+from celeste.modalities.images.providers.google.client import GoogleImagesClient
+from celeste.modalities.images.providers.google.imagen import (
+    GoogleImagenUpscaleImagesClient,
+)
+from celeste.modalities.images.providers.google.models import (
+    GOOGLE_IMAGEN_MODELS,
+    GOOGLE_IMAGEN_UPSCALE_MODELS,
+)
+from celeste.models import Model
+from celeste.providers.google.auth import GoogleADC
+from celeste.providers.google.imagen import config
+
+
+def _model() -> Model:
+    return GOOGLE_IMAGEN_UPSCALE_MODELS[0]
+
+
+def _client(model: Model | None = None) -> GoogleImagesClient:
+    return GoogleImagesClient(
+        model=model or _model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p", location="us-central1"),
+    )
+
+
+def _api_key_auth() -> AuthHeader:
+    return AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix="")
+
+
+def test_upscale_model_catalog_and_vertex_routing() -> None:
+    model = _model()
+    factor = model.parameter_constraints[ImageParameter.UPSCALE_FACTOR]
+
+    assert model.id == "imagen-4.0-upscale-preview"
+    assert model.operations == {Modality.IMAGES: {Operation.UPSCALE}}
+    assert isinstance(factor, Choice)
+    assert factor.options == ["x2", "x3", "x4"]
+
+    client = _client()
+    assert isinstance(client._strategy, GoogleImagenUpscaleImagesClient)
+    assert client._upscale_endpoint == config.GoogleImagenEndpoint.CREATE_IMAGE
+    assert client._strategy._build_url(client._upscale_endpoint) == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/"
+        "us-central1/publishers/google/models/imagen-4.0-upscale-preview:predict"
+    )
+
+
+def test_upscale_requires_regional_google_adc() -> None:
+    with pytest.raises(ValueError, match="GoogleADC"):
+        GoogleImagesClient(
+            model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+        )
+
+    with pytest.raises(ValueError, match="regional"):
+        GoogleImagesClient(
+            model=_model(),
+            provider=Provider.GOOGLE,
+            auth=GoogleADC(project_id="p"),
+        )
+
+
+def test_upscale_builds_inline_predict_request() -> None:
+    request = _client()._build_request(
+        ImageInput(image=ImageArtifact(data=b"abc", mime_type=ImageMimeType.PNG)),
+        upscale_factor="x3",
+    )
+
+    assert request == {
+        "instances": [
+            {
+                "prompt": "Upscale the image",
+                "image": {"bytesBase64Encoded": "YWJj"},
+            }
+        ],
+        "parameters": {
+            "mode": "upscale",
+            "upscaleConfig": {"upscaleFactor": "x3"},
+        },
+    }
+
+
+def test_upscale_builds_gcs_predict_request() -> None:
+    request = _client()._build_request(
+        ImageInput(image=ImageArtifact(url="gs://bucket/input.jpg")),
+        upscale_factor="x2",
+    )
+
+    assert request["instances"][0]["image"] == {"gcsUri": "gs://bucket/input.jpg"}
+
+
+def test_upscale_requires_factor_and_rejects_http_input_url() -> None:
+    client = _client()
+    with pytest.raises(ValueError, match="upscale_factor"):
+        client._build_request(ImageInput(image=ImageArtifact(data=b"abc")))
+
+    with pytest.raises(ValueError, match="gs://"):
+        client._build_request(
+            ImageInput(image=ImageArtifact(url="https://example.com/input.png")),
+            upscale_factor="x2",
+        )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [*GOOGLE_IMAGEN_MODELS, *GOOGLE_IMAGEN_UPSCALE_MODELS],
+    ids=lambda model: model.id,
+)
+def test_imagen_metadata_retains_only_successful_image_count(model: Model) -> None:
+    client = _client(model)
+    response_data = {
+        "deployedModelId": "served-model",
+        "predictions": [
+            {"mimeType": "image/png", "bytesBase64Encoded": "YWJj"},
+            {"mimeType": "image/jpeg", "bytesBase64Encoded": "ZGVm"},
+            {"raiFilteredReason": "Blocked by safety policy."},
+        ],
+    }
+
+    metadata = client._build_metadata(response_data)
+
+    assert metadata["raw_response"] == {
+        "deployedModelId": "served-model",
+        "num_images": 2,
+    }
+    assert client._parse_usage(response_data)["num_images"] == 2
+
+    artifacts = client._parse_content(response_data)
+    assert isinstance(artifacts, list)
+    assert len(artifacts) == 2
+    assert artifacts[0].data == b"abc"
+    assert artifacts[1].data == b"def"

--- a/tests/unit_tests/test_google_images_interactions.py
+++ b/tests/unit_tests/test_google_images_interactions.py
@@ -1,5 +1,6 @@
 """Unit tests for Google images provider Interactions/Vertex dispatch and wire shape."""
 
+import pytest
 from pydantic import SecretStr
 
 from celeste import Model
@@ -16,9 +17,9 @@ from celeste.modalities.images.providers.google.vertex import GoogleVertexImages
 from celeste.providers.google.auth import GoogleADC
 
 
-def _model() -> Model:
+def _model(model_id: str = "gemini-3.1-flash-image") -> Model:
     return Model(
-        id="gemini-3.1-flash-image",
+        id=model_id,
         provider=Provider.GOOGLE,
         display_name="Nano Banana 2",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
@@ -45,6 +46,43 @@ def test_google_adc_auth_dispatches_to_vertex_strategy() -> None:
     assert isinstance(client._strategy, GoogleVertexImagesClient)
     assert client._generate_endpoint == client._strategy._generate_endpoint
     assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-3-pro-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-lite-image",
+    ],
+)
+def test_vertex_global_only_image_models_reject_regional_adc(model_id: str) -> None:
+    with pytest.raises(ValueError, match="only available in the global"):
+        GoogleImagesClient(
+            model=_model(model_id),
+            provider=Provider.GOOGLE,
+            auth=GoogleADC(project_id="p", location="us-central1"),
+        )
+
+    client = GoogleImagesClient(
+        model=_model(model_id),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    assert isinstance(client._strategy, GoogleVertexImagesClient)
+
+
+def test_vertex_2_5_flash_image_allows_regional_adc() -> None:
+    client = GoogleImagesClient(
+        model=_model("gemini-2.5-flash-image"),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p", location="us-central1"),
+    )
+
+    assert isinstance(client._strategy, GoogleVertexImagesClient)
+    assert client._strategy._build_url(client._edit_endpoint).startswith(
+        "https://us-central1-aiplatform.googleapis.com/"
+    )
 
 
 def test_interactions_init_request_generate_is_text_only() -> None:
@@ -142,3 +180,208 @@ def test_interactions_parse_content_extracts_image_from_model_output_step() -> N
     assert isinstance(artifact, ImageArtifact)
     assert artifact.data == b"abc"
     assert artifact.mime_type == ImageMimeType.PNG
+
+
+def test_vertex_parses_and_counts_final_inline_image_parts() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"inlineData": {"data": "YWJj", "mimeType": "image/png"}},
+                        {
+                            "thought": True,
+                            "inlineData": {
+                                "data": "dGhvdWdodA==",
+                                "mimeType": "image/png",
+                            },
+                        },
+                        {"text": "Between images"},
+                        {
+                            "inlineData": {
+                                "data": "ZGVm",
+                                "mimeType": "image/jpeg",
+                            }
+                        },
+                    ]
+                }
+            },
+            {"finishReason": "SAFETY"},
+        ]
+    }
+
+    assert client._parse_usage(response_data)["num_images"] == 2
+
+    artifacts = client._parse_content(response_data)
+
+    assert isinstance(artifacts, list)
+    assert len(artifacts) == 2
+    assert artifacts[0].data == b"abc"
+    assert artifacts[0].mime_type == ImageMimeType.PNG
+    assert artifacts[1].data == b"def"
+    assert artifacts[1].mime_type == ImageMimeType.JPEG
+
+
+def test_vertex_prompt_feedback_without_candidates_returns_empty_artifact() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "promptFeedback": {
+            "blockReason": "SAFETY",
+            "blockReasonMessage": "The prompt was blocked for safety.",
+            "safetyRatings": [{"category": "HARM_CATEGORY_DANGEROUS_CONTENT"}],
+        }
+    }
+
+    artifact = client._parse_content(response_data)
+
+    assert isinstance(artifact, ImageArtifact)
+    assert not artifact.has_content
+    assert client._parse_usage(response_data)["num_images"] == 0
+    finish_reason = client._parse_finish_reason(response_data)
+    assert finish_reason.reason == "SAFETY"
+    assert finish_reason.message == "The prompt was blocked for safety."
+    assert client._build_metadata(response_data)["raw_response"] == response_data
+
+
+def test_vertex_metadata_retains_only_grounding_query_counts() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "responseId": "response-id",
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "inlineData": {
+                                "data": "c2Vuc2l0aXZl",
+                                "mimeType": "image/png",
+                            }
+                        }
+                    ]
+                },
+                "groundingMetadata": {
+                    "webSearchQueries": ["first query", "second query"],
+                    "imageSearchQueries": ["image query"],
+                    "groundingChunks": [{"web": {"uri": "https://example.com"}}],
+                },
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5},
+    }
+
+    metadata = client._build_metadata(response_data)
+
+    assert metadata["raw_response"] == {
+        "responseId": "response-id",
+        "usageMetadata": {"promptTokenCount": 5},
+        "grounding_web_query_count": 2,
+        "grounding_image_query_count": 1,
+    }
+
+
+def test_interactions_parses_and_counts_inline_and_uri_images() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    response_data = {
+        "status": "completed",
+        "steps": [
+            {
+                "type": "model_output",
+                "content": [
+                    {
+                        "type": "image",
+                        "data": "YWJj",
+                        "mime_type": "image/png",
+                    },
+                    {"type": "text", "text": "Between images"},
+                    {
+                        "type": "image",
+                        "uri": "https://example.com/generated.jpg",
+                    },
+                    {"type": "image"},
+                ],
+            }
+        ],
+    }
+
+    assert client._parse_usage(response_data)["num_images"] == 2
+
+    artifacts = client._parse_content(response_data)
+
+    assert isinstance(artifacts, list)
+    assert len(artifacts) == 2
+    assert artifacts[0].data == b"abc"
+    assert artifacts[0].url is None
+    assert artifacts[0].mime_type == ImageMimeType.PNG
+    assert artifacts[1].data is None
+    assert artifacts[1].url == "https://example.com/generated.jpg"
+    assert artifacts[1].mime_type is None
+
+
+def test_interactions_metadata_retains_only_executed_search_count() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    response_data = {
+        "id": "interaction-id",
+        "usage": {"total_tokens": 10},
+        "steps": [
+            {
+                "type": "google_search_call",
+                "arguments": {"queries": ["web query", "image query"]},
+                "result": {"sensitive": "provider payload"},
+            },
+            {
+                "type": "google_search_call",
+                "arguments": {"queries": ["second image query"]},
+            },
+            {
+                "type": "model_output",
+                "content": [
+                    {
+                        "type": "image",
+                        "data": "c2Vuc2l0aXZl",
+                        "mime_type": "image/png",
+                    }
+                ],
+            },
+        ],
+    }
+
+    metadata = client._build_metadata(response_data)
+
+    assert metadata["raw_response"] == {
+        "id": "interaction-id",
+        "usage": {"total_tokens": 10},
+        "grounding_query_count": 3,
+    }
+
+
+def test_interactions_metadata_emits_query_count_only_when_steps_are_present() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    usage = {"grounding_tool_count": [{"type": "google_search", "count": 2}]}
+
+    omitted_steps = client._build_metadata({"usage": usage})
+    empty_steps = client._build_metadata({"usage": usage, "steps": []})
+
+    assert omitted_steps["raw_response"] == {"usage": usage}
+    assert empty_steps["raw_response"] == {
+        "usage": usage,
+        "grounding_query_count": 0,
+    }


### PR DESCRIPTION
## Summary

- add the four documented extreme aspect ratios only to `gemini-3.1-flash-lite-image`
- retain complete, compact image artifacts and grounding counts from Developer Interactions and Vertex GenerateContent responses, including prompt-block and thought-image handling
- route the three GA native-image model IDs globally on Vertex
- add Imagen 4 preview upscaling with x2/x3/x4 input validation and count only successful generated/upscaled artifacts

## Exact scope

- **Developer API / Interactions (synchronous):** ordered final image artifacts are retained from inline data or URI forms; `google_search_call` queries become a compact top-level grounding count.
- **Vertex / GenerateContent (synchronous ADC):** final non-thought inline image parts, prompt-blocked responses, safety metadata, and separate web/image grounding counts are retained without candidate text or query strings.
- **Vertex / Imagen Predict:** `imagen-4.0-upscale-preview` accepts base64 bytes or `gs://` URI inputs at x2, x3, or x4 and records only successful artifacts. Existing Imagen generation uses the same successful-artifact rule.
- **Routing:** `gemini-3-pro-image`, `gemini-3.1-flash-image`, and `gemini-3.1-flash-lite-image` use the documented global Vertex route; Imagen remains regional.
- **Timing:** this captures the current documented contracts rechecked 2026-08-29. Conflicting Imagen lifecycle pages are deliberately not used to remove active model support.

## Evidence

- [Gemini image generation](https://ai.google.dev/gemini-api/docs/image-generation)
- [Gemini model catalog](https://ai.google.dev/gemini-api/docs/models)
- [Interactions API](https://ai.google.dev/api/interactions-api-v1)
- [Imagen generation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images)
- [Imagen upscaling](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/upscale-image)
- [Vertex locations](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations)

## Validation

- 27 focused Google image tests passed
- 605 unit tests passed with 70.18% coverage
- Ruff lint and format checks passed
- mypy passed for `celeste` and tests
- Bandit, compileall, staged-diff checks, commit hooks, and push hooks passed

## Coordination

Paired pricing draft: [withceleste/celeste-pricing#19](https://github.com/withceleste/celeste-pricing/pull/19). No Chat change is included; Chat remains pinned until both dependency changes merge and publish.