### PR TITLE
feat(anthropic): support current Claude Messages contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ response = client.messages.create(
         {"role": "user",
          "content": "Extract user info: John is 30"}
     ],
-    output_format={
-        "type": "json_schema",
-        "schema": User.model_json_schema()
+    output_config={
+        "format": {
+            "type": "json_schema",
+            "schema": User.model_json_schema()
+        }
     }
 )
 user_data = json.loads(response.content[0].text)

--- a/src/celeste/modalities/text/providers/anthropic/client.py
+++ b/src/celeste/modalities/text/providers/anthropic/client.py
@@ -1,7 +1,7 @@
 """Anthropic text client (modality)."""
 
 import base64
-from typing import Any
+from typing import Any, Unpack
 
 from celeste.artifacts import DocumentArtifact, ImageArtifact
 from celeste.grounding import Grounding
@@ -16,11 +16,12 @@ from celeste.parameters import ParameterMapper
 from celeste.providers.anthropic.messages.client import (
     AnthropicMessagesClient as AnthropicMessagesMixin,
 )
-from celeste.providers.anthropic.messages.client import needs_native_replay
+from celeste.providers.anthropic.messages.client import native_replay_blocks
 from celeste.providers.anthropic.messages.streaming import (
     AnthropicMessagesStream as _AnthropicMessagesStream,
 )
-from celeste.tools import ToolCall, ToolResult
+from celeste.providers.google.auth import GoogleADC
+from celeste.tools import ToolCall, ToolResult, WebSearch
 from celeste.types import DocumentPart, ImagePart, Role, TextContent, TextPart
 from celeste.utils import detect_mime_type
 
@@ -30,9 +31,15 @@ from ...io import (
     TextInput,
     TextUsage,
 )
+from ...parameters import TextParameters
 from ...streaming import TextStream
 from .grounding import parse_grounding
+from .models import DYNAMIC_FILTERING_MODELS
 from .parameters import ANTHROPIC_PARAMETER_MAPPERS
+
+_MID_CONVERSATION_SYSTEM_MODELS = frozenset(
+    {"claude-fable-5", "claude-mythos-5", "claude-opus-4-8", "claude-opus-5"}
+)
 
 
 class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
@@ -57,7 +64,7 @@ class AnthropicTextStream(_AnthropicMessagesStream, TextStream):
     ) -> list[dict[str, Any]]:
         """Return native content when Anthropic requires exact assistant replay."""
         blocks = self._aggregate_content_blocks()
-        return blocks if needs_native_replay(blocks) else []
+        return native_replay_blocks(blocks)
 
     def _aggregate_container(
         self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
@@ -90,6 +97,45 @@ class AnthropicTextClient(AnthropicMessagesMixin, TextClient):
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:
         return ANTHROPIC_PARAMETER_MAPPERS
+
+    def _build_request(
+        self,
+        inputs: TextInput,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Unpack[TextParameters],
+    ) -> dict[str, Any]:
+        """Select the supported web-search version for unified tools on this route."""
+        tools = parameters.get("tools")
+        unified_web_search = (
+            [
+                isinstance(tool, WebSearch)
+                or (
+                    isinstance(tool, dict)
+                    and tool.get("kind") == "web_search"
+                    and "type" not in tool
+                )
+                for tool in tools
+            ]
+            if isinstance(tools, list)
+            else []
+        )
+        request = super()._build_request(
+            inputs, extra_body=extra_body, streaming=streaming, **parameters
+        )
+        if not (extra_body and "tools" in extra_body):
+            if isinstance(self.auth, GoogleADC):
+                version = "web_search"
+            elif self.model.id in DYNAMIC_FILTERING_MODELS:
+                version = "web_search_20260209"
+            else:
+                version = "web_search_20250305"
+            for tool, is_unified in zip(
+                request.get("tools", []), unified_web_search, strict=False
+            ):
+                if is_unified:
+                    tool["type"] = version
+        return request
 
     def _init_request(self, inputs: TextInput) -> dict[str, Any]:
         """Initialize request from Anthropic Messages API format."""
@@ -124,6 +170,7 @@ class AnthropicTextClient(AnthropicMessagesMixin, TextClient):
         messages: list[dict[str, Any]] = []
         pending_tool_results: list[dict[str, Any]] = []
         container_id: str | None = None
+        supports_mid_system = self.model.id in _MID_CONVERSATION_SYSTEM_MODELS
 
         for message in request_messages(
             prompt=inputs.prompt,
@@ -137,7 +184,19 @@ class AnthropicTextClient(AnthropicMessagesMixin, TextClient):
             content = message.content
 
             if role in {Role.SYSTEM, Role.DEVELOPER}:
-                system_blocks.extend(content_to_blocks(content))
+                blocks = content_to_blocks(content)
+                if supports_mid_system and (messages or pending_tool_results):
+                    if pending_tool_results:
+                        messages.append(
+                            {"role": "user", "content": pending_tool_results}
+                        )
+                        pending_tool_results = []
+                    if messages[-1]["role"] == Role.SYSTEM:
+                        messages[-1]["content"].extend(blocks)
+                    else:
+                        messages.append({"role": Role.SYSTEM, "content": blocks})
+                else:
+                    system_blocks.extend(blocks)
                 continue
 
             if isinstance(message, ToolResult):
@@ -246,14 +305,11 @@ class AnthropicTextClient(AnthropicMessagesMixin, TextClient):
     ) -> TextContent:
         """Parse content from response."""
         content = super()._parse_content(response_data)
-
-        text_content = ""
-        for content_block in content:
-            if content_block.get("type") == "text":
-                text_content = content_block.get("text") or ""
-                break
-
-        return text_content
+        return "".join(
+            content_block.get("text") or ""
+            for content_block in content
+            if content_block.get("type") in {"connector_text", "text"}
+        )
 
     def _parse_reasoning(
         self, response_data: dict[str, Any]
@@ -266,7 +322,7 @@ class AnthropicTextClient(AnthropicMessagesMixin, TextClient):
             if b.get("type") == "thinking" and b.get("thinking")
         ]
         text = "\n".join(reasoning_parts) if reasoning_parts else None
-        return text, list(blocks) if needs_native_replay(blocks) else []
+        return text, native_replay_blocks(blocks)
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Anthropic response."""

--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -11,7 +11,7 @@ from celeste.constraints import (
 )
 from celeste.core import Modality, Operation, Parameter, Provider
 from celeste.models import Model
-from celeste.tools import ToolChoice, WebSearch
+from celeste.tools import WebSearch
 
 from ...parameters import TextParameter
 
@@ -29,9 +29,25 @@ MODELS: list[Model] = [
             ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: Choice(
-                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-mythos-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Mythos 5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
             ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
@@ -40,6 +56,24 @@ MODELS: list[Model] = [
         id="claude-opus-4-8",
         provider=Provider.ANTHROPIC,
         display_name="Claude Opus 4.8",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-opus-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Opus 5",
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={
@@ -81,7 +115,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=64000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -98,7 +132,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=64000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -115,8 +149,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.IMAGE: ImagesConstraint(),
@@ -132,7 +165,8 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=64000),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -148,8 +182,11 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "max"]
+            ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -183,7 +220,8 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=64000),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=128000),
             TextParameter.THINKING_LEVEL: Choice(
                 options=["low", "medium", "high", "max"]
             ),
@@ -200,7 +238,9 @@ MODELS: list[Model] = [
 DYNAMIC_FILTERING_MODELS = frozenset(
     {
         "claude-fable-5",
+        "claude-mythos-5",
         "claude-opus-4-8",
+        "claude-opus-5",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-5",

--- a/src/celeste/modalities/text/providers/anthropic/parameters.py
+++ b/src/celeste/modalities/text/providers/anthropic/parameters.py
@@ -1,8 +1,5 @@
 """Anthropic parameter mappers for text."""
 
-from typing import Any
-
-from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.anthropic.messages.parameters import (
     MaxTokensMapper as _MaxTokensMapper,
@@ -28,7 +25,6 @@ from celeste.providers.anthropic.messages.parameters import (
 from celeste.types import TextContent
 
 from ...parameters import TextParameter
-from .models import DYNAMIC_FILTERING_MODELS
 
 
 class TemperatureMapper(_TemperatureMapper):
@@ -48,25 +44,6 @@ class ThinkingBudgetMapper(_ThinkingMapper):
 
     name = TextParameter.THINKING_BUDGET
 
-    def map(
-        self,
-        request: dict[str, Any],
-        value: object,
-        model: Model,
-    ) -> dict[str, Any]:
-        """Transform thinking_budget with unified value translation."""
-        validated_value = self._validate_value(value, model)
-        if validated_value is None:
-            return request
-
-        # Translate unified → provider-native
-        if validated_value == -1:
-            provider_value = "auto"
-        else:
-            provider_value = validated_value
-
-        return super().map(request, provider_value, model)
-
 
 class ThinkingLevelMapper(_ThinkingLevelMapper):
     """Map thinking_level to Anthropic's adaptive thinking + output_config.effort."""
@@ -75,29 +52,15 @@ class ThinkingLevelMapper(_ThinkingLevelMapper):
 
 
 class OutputSchemaMapper(_OutputFormatMapper):
-    """Map output_schema to Anthropic's output_format parameter."""
+    """Map output_schema to Anthropic's output_config.format parameter."""
 
     name = TextParameter.OUTPUT_SCHEMA
 
 
 class ToolsMapper(_ToolsMapper):
-    """Map tools to Anthropic's tools parameter (web_search version per model)."""
+    """Map tools to Anthropic's tools parameter."""
 
     name = TextParameter.TOOLS
-
-    def map(
-        self,
-        request: dict[str, Any],
-        value: object,
-        model: Model,
-    ) -> dict[str, Any]:
-        """Upgrade web_search to dynamic filtering (web_search_20260209) where the model supports it."""
-        request = super().map(request, value, model)
-        if model.id in DYNAMIC_FILTERING_MODELS:
-            for tool in request.get("tools", []):
-                if tool.get("name") == "web_search":
-                    tool["type"] = "web_search_20260209"
-        return request
 
 
 class ToolChoiceMapper(_ToolChoiceMapper):

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -11,7 +11,14 @@ from celeste.providers.google.auth import GoogleADC
 
 from . import config
 
-_NATIVE_REPLAY_BLOCK_TYPES = {"thinking", "redacted_thinking", "server_tool_use"}
+_NATIVE_REPLAY_BLOCK_TYPES = {
+    "compaction",
+    "fallback",
+    "mcp_tool_use",
+    "thinking",
+    "redacted_thinking",
+    "server_tool_use",
+}
 
 
 def needs_native_replay(blocks: list[dict[str, Any]]) -> bool:
@@ -26,6 +33,38 @@ def needs_native_replay(blocks: list[dict[str, Any]]) -> bool:
         )
         for block in blocks
     )
+
+
+def native_replay_blocks(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the exact assistant blocks valid for a continuation request."""
+    fallback_indexes = [
+        index for index, block in enumerate(blocks) if block.get("type") == "fallback"
+    ]
+    if not fallback_indexes:
+        return list(blocks) if needs_native_replay(blocks) else []
+
+    final_fallback = fallback_indexes[-1]
+    before = blocks[:final_fallback]
+    result_ids = {
+        block.get("tool_use_id")
+        for block in before
+        if isinstance(block.get("type"), str) and block["type"].endswith("_tool_result")
+    }
+    server_ids = {
+        block.get("id") for block in before if block.get("type") == "server_tool_use"
+    }
+    replayable = [
+        block
+        for block in before
+        if block.get("type") in {"compaction", "fallback", "text"}
+        or (block.get("type") == "server_tool_use" and block.get("id") in result_ids)
+        or (
+            isinstance(block.get("type"), str)
+            and block["type"].endswith("_tool_result")
+            and block.get("tool_use_id") in server_ids
+        )
+    ]
+    return [*replayable, *blocks[final_fallback:]]
 
 
 class AnthropicMessagesClient(APIMixin):
@@ -78,10 +117,9 @@ class AnthropicMessagesClient(APIMixin):
         extra_headers: dict[str, str] | None = None,
     ) -> dict[str, str]:
         """Build Anthropic request headers."""
-        headers: dict[str, str] = {
-            **self._json_headers(),
-            config.HEADER_ANTHROPIC_VERSION: config.ANTHROPIC_VERSION,
-        }
+        headers = self._json_headers()
+        if not isinstance(self.auth, GoogleADC):
+            headers[config.HEADER_ANTHROPIC_VERSION] = config.ANTHROPIC_VERSION
         if beta_features:
             beta_values = [
                 getattr(config, f"BETA_{f.upper().replace('-', '_')}")
@@ -103,7 +141,13 @@ class AnthropicMessagesClient(APIMixin):
         request_body = super()._build_request(
             inputs, extra_body=extra_body, streaming=streaming, **parameters
         )
-        request_body["model"] = self.model.id
+        if isinstance(self.auth, GoogleADC):
+            request_body.pop("model", None)
+            request_body.setdefault(
+                "anthropic_version", config.VERTEX_ANTHROPIC_VERSION
+            )
+        else:
+            request_body["model"] = self.model.id
         if streaming:
             request_body["stream"] = True
         return request_body
@@ -207,6 +251,14 @@ class AnthropicMessagesClient(APIMixin):
         """
         content = response_data.get("content", [])
         if not content:
+            feedback = response_data.get("promptFeedback")
+            if isinstance(feedback, dict):
+                reason = feedback.get("blockReason")
+                suffix = f": {reason}" if reason else ""
+                msg = f"Prompt blocked by Google Vertex safety filters{suffix}"
+                raise ValueError(msg)
+            if response_data.get("stop_reason") == "refusal":
+                return []
             msg = "No content in response"
             raise ValueError(msg)
         return content

--- a/src/celeste/providers/anthropic/messages/config.py
+++ b/src/celeste/providers/anthropic/messages/config.py
@@ -23,6 +23,7 @@ BASE_URL = "https://api.anthropic.com"
 
 # Required
 ANTHROPIC_VERSION = "2023-06-01"
+VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
 CONTENT_TYPE_JSON = "application/json"
 
 # Header
@@ -35,8 +36,6 @@ BETA_COMPUTER_USE = "computer-use-2024-10-22"
 BETA_PDFS = "pdfs-2024-09-25"
 BETA_TOKEN_COUNTING = "token-counting-2024-11-01"  # nosec B105
 BETA_MAX_TOKENS_SONNET_3_5 = "max-tokens-3-5-sonnet-2024-07-15"
-BETA_STRUCTURED_OUTPUTS = "structured-outputs-2025-11-13"
-
 # Defaults
 DEFAULT_MAX_TOKENS = 1024
 

--- a/src/celeste/providers/anthropic/messages/parameters.py
+++ b/src/celeste/providers/anthropic/messages/parameters.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, get_args, get_origin
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from celeste.exceptions import InvalidToolError
 from celeste.models import Model
@@ -48,9 +48,7 @@ class StopSequencesMapper(FieldMapper[TextContent]):
 class ThinkingMapper(ParameterMapper[TextContent]):
     """Map thinking to Anthropic thinking field.
 
-    Accepts provider-native values:
-    - "auto": Dynamic budget (API decides)
-    - int: Fixed budget with specified tokens
+    Accepts a fixed manual thinking budget in tokens.
     """
 
     def map(
@@ -64,15 +62,12 @@ class ThinkingMapper(ParameterMapper[TextContent]):
         if validated_value is None:
             return request
 
-        if validated_value == "auto":
-            request["thinking"] = {"type": "auto"}
-        else:
-            request["thinking"] = {"type": "enabled", "budget_tokens": validated_value}
+        request["thinking"] = {"type": "enabled", "budget_tokens": validated_value}
         return request
 
 
 class ThinkingLevelMapper(ParameterMapper[TextContent]):
-    """Map thinking_level to adaptive thinking plus output_config.effort.
+    """Map thinking_level to output_config.effort and adaptive thinking where supported.
 
     display="summarized" so thinking summaries stream (API default "omitted" is empty).
     effort goes in output_config, not the thinking object (the API rejects it there).
@@ -88,7 +83,8 @@ class ThinkingLevelMapper(ParameterMapper[TextContent]):
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
-        request["thinking"] = {"type": "adaptive", "display": "summarized"}
+        if model.id != "claude-opus-4-5" and "thinking" not in request:
+            request["thinking"] = {"type": "adaptive", "display": "summarized"}
         request.setdefault("output_config", {})["effort"] = validated_value
         return request
 
@@ -141,6 +137,8 @@ class ToolsMapper(ParameterMapper[TextContent]):
         result: dict[str, Any] = {"name": tool["name"], "input_schema": input_schema}
         if "description" in tool:
             result["description"] = tool["description"]
+        if "strict" in tool:
+            result["strict"] = tool["strict"]
         return result
 
 
@@ -176,7 +174,7 @@ class ToolChoiceMapper(ParameterMapper[TextContent]):
 
 
 class OutputFormatMapper(ParameterMapper[TextContent]):
-    """Map output_schema to Anthropic output_format field.
+    """Map output_schema to Anthropic output_config.format field.
 
     Handles both single BaseModel and list[BaseModel] types.
     Anthropic supports top-level arrays, $ref, and $defs natively.
@@ -208,14 +206,10 @@ class OutputFormatMapper(ParameterMapper[TextContent]):
                 mode="serialization",
             )
 
-        request["output_format"] = {
+        request.setdefault("output_config", {})["format"] = {
             "type": "json_schema",
             "schema": schema,
         }
-
-        # Signal that structured outputs beta header is needed
-        request.setdefault("_beta_features", []).append("structured-outputs")
-
         return request
 
     def parse_output(self, content: TextContent, value: object | None) -> TextContent:
@@ -233,11 +227,17 @@ class OutputFormatMapper(ParameterMapper[TextContent]):
         if isinstance(content, dict):
             parsed = content
         elif isinstance(content, str):
-            parsed = json.loads(content, strict=False)
+            try:
+                parsed = json.loads(content, strict=False)
+            except json.JSONDecodeError:
+                return content
         else:
             parsed = content
 
-        return TypeAdapter(value).validate_python(parsed)
+        try:
+            return TypeAdapter(value).validate_python(parsed)
+        except ValidationError:
+            return content
 
 
 __all__ = [

--- a/src/celeste/providers/anthropic/messages/streaming.py
+++ b/src/celeste/providers/anthropic/messages/streaming.py
@@ -38,7 +38,7 @@ class AnthropicMessagesStream:
             block = event_data.get("content_block", {})
             block_type = block.get("type")
             idx = event_data.get("index", len(self._content_blocks))
-            if block_type in {"server_tool_use", "tool_use"}:
+            if block_type in {"mcp_tool_use", "server_tool_use", "tool_use"}:
                 input_value = block.get("input")
                 # Keep provider fields like `caller`; only input streams via deltas.
                 captured = dict(block)
@@ -63,13 +63,19 @@ class AnthropicMessagesStream:
                     "text": block.get("text", ""),
                     "citations": [],
                 }
+            elif block_type in {"compaction", "connector_text", "fallback"}:
+                self._content_blocks[idx] = dict(block)
         elif event_type == "content_block_delta":
             delta = event_data.get("delta", {})
             delta_type = delta.get("type")
             idx = event_data.get("index", -1)
             block = self._content_blocks.get(idx)
             if delta_type == "input_json_delta":
-                if block and block.get("type") in {"server_tool_use", "tool_use"}:
+                if block and block.get("type") in {
+                    "mcp_tool_use",
+                    "server_tool_use",
+                    "tool_use",
+                }:
                     block["input_json"] += delta.get("partial_json", "")
             elif delta_type in {"thinking_delta", "signature_delta"}:
                 key = delta_type.removesuffix("_delta")
@@ -85,6 +91,14 @@ class AnthropicMessagesStream:
                     citation = delta.get("citation")
                     if isinstance(citation, dict):
                         block["citations"].append(citation)
+            elif (
+                delta_type == "compaction_delta"
+                and block
+                and block.get("type") == "compaction"
+            ):
+                block.update(
+                    {key: value for key, value in delta.items() if key != "type"}
+                )
         return super()._parse_chunk(event_data)  # type: ignore[misc]
 
     def _aggregate_event_data(self, chunks: list[Any]) -> list[dict[str, Any]]:
@@ -110,6 +124,12 @@ class AnthropicMessagesStream:
                     **(event.get("usage") or {}),
                 }
                 break
+        for block in reversed(self._aggregate_content_blocks()):
+            target = block.get("to")
+            if block.get("type") == "fallback" and isinstance(target, dict):
+                if isinstance(target_model := target.get("model"), str):
+                    response["model"] = target_model
+                break
         return response
 
     def _aggregate_content_blocks(self) -> list[dict[str, Any]]:
@@ -117,7 +137,7 @@ class AnthropicMessagesStream:
         blocks: list[dict[str, Any]] = []
         for idx in sorted(self._content_blocks):
             block = self._content_blocks[idx]
-            if block.get("type") in {"server_tool_use", "tool_use"}:
+            if block.get("type") in {"mcp_tool_use", "server_tool_use", "tool_use"}:
                 input_data = block.get("input") or {}
                 if block.get("input_json"):
                     with contextlib.suppress(ValueError, TypeError):
@@ -145,6 +165,18 @@ class AnthropicMessagesStream:
                 return delta.get("text") or None
 
         return None
+
+    def _parse_stream_error(self, event_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Detect Google Vertex HTTP-200 prompt blocks."""
+        feedback = event_data.get("promptFeedback")
+        if isinstance(feedback, dict):
+            reason = feedback.get("blockReason")
+            suffix = f": {reason}" if reason else ""
+            return {
+                "type": str(reason) if reason else "vertex_prompt_blocked",
+                "message": f"Prompt blocked by Google Vertex safety filters{suffix}",
+            }
+        return super()._parse_stream_error(event_data)  # type: ignore[misc]
 
     def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
         """Extract thinking content from SSE event."""

--- a/tests/unit_tests/test_anthropic_max_tokens_default.py
+++ b/tests/unit_tests/test_anthropic_max_tokens_default.py
@@ -1,7 +1,12 @@
 """Anthropic max_tokens defaults to the model's output ceiling."""
 
-from celeste.constraints import Range
+from celeste.constraints import Range, ToolChoiceSupport
 from celeste.core import Parameter
+from celeste.modalities.text.parameters import TextParameter
+from celeste.modalities.text.providers.anthropic.models import (
+    DYNAMIC_FILTERING_MODELS,
+    MODELS,
+)
 from celeste.providers.anthropic.messages import config
 from tests.unit_tests.conftest import anthropic_test_client
 
@@ -11,3 +16,41 @@ def test_max_tokens_defaults_to_model_ceiling() -> None:
 
     assert client._resolve_max_tokens() == 128000
     assert anthropic_test_client()._resolve_max_tokens() == config.DEFAULT_MAX_TOKENS
+
+
+def test_anthropic_opus_5_catalog_and_structured_output_support() -> None:
+    models = {model.id: model for model in MODELS}
+
+    opus_5 = models["claude-opus-5"]
+    max_tokens = opus_5.parameter_constraints[Parameter.MAX_TOKENS]
+    assert isinstance(max_tokens, Range) and max_tokens.max == 128000
+    assert TextParameter.OUTPUT_SCHEMA in opus_5.parameter_constraints
+    assert "claude-opus-5" in DYNAMIC_FILTERING_MODELS
+    assert "claude-mythos-5" in models
+    assert "claude-mythos-5" in DYNAMIC_FILTERING_MODELS
+    assert isinstance(
+        models["claude-fable-5"].parameter_constraints[TextParameter.TOOL_CHOICE],
+        ToolChoiceSupport,
+    )
+    assert (
+        TextParameter.OUTPUT_SCHEMA
+        not in models["claude-opus-4-1"].parameter_constraints
+    )
+    for model_id in ("claude-opus-4-6", "claude-sonnet-4-6"):
+        constraint = models[model_id].parameter_constraints[Parameter.MAX_TOKENS]
+        assert isinstance(constraint, Range) and constraint.max == 128000
+    assert (
+        TextParameter.THINKING_LEVEL in models["claude-opus-4-6"].parameter_constraints
+    )
+    for model_id in (
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+        "claude-opus-4-1",
+        "claude-opus-4-5",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+    ):
+        constraint = models[model_id].parameter_constraints[
+            TextParameter.THINKING_BUDGET
+        ]
+        assert isinstance(constraint, Range) and constraint.min == 1024

--- a/tests/unit_tests/test_anthropic_native_replay.py
+++ b/tests/unit_tests/test_anthropic_native_replay.py
@@ -3,9 +3,18 @@
 from collections.abc import AsyncIterator
 from typing import Any
 
+import pytest
+from pydantic import BaseModel
+
+from celeste.core import Provider
+from celeste.exceptions import StreamEventError
 from celeste.modalities.text.io import TextInput
 from celeste.modalities.text.providers.anthropic.client import AnthropicTextStream
 from tests.unit_tests.conftest import anthropic_test_client
+
+
+class _RefusalSchema(BaseModel):
+    value: int
 
 
 async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
@@ -171,3 +180,232 @@ async def test_anthropic_programmatic_tool_use_alone_triggers_native_replay() ->
 
     signature = stream.output.signature
     assert signature is not None and signature[0]["caller"] == caller
+
+
+async def test_anthropic_stream_preserves_valid_blocks_across_fallback() -> None:
+    fallback = {
+        "type": "fallback",
+        "from": {"model": "claude-opus-5"},
+        "to": {"model": "claude-opus-4-8"},
+    }
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_01",
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 10},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "partial"},
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "connector_text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "tool narration"},
+        },
+        {
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": fallback,
+        },
+        {
+            "type": "content_block_start",
+            "index": 3,
+            "content_block": {"type": "thinking", "thinking": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 3,
+            "delta": {"type": "thinking_delta", "thinking": "new thought"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 4,
+            "delta": {"type": "text_delta", "text": "answer"},
+        },
+        {
+            "type": "content_block_start",
+            "index": 5,
+            "content_block": {
+                "type": "connector_text",
+                "text": "",
+                "signature": "opaque",
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 5,
+            "delta": {"type": "text_delta", "text": "connector narration"},
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 12},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    signature = stream.output.signature
+    assert signature == [
+        {"type": "text", "text": "partial"},
+        fallback,
+        {"type": "thinking", "thinking": "new thought", "signature": ""},
+        {"type": "text", "text": "answer"},
+        {
+            "type": "connector_text",
+            "text": "connector narration",
+            "signature": "opaque",
+        },
+    ]
+    request = anthropic_test_client()._init_request(
+        TextInput(messages=[stream.output.message])
+    )
+    assert request["messages"][0]["content"] == signature
+    assert stream.output.metadata["response_model"] == "claude-opus-4-8"
+    assert stream.output.metadata["raw_response"]["model"] == "claude-opus-4-8"
+
+
+async def test_anthropic_stream_preserves_compaction_for_replay() -> None:
+    compaction = {
+        "type": "compaction",
+        "content": "compacted conversation",
+        "encrypted_content": "opaque",
+    }
+    events = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "compaction", "content": None},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "compaction_delta",
+                "content": compaction["content"],
+                "encrypted_content": compaction["encrypted_content"],
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "continued"},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    assert stream.output.signature == [
+        compaction,
+        {"type": "text", "text": "continued"},
+    ]
+    request = anthropic_test_client()._init_request(
+        TextInput(messages=[stream.output.message])
+    )
+    assert request["messages"][0]["content"] == stream.output.signature
+
+
+async def test_anthropic_stream_preserves_mcp_tool_pair_for_replay() -> None:
+    tool_use = {
+        "type": "mcp_tool_use",
+        "id": "mcptoolu_01",
+        "name": "search",
+        "server_name": "docs",
+        "input": {"query": "Opus 5"},
+    }
+    result = {
+        "type": "mcp_tool_result",
+        "tool_use_id": "mcptoolu_01",
+        "content": [{"type": "text", "text": "found"}],
+        "is_error": False,
+    }
+    events = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {**tool_use, "input": {}},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"query":"Opus 5"}',
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": result,
+        },
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 5},
+        },
+    ]
+    stream = AnthropicTextStream(_async_iter(events))
+
+    async for _ in stream:
+        pass
+
+    assert stream.output.signature == [tool_use, result]
+    request = anthropic_test_client()._init_request(
+        TextInput(messages=[stream.output.message])
+    )
+    assert request["messages"][0]["content"] == [tool_use, result]
+
+
+async def test_anthropic_stream_raises_for_vertex_prompt_block() -> None:
+    event = {"promptFeedback": {"blockReason": "PROHIBITED_CONTENT"}}
+    stream = AnthropicTextStream(
+        _async_iter([event]), stream_metadata={"provider": Provider.ANTHROPIC}
+    )
+
+    with pytest.raises(StreamEventError, match="PROHIBITED_CONTENT") as caught:
+        async for _ in stream:
+            pass
+
+    assert caught.value.error_type == "PROHIBITED_CONTENT"
+
+
+def test_anthropic_pre_output_refusal_is_a_valid_empty_response() -> None:
+    client = anthropic_test_client()
+    response = {
+        "content": [],
+        "stop_reason": "refusal",
+        "stop_details": {"type": "refusal", "category": "cyber"},
+        "usage": {"input_tokens": 10, "output_tokens": 0},
+    }
+
+    content = client._parse_content(response)
+    assert content == ""
+    assert client._transform_output(content, output_schema=_RefusalSchema) == ""
+    assert client._parse_usage(response)["output_tokens"] == 0
+
+
+def test_anthropic_unary_response_joins_all_text_blocks() -> None:
+    response = {
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "connector_text", "text": " narration"},
+            {"type": "fallback", "to": {"model": "claude-opus-4-8"}},
+            {"type": "text", "text": " second"},
+        ]
+    }
+
+    assert anthropic_test_client()._parse_content(response) == "first narration second"

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -24,6 +24,9 @@ from celeste.modalities.text.protocols.chatcompletions.client import (
     ChatCompletionsTextStream,
 )
 from celeste.modalities.text.providers.anthropic import parameters as anthropic
+from celeste.modalities.text.providers.anthropic.models import (
+    MODELS as ANTHROPIC_MODELS,
+)
 from celeste.modalities.text.providers.google import parameters as google_text
 from celeste.modalities.text.providers.groq import parameters as groq
 from celeste.modalities.text.providers.moonshot import parameters as moonshot
@@ -226,6 +229,13 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (CHAT, T.MAX_TOKENS, 100, ("max_tokens",), 100),
         (CHAT, T.THINKING_BUDGET, "high", ("reasoning_effort",), "high"),
         (ANTHROPIC, T.TEMPERATURE, 0.3, ("temperature",), 0.3),
+        (
+            ANTHROPIC,
+            T.THINKING_BUDGET,
+            2048,
+            ("thinking",),
+            {"type": "enabled", "budget_tokens": 2048},
+        ),
         (MOONSHOT, T.TEMPERATURE, 0.4, ("temperature",), 0.4),
         (MOONSHOT, T.MAX_TOKENS, 120, ("max_completion_tokens",), 120),
         (MOONSHOT, T.THINKING_BUDGET, "max", ("reasoning_effort",), "max"),
@@ -329,6 +339,14 @@ def test_none_omits_every_optional_parameter(
     ("mappers", "schema", "wire", "path", "mapped", "parsed"),
     [
         (GOOGLE_VERTEX, Answer, '{"value":1}', GS, "integer", Answer(value=1)),
+        (
+            ANTHROPIC,
+            Answer,
+            '{"value":1}',
+            ("output_config", "format", "schema", "properties", "value", "type"),
+            "integer",
+            Answer(value=1),
+        ),
         (OPEN, ANSWERS, '{"items":[{"value":2}]}', TF, "answer_list", A2),
         (CHAT, ANSWERS, W3, RF, "json_object", A3),
         (GROQ, ANSWERS, W3, RF, "json_object", A3),
@@ -358,6 +376,53 @@ def test_user_tools_use_protocol_function_shape(
     assert mapped["type"] == "function"
     assert function["name"] == "lookup"
     assert function["parameters"]["properties"]["value"]["type"] == "integer"
+
+
+def test_anthropic_user_tools_preserve_strict_mode() -> None:
+    tool = _map(
+        ANTHROPIC,
+        T.TOOLS,
+        [{"name": "lookup", "parameters": Answer, "strict": True}],
+    )["tools"][0]
+
+    assert tool["strict"] is True
+    assert tool["input_schema"]["properties"]["value"]["type"] == "integer"
+
+
+def test_anthropic_structured_output_uses_stable_wire_shape() -> None:
+    request = _map(ANTHROPIC, T.OUTPUT_SCHEMA, Answer)
+
+    assert request["output_config"]["format"]["type"] == "json_schema"
+    assert "output_format" not in request
+    assert "_beta_features" not in request
+
+
+@pytest.mark.parametrize("content", ("", '{"value":', '{"refusal":"blocked"}'))
+def test_anthropic_structured_output_preserves_non_schema_stop_content(
+    content: str,
+) -> None:
+    mapper = _mapper(ANTHROPIC, T.OUTPUT_SCHEMA)
+
+    assert mapper.parse_output(content, Answer) == content
+
+
+def test_anthropic_opus_4_5_effort_does_not_enable_adaptive_thinking() -> None:
+    model = next(model for model in ANTHROPIC_MODELS if model.id == "claude-opus-4-5")
+    request = _mapper(ANTHROPIC, T.THINKING_LEVEL).map({}, "medium", model)
+
+    assert request == {"output_config": {"effort": "medium"}}
+
+
+def test_anthropic_4_6_effort_preserves_manual_thinking_budget() -> None:
+    model = next(model for model in ANTHROPIC_MODELS if model.id == "claude-opus-4-6")
+    request = _mapper(ANTHROPIC, T.THINKING_BUDGET).map({}, 2048, model)
+
+    request = _mapper(ANTHROPIC, T.THINKING_LEVEL).map(request, "low", model)
+
+    assert request == {
+        "thinking": {"type": "enabled", "budget_tokens": 2048},
+        "output_config": {"effort": "low"},
+    }
 
 
 def test_google_media_precedes_text_content() -> None:

--- a/tests/unit_tests/test_text_multimodal_message_request_building.py
+++ b/tests/unit_tests/test_text_multimodal_message_request_building.py
@@ -239,6 +239,57 @@ def test_anthropic_message_parts_include_image_and_document_sources() -> None:
     assert content[2] == {"type": "text", "text": "inspect"}
 
 
+def test_anthropic_keeps_supported_mid_conversation_system_messages_in_place() -> None:
+    model = _model(Provider.ANTHROPIC).model_copy(update={"id": "claude-opus-5"})
+    client = AnthropicTextClient(
+        model=model,
+        provider=Provider.ANTHROPIC,
+        auth=_auth(Provider.ANTHROPIC),
+    )
+
+    request = client._init_request(
+        TextInput(
+            messages=[
+                Message(role=Role.SYSTEM, content="top-level"),
+                Message(role=Role.USER, content="question"),
+                Message(role=Role.DEVELOPER, content="updated rule"),
+                Message(role=Role.ASSISTANT, content="answer"),
+            ]
+        )
+    )
+
+    assert request["system"] == [{"type": "text", "text": "top-level"}]
+    assert [message["role"] for message in request["messages"]] == [
+        Role.USER,
+        Role.SYSTEM,
+        Role.ASSISTANT,
+    ]
+    assert request["messages"][1]["content"] == [
+        {"type": "text", "text": "updated rule"}
+    ]
+
+
+def test_anthropic_hoists_mid_conversation_system_for_unsupported_models() -> None:
+    model = _model(Provider.ANTHROPIC).model_copy(update={"id": "claude-sonnet-5"})
+    client = AnthropicTextClient(
+        model=model,
+        provider=Provider.ANTHROPIC,
+        auth=_auth(Provider.ANTHROPIC),
+    )
+
+    request = client._init_request(
+        TextInput(
+            messages=[
+                Message(role=Role.USER, content="question"),
+                Message(role=Role.SYSTEM, content="updated rule"),
+            ]
+        )
+    )
+
+    assert request["system"] == [{"type": "text", "text": "updated rule"}]
+    assert [message["role"] for message in request["messages"]] == [Role.USER]
+
+
 def test_cohere_message_parts_include_image_block() -> None:
     client = CohereTextClient(
         model=_model(Provider.COHERE),

--- a/tests/unit_tests/test_vertex_routing.py
+++ b/tests/unit_tests/test_vertex_routing.py
@@ -8,6 +8,8 @@ from pydantic import SecretStr
 
 from celeste.auth import AuthHeader
 from celeste.core import Provider
+from celeste.modalities.text.io import TextInput
+from celeste.modalities.text.providers.anthropic.client import AnthropicTextClient
 from celeste.models import Model
 from celeste.providers.anthropic.messages import config as anthropic_config
 from celeste.providers.anthropic.messages.client import AnthropicMessagesClient
@@ -24,6 +26,7 @@ from celeste.providers.google.veo import config as veo_config
 from celeste.providers.google.veo.client import GoogleVeoClient
 from celeste.providers.mistral.chat import config as mistral_config
 from celeste.providers.mistral.chat.client import MistralChatClient
+from celeste.tools import WebSearch
 
 
 def _model(model_id: str) -> Model:
@@ -209,6 +212,91 @@ def test_vertex_streaming_uses_stream_endpoint(
     assert "streamRawPredict" in _build_url(
         client_type, endpoint, model_id, _adc(), streaming=True
     )
+
+
+def test_anthropic_vertex_uses_url_model_and_body_version() -> None:
+    client = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_adc(),
+    )
+
+    request = client._build_request(
+        TextInput(prompt="hello"), extra_body={"model": "body-override"}
+    )
+
+    assert request["anthropic_version"] == "vertex-2023-10-16"
+    assert "model" not in request
+    assert anthropic_config.HEADER_ANTHROPIC_VERSION not in client._build_headers()
+
+
+def test_anthropic_direct_request_keeps_model_and_version_header() -> None:
+    client = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_api_key(),
+    )
+
+    request = client._build_request(TextInput(prompt="hello"))
+
+    assert request["model"] == "claude-opus-5"
+    assert client._build_headers()[anthropic_config.HEADER_ANTHROPIC_VERSION] == (
+        anthropic_config.ANTHROPIC_VERSION
+    )
+
+
+def test_anthropic_web_search_version_respects_serving_route() -> None:
+    direct = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_api_key(),
+    )
+    vertex = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_adc(),
+    )
+
+    assert (
+        direct._build_request(TextInput(prompt="hello"), tools=[WebSearch()])["tools"][
+            0
+        ]["type"]
+        == "web_search_20260209"
+    )
+    assert (
+        vertex._build_request(TextInput(prompt="hello"), tools=[WebSearch()])["tools"][
+            0
+        ]["type"]
+        == "web_search"
+    )
+
+
+def test_anthropic_raw_web_search_tool_is_not_rewritten() -> None:
+    client = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_api_key(),
+    )
+    raw = {
+        "type": "web_search_20260318",
+        "name": "web_search",
+        "response_inclusion": "search_results",
+    }
+
+    assert client._build_request(TextInput(prompt="hello"), tools=[raw])["tools"] == [
+        raw
+    ]
+
+
+def test_anthropic_vertex_prompt_feedback_is_an_error() -> None:
+    client = AnthropicTextClient(
+        model=_model("claude-opus-5"),
+        provider=Provider.ANTHROPIC,
+        auth=_adc(),
+    )
+
+    with pytest.raises(ValueError, match="PROHIBTED_CONTENT"):
+        client._parse_content({"promptFeedback": {"blockReason": "PROHIBTED_CONTENT"}})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_vertex_routing.py
+++ b/tests/unit_tests/test_vertex_routing.py
@@ -214,7 +214,10 @@ def test_vertex_streaming_uses_stream_endpoint(
     )
 
 
-def test_anthropic_vertex_uses_url_model_and_body_version() -> None:
+def test_anthropic_vertex_uses_url_model_and_body_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(GoogleADC, "get_headers", lambda self: {})
     client = AnthropicTextClient(
         model=_model("claude-opus-5"),
         provider=Provider.ANTHROPIC,


### PR DESCRIPTION
## Summary

- add Claude Fable 5, Mythos 5, and Opus 5, and correct current Claude 4.x capabilities, output ceilings, thinking modes, and manual-thinking budgets
- use stable structured outputs (`output_config.format`), preserve strict tool definitions, and select the current route-specific web-search wire type
- align Anthropic-direct and Vertex request envelopes, surface Vertex HTTP-200 safety blocks, and accept no-output refusals
- preserve fallback, compaction, MCP, connector, reasoning, and server-tool blocks needed for exact continuation replay; expose the final serving model after fallback
- keep unary and streamed visible text consistent, including connector narration

## First-party evidence

- [Claude platform release notes](https://platform.claude.com/docs/en/release-notes/overview)
- [Model IDs and lifecycle](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions)
- [Fable 5 and Mythos 5 introduction](https://platform.claude.com/docs/en/models/fable-5/introducing-claude-fable-5-and-claude-mythos-5)
- [Mythos 5 overview](https://platform.claude.com/docs/en/models/mythos-5/overview)
- [Opus 5 overview](https://platform.claude.com/docs/en/models/opus-5/overview)
- [Structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
- [Mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)
- [Refusals and fallback](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback)
- [Compaction](https://platform.claude.com/docs/en/build-with-claude/compaction)
- [Google Vertex partner-model web search](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/web-search)

## Validation

- `ruff format` and `ruff check`
- mypy: 388 package files and 82 test files
- Bandit: clean (existing informational warnings only)
- unit tests: 608 passed; coverage 70.30% (required 65%)
- `git diff --check`

## Notes

- Companion pricing change: [withceleste/celeste-pricing#20](https://github.com/withceleste/celeste-pricing/pull/20).
- Raw provider-native tool dictionaries are not rewritten; only Celeste's unified `WebSearch` abstraction is route-mapped.
- Chat model exposure is intentionally unchanged until the SDK and pricing updates are merged and released.
