### PR TITLE
feat(anthropic): add Mythos 5 and Opus 5 models

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -37,6 +37,42 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="claude-mythos-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Mythos 5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-opus-5",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Opus 5",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="claude-opus-4-8",
         provider=Provider.ANTHROPIC,
         display_name="Claude Opus 4.8",
@@ -200,6 +236,8 @@ MODELS: list[Model] = [
 DYNAMIC_FILTERING_MODELS = frozenset(
     {
         "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",

--- a/tests/unit_tests/test_anthropic_max_tokens_default.py
+++ b/tests/unit_tests/test_anthropic_max_tokens_default.py
@@ -1,12 +1,7 @@
-"""Anthropic model metadata tests."""
+"""Anthropic max_tokens defaults to the model's output ceiling."""
 
-from celeste.constraints import Choice, Range, ToolChoiceSupport
+from celeste.constraints import Range
 from celeste.core import Parameter
-from celeste.modalities.text.parameters import TextParameter
-from celeste.modalities.text.providers.anthropic.models import (
-    DYNAMIC_FILTERING_MODELS,
-    MODELS,
-)
 from celeste.providers.anthropic.messages import config
 from tests.unit_tests.conftest import anthropic_test_client
 
@@ -16,18 +11,3 @@ def test_max_tokens_defaults_to_model_ceiling() -> None:
 
     assert client._resolve_max_tokens() == 128000
     assert anthropic_test_client()._resolve_max_tokens() == config.DEFAULT_MAX_TOKENS
-
-
-def test_claude_5_model_metadata() -> None:
-    models = {model.id: model for model in MODELS}
-    model_ids = {"claude-mythos-5", "claude-opus-5"}
-
-    for model_id in model_ids:
-        constraints = models[model_id].parameter_constraints
-        assert constraints[Parameter.MAX_TOKENS] == Range(min=1, max=128000)
-        assert constraints[TextParameter.THINKING_LEVEL] == Choice(
-            options=["low", "medium", "high", "xhigh", "max"]
-        )
-        assert isinstance(constraints[TextParameter.TOOL_CHOICE], ToolChoiceSupport)
-
-    assert model_ids <= DYNAMIC_FILTERING_MODELS

--- a/tests/unit_tests/test_anthropic_max_tokens_default.py
+++ b/tests/unit_tests/test_anthropic_max_tokens_default.py
@@ -1,7 +1,12 @@
-"""Anthropic max_tokens defaults to the model's output ceiling."""
+"""Anthropic model metadata tests."""
 
-from celeste.constraints import Range
+from celeste.constraints import Choice, Range, ToolChoiceSupport
 from celeste.core import Parameter
+from celeste.modalities.text.parameters import TextParameter
+from celeste.modalities.text.providers.anthropic.models import (
+    DYNAMIC_FILTERING_MODELS,
+    MODELS,
+)
 from celeste.providers.anthropic.messages import config
 from tests.unit_tests.conftest import anthropic_test_client
 
@@ -11,3 +16,18 @@ def test_max_tokens_defaults_to_model_ceiling() -> None:
 
     assert client._resolve_max_tokens() == 128000
     assert anthropic_test_client()._resolve_max_tokens() == config.DEFAULT_MAX_TOKENS
+
+
+def test_claude_5_model_metadata() -> None:
+    models = {model.id: model for model in MODELS}
+    model_ids = {"claude-mythos-5", "claude-opus-5"}
+
+    for model_id in model_ids:
+        constraints = models[model_id].parameter_constraints
+        assert constraints[Parameter.MAX_TOKENS] == Range(min=1, max=128000)
+        assert constraints[TextParameter.THINKING_LEVEL] == Choice(
+            options=["low", "medium", "high", "xhigh", "max"]
+        )
+        assert isinstance(constraints[TextParameter.TOOL_CHOICE], ToolChoiceSupport)
+
+    assert model_ids <= DYNAMIC_FILTERING_MODELS


### PR DESCRIPTION
## Summary

- Register Claude Mythos 5 and Claude Opus 5 in the existing Anthropic text-model catalog.
- Add both models to the existing dynamic web-search filtering set.

This replaces the closed #359 with a deliberately narrow change.

## Scope

Model metadata only. This PR does not add or alter public APIs, request mapping, response parsing, streaming, or structured-output plumbing.

## Validation

- Ruff
- mypy
- Bandit
- Existing unit test suite

## References

- https://platform.claude.com/docs/en/models/mythos-5/overview
- https://platform.claude.com/docs/en/models/opus-5/overview
