### PR TITLE
fix(google): correct existing image operation handling

### DIFF
--- a/src/celeste/modalities/images/providers/google/imagen.py
+++ b/src/celeste/modalities/images/providers/google/imagen.py
@@ -39,9 +39,9 @@ class GoogleImagenImagesClient(GoogleImagenMixin, ImagesClient):
 
         images: list[ImageArtifact] = []
         for prediction in predictions:
-            base64_data = prediction.get("bytesBase64Encoded")
-            if not base64_data:
+            if not self._is_image_prediction(prediction):
                 continue
+            base64_data = prediction.get("bytesBase64Encoded")
             mime_type = ImageMimeType(prediction.get("mimeType", "image/png"))
             images.append(ImageArtifact(data=base64_data, mime_type=mime_type))
 

--- a/src/celeste/modalities/images/providers/google/interactions.py
+++ b/src/celeste/modalities/images/providers/google/interactions.py
@@ -27,6 +27,17 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
     def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
         return GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Retain executed search count without retaining queries or results."""
+        metadata = super()._build_metadata(response_data)
+        if "steps" in response_data:
+            metadata["raw_response"]["grounding_query_count"] = sum(
+                len(step.get("arguments", {}).get("queries", []))
+                for step in response_data["steps"]
+                if step.get("type") == "google_search_call"
+            )
+        return metadata
+
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
         """Initialize request for Gemini image generation/edit."""
         parts: list[dict[str, Any]] = []
@@ -53,7 +64,7 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
             for step in steps
             if step.get("type") == "model_output"
             for part in step.get("content", [])
-            if part.get("type") == "image"
+            if part.get("type") == "image" and (part.get("data") or part.get("uri"))
         )
         return {**usage, UsageField.NUM_IMAGES: num_images}
 
@@ -72,10 +83,14 @@ class GoogleInteractionsImagesClient(GoogleInteractionsMixin, ImagesClient):
                 if part.get("type") != "image":
                     continue
                 base64_data = part.get("data")
-                if not base64_data:
+                uri = part.get("uri")
+                if not base64_data and not uri:
                     continue
-                mime_type = ImageMimeType(part.get("mime_type", "image/png"))
-                artifacts.append(ImageArtifact(data=base64_data, mime_type=mime_type))
+                mime_value = part.get("mime_type")
+                mime_type = ImageMimeType(mime_value) if mime_value else None
+                artifacts.append(
+                    ImageArtifact(data=base64_data, url=uri, mime_type=mime_type)
+                )
 
         if not artifacts:
             return ImageArtifact()

--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -136,12 +136,16 @@ GOOGLE_GEMINI_MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Choice(
                 options=[
                     "1:1",
+                    "1:4",
+                    "1:8",
                     "2:3",
                     "3:2",
                     "3:4",
+                    "4:1",
                     "4:3",
                     "4:5",
                     "5:4",
+                    "8:1",
                     "9:16",
                     "16:9",
                     "21:9",

--- a/src/celeste/modalities/images/providers/google/vertex.py
+++ b/src/celeste/modalities/images/providers/google/vertex.py
@@ -6,6 +6,7 @@ from celeste.artifacts import ImageArtifact
 from celeste.core import UsageField
 from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
 from celeste.providers.google.generate_content import config
 from celeste.providers.google.generate_content.client import (
     GoogleGenerateContentClient as GoogleGenerateContentMixin,
@@ -17,15 +18,49 @@ from ...client import ImagesClient
 from ...io import ImageFinishReason, ImageInput
 from .parameters import GOOGLE_VERTEX_PARAMETER_MAPPERS
 
+_GLOBAL_ONLY_MODEL_IDS = frozenset(
+    {
+        "gemini-3-pro-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-lite-image",
+    }
+)
+
 
 class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
     """Google images client (Vertex / GenerateContent)."""
 
     _edit_endpoint = config.GoogleGenerateContentEndpoint.GENERATE_CONTENT
 
+    def model_post_init(self, __context: object) -> None:
+        """Enforce model-specific Vertex AI location availability."""
+        super().model_post_init(__context)
+        if (
+            self.model.id in _GLOBAL_ONLY_MODEL_IDS
+            and isinstance(self.auth, GoogleADC)
+            and self.auth.location != "global"
+        ):
+            raise ValueError(
+                f"{self.model.id} is only available in the global Vertex AI location"
+            )
+
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
         return GOOGLE_VERTEX_PARAMETER_MAPPERS
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Preserve billing metadata without retaining generated image content."""
+        metadata = super()._build_metadata(response_data)
+        web_query_count = 0
+        image_query_count = 0
+        for candidate in response_data.get("candidates", []):
+            grounding_metadata = candidate.get("groundingMetadata", {})
+            web_query_count += len(grounding_metadata.get("webSearchQueries") or [])
+            image_query_count += len(grounding_metadata.get("imageSearchQueries") or [])
+        if web_query_count or image_query_count:
+            metadata["raw_response"]["grounding_web_query_count"] = web_query_count
+            metadata["raw_response"]["grounding_image_query_count"] = image_query_count
+        return metadata
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
         """Initialize request for Gemini image generation/edit."""
@@ -51,13 +86,21 @@ class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
         """Parse usage from response."""
         usage = super()._parse_usage(response_data)
         candidates = response_data.get("candidates", [])
-        return {**usage, UsageField.NUM_IMAGES: len(candidates)}
+        num_images = sum(
+            1
+            for candidate in candidates
+            for part in candidate.get("content", {}).get("parts", [])
+            if not part.get("thought") and part.get("inlineData", {}).get("data")
+        )
+        return {**usage, UsageField.NUM_IMAGES: num_images}
 
     def _parse_content(
         self,
         response_data: dict[str, Any],
     ) -> ImageContent:
         """Parse image artifacts from Gemini candidates."""
+        if not response_data.get("candidates") and "promptFeedback" in response_data:
+            return ImageArtifact()
         candidates = super()._parse_content(response_data)
         artifacts: list[ImageArtifact] = []
 
@@ -84,8 +127,17 @@ class GoogleVertexImagesClient(GoogleGenerateContentMixin, ImagesClient):
         """Parse finish reason from response."""
         finish_reason = super()._parse_finish_reason(response_data)
         candidates = response_data.get("candidates", [])
-        finish_message = candidates[0].get("finishMessage") if candidates else None
-        return ImageFinishReason(reason=finish_reason.reason, message=finish_message)
+        if candidates:
+            finish_message = candidates[0].get("finishMessage")
+            return ImageFinishReason(
+                reason=finish_reason.reason, message=finish_message
+            )
+
+        prompt_feedback = response_data.get("promptFeedback", {})
+        return ImageFinishReason(
+            reason=prompt_feedback.get("blockReason"),
+            message=prompt_feedback.get("blockReasonMessage"),
+        )
 
 
 __all__ = ["GoogleVertexImagesClient"]

--- a/src/celeste/providers/google/imagen/client.py
+++ b/src/celeste/providers/google/imagen/client.py
@@ -89,7 +89,21 @@ class GoogleImagenClient(APIMixin):
         raise StreamingNotSupportedError(model_id=self.model.id)
 
     @staticmethod
-    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
+    def _is_image_prediction(prediction: dict[str, Any]) -> bool:
+        """Return whether a prediction contains a generated image artifact."""
+        return bool(prediction.get("bytesBase64Encoded"))
+
+    @classmethod
+    def _count_image_predictions(cls, predictions: list[dict[str, Any]]) -> int:
+        """Count successful images, excluding RAI-filtered predictions."""
+        return sum(
+            1 for prediction in predictions if cls._is_image_prediction(prediction)
+        )
+
+    @classmethod
+    def map_usage_fields(
+        cls, usage_data: dict[str, Any]
+    ) -> dict[str, int | float | None]:
         """Map Google Imagen usage fields to unified names.
 
         Shared by client and streaming across all capabilities.
@@ -97,7 +111,7 @@ class GoogleImagenClient(APIMixin):
         """
         predictions = usage_data.get("predictions", [])
         return {
-            UsageField.NUM_IMAGES: len(predictions),
+            UsageField.NUM_IMAGES: cls._count_image_predictions(predictions),
         }
 
     def _parse_usage(
@@ -106,6 +120,14 @@ class GoogleImagenClient(APIMixin):
         """Extract usage data from Imagen API response."""
         predictions = response_data.get("predictions", [])
         return GoogleImagenClient.map_usage_fields({"predictions": predictions})
+
+    def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Retain successful output count without retaining image payloads."""
+        metadata = super()._build_metadata(response_data)
+        metadata["raw_response"]["num_images"] = self._count_image_predictions(
+            response_data.get("predictions", [])
+        )
+        return metadata
 
     def _parse_content(self, response_data: dict[str, Any]) -> Any:
         """Parse predictions from response.

--- a/tests/unit_tests/test_google_image_models.py
+++ b/tests/unit_tests/test_google_image_models.py
@@ -1,0 +1,32 @@
+"""Unit tests for Google image model metadata."""
+
+from celeste.constraints import Choice
+from celeste.modalities.images.parameters import ImageParameter
+from celeste.modalities.images.providers.google.models import GOOGLE_GEMINI_MODELS
+
+
+def test_flash_lite_supports_all_documented_aspect_ratios() -> None:
+    model = next(
+        model
+        for model in GOOGLE_GEMINI_MODELS
+        if model.id == "gemini-3.1-flash-lite-image"
+    )
+    constraint = model.parameter_constraints[ImageParameter.ASPECT_RATIO]
+
+    assert isinstance(constraint, Choice)
+    assert constraint.options == [
+        "1:1",
+        "1:4",
+        "1:8",
+        "2:3",
+        "3:2",
+        "3:4",
+        "4:1",
+        "4:3",
+        "4:5",
+        "5:4",
+        "8:1",
+        "9:16",
+        "16:9",
+        "21:9",
+    ]

--- a/tests/unit_tests/test_google_imagen.py
+++ b/tests/unit_tests/test_google_imagen.py
@@ -1,0 +1,31 @@
+"""Tests for the existing Google Imagen generation path."""
+
+from celeste.artifacts import ImageArtifact
+from celeste.core import Provider
+from celeste.modalities.images.providers.google.client import GoogleImagesClient
+from celeste.modalities.images.providers.google.models import GOOGLE_IMAGEN_MODELS
+from celeste.providers.google.auth import GoogleADC
+
+
+def test_imagen_retains_only_successful_image_count() -> None:
+    client = GoogleImagesClient(
+        model=GOOGLE_IMAGEN_MODELS[0],
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p", location="us-central1"),
+    )
+    response = {
+        "deployedModelId": "served-model",
+        "predictions": [
+            {"mimeType": "image/png", "bytesBase64Encoded": "YWJj"},
+            {"raiFilteredReason": "Blocked by safety policy."},
+        ],
+    }
+
+    assert client._build_metadata(response)["raw_response"] == {
+        "deployedModelId": "served-model",
+        "num_images": 1,
+    }
+    assert client._parse_usage(response)["num_images"] == 1
+    content = client._parse_content(response)
+    assert isinstance(content, ImageArtifact)
+    assert content.data == b"abc"

--- a/tests/unit_tests/test_google_images_interactions.py
+++ b/tests/unit_tests/test_google_images_interactions.py
@@ -1,5 +1,6 @@
 """Unit tests for Google images provider Interactions/Vertex dispatch and wire shape."""
 
+import pytest
 from pydantic import SecretStr
 
 from celeste import Model
@@ -16,9 +17,9 @@ from celeste.modalities.images.providers.google.vertex import GoogleVertexImages
 from celeste.providers.google.auth import GoogleADC
 
 
-def _model() -> Model:
+def _model(model_id: str = "gemini-3.1-flash-image") -> Model:
     return Model(
-        id="gemini-3.1-flash-image",
+        id=model_id,
         provider=Provider.GOOGLE,
         display_name="Nano Banana 2",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
@@ -45,6 +46,43 @@ def test_google_adc_auth_dispatches_to_vertex_strategy() -> None:
     assert isinstance(client._strategy, GoogleVertexImagesClient)
     assert client._generate_endpoint == client._strategy._generate_endpoint
     assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "gemini-3-pro-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-lite-image",
+    ],
+)
+def test_vertex_global_only_image_models_reject_regional_adc(model_id: str) -> None:
+    with pytest.raises(ValueError, match="only available in the global"):
+        GoogleImagesClient(
+            model=_model(model_id),
+            provider=Provider.GOOGLE,
+            auth=GoogleADC(project_id="p", location="us-central1"),
+        )
+
+    client = GoogleImagesClient(
+        model=_model(model_id),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    assert isinstance(client._strategy, GoogleVertexImagesClient)
+
+
+def test_vertex_2_5_flash_image_allows_regional_adc() -> None:
+    client = GoogleImagesClient(
+        model=_model("gemini-2.5-flash-image"),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p", location="us-central1"),
+    )
+
+    assert isinstance(client._strategy, GoogleVertexImagesClient)
+    assert client._strategy._build_url(client._edit_endpoint).startswith(
+        "https://us-central1-aiplatform.googleapis.com/"
+    )
 
 
 def test_interactions_init_request_generate_is_text_only() -> None:
@@ -142,3 +180,208 @@ def test_interactions_parse_content_extracts_image_from_model_output_step() -> N
     assert isinstance(artifact, ImageArtifact)
     assert artifact.data == b"abc"
     assert artifact.mime_type == ImageMimeType.PNG
+
+
+def test_vertex_parses_and_counts_final_inline_image_parts() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"inlineData": {"data": "YWJj", "mimeType": "image/png"}},
+                        {
+                            "thought": True,
+                            "inlineData": {
+                                "data": "dGhvdWdodA==",
+                                "mimeType": "image/png",
+                            },
+                        },
+                        {"text": "Between images"},
+                        {
+                            "inlineData": {
+                                "data": "ZGVm",
+                                "mimeType": "image/jpeg",
+                            }
+                        },
+                    ]
+                }
+            },
+            {"finishReason": "SAFETY"},
+        ]
+    }
+
+    assert client._parse_usage(response_data)["num_images"] == 2
+
+    artifacts = client._parse_content(response_data)
+
+    assert isinstance(artifacts, list)
+    assert len(artifacts) == 2
+    assert artifacts[0].data == b"abc"
+    assert artifacts[0].mime_type == ImageMimeType.PNG
+    assert artifacts[1].data == b"def"
+    assert artifacts[1].mime_type == ImageMimeType.JPEG
+
+
+def test_vertex_prompt_feedback_without_candidates_returns_empty_artifact() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "promptFeedback": {
+            "blockReason": "SAFETY",
+            "blockReasonMessage": "The prompt was blocked for safety.",
+            "safetyRatings": [{"category": "HARM_CATEGORY_DANGEROUS_CONTENT"}],
+        }
+    }
+
+    artifact = client._parse_content(response_data)
+
+    assert isinstance(artifact, ImageArtifact)
+    assert not artifact.has_content
+    assert client._parse_usage(response_data)["num_images"] == 0
+    finish_reason = client._parse_finish_reason(response_data)
+    assert finish_reason.reason == "SAFETY"
+    assert finish_reason.message == "The prompt was blocked for safety."
+    assert client._build_metadata(response_data)["raw_response"] == response_data
+
+
+def test_vertex_metadata_retains_only_grounding_query_counts() -> None:
+    client = GoogleVertexImagesClient(
+        model=_model(),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="p"),
+    )
+    response_data = {
+        "responseId": "response-id",
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "inlineData": {
+                                "data": "c2Vuc2l0aXZl",
+                                "mimeType": "image/png",
+                            }
+                        }
+                    ]
+                },
+                "groundingMetadata": {
+                    "webSearchQueries": ["first query", "second query"],
+                    "imageSearchQueries": ["image query"],
+                    "groundingChunks": [{"web": {"uri": "https://example.com"}}],
+                },
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5},
+    }
+
+    metadata = client._build_metadata(response_data)
+
+    assert metadata["raw_response"] == {
+        "responseId": "response-id",
+        "usageMetadata": {"promptTokenCount": 5},
+        "grounding_web_query_count": 2,
+        "grounding_image_query_count": 1,
+    }
+
+
+def test_interactions_parses_and_counts_inline_and_uri_images() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    response_data = {
+        "status": "completed",
+        "steps": [
+            {
+                "type": "model_output",
+                "content": [
+                    {
+                        "type": "image",
+                        "data": "YWJj",
+                        "mime_type": "image/png",
+                    },
+                    {"type": "text", "text": "Between images"},
+                    {
+                        "type": "image",
+                        "uri": "https://example.com/generated.jpg",
+                    },
+                    {"type": "image"},
+                ],
+            }
+        ],
+    }
+
+    assert client._parse_usage(response_data)["num_images"] == 2
+
+    artifacts = client._parse_content(response_data)
+
+    assert isinstance(artifacts, list)
+    assert len(artifacts) == 2
+    assert artifacts[0].data == b"abc"
+    assert artifacts[0].url is None
+    assert artifacts[0].mime_type == ImageMimeType.PNG
+    assert artifacts[1].data is None
+    assert artifacts[1].url == "https://example.com/generated.jpg"
+    assert artifacts[1].mime_type is None
+
+
+def test_interactions_metadata_retains_only_executed_search_count() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    response_data = {
+        "id": "interaction-id",
+        "usage": {"total_tokens": 10},
+        "steps": [
+            {
+                "type": "google_search_call",
+                "arguments": {"queries": ["web query", "image query"]},
+                "result": {"sensitive": "provider payload"},
+            },
+            {
+                "type": "google_search_call",
+                "arguments": {"queries": ["second image query"]},
+            },
+            {
+                "type": "model_output",
+                "content": [
+                    {
+                        "type": "image",
+                        "data": "c2Vuc2l0aXZl",
+                        "mime_type": "image/png",
+                    }
+                ],
+            },
+        ],
+    }
+
+    metadata = client._build_metadata(response_data)
+
+    assert metadata["raw_response"] == {
+        "id": "interaction-id",
+        "usage": {"total_tokens": 10},
+        "grounding_query_count": 3,
+    }
+
+
+def test_interactions_metadata_emits_query_count_only_when_steps_are_present() -> None:
+    client = GoogleInteractionsImagesClient(
+        model=_model(), provider=Provider.GOOGLE, auth=_api_key_auth()
+    )
+    usage = {"grounding_tool_count": [{"type": "google_search", "count": 2}]}
+
+    omitted_steps = client._build_metadata({"usage": usage})
+    empty_steps = client._build_metadata({"usage": usage, "steps": []})
+
+    assert omitted_steps["raw_response"] == {"usage": usage}
+    assert empty_steps["raw_response"] == {
+        "usage": usage,
+        "grounding_query_count": 0,
+    }


### PR DESCRIPTION
## Scope

This PR only corrects models and image operations already represented in Celeste. It does **not** add Imagen upscaling, a new client, a new model registration, or a new operation. It supersedes closed PR #358 after removing all upscale-related code and tests.

## Summary

- update the existing `gemini-3.1-flash-lite-image` aspect-ratio constraint
- retain complete, compact image artifacts and grounding counts from the existing Developer Interactions and Vertex GenerateContent paths, including prompt-block and thought-image handling
- correct global Vertex routing for the three already-registered GA native-image models
- count only successful artifacts on the existing Imagen generation path and retain that compact count for billing

## Evidence

- [Gemini image generation](https://ai.google.dev/gemini-api/docs/image-generation)
- [Gemini model catalog](https://ai.google.dev/gemini-api/docs/models)
- [Interactions API](https://ai.google.dev/api/interactions-api-v1)
- [Imagen generation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images)
- [Vertex locations](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations)

## Validation

- 19 focused Google image tests passed
- 597 unit tests passed with 70.04% coverage
- Ruff lint and format checks passed
- mypy passed for `celeste` and tests
- Bandit, diff checks, commit hooks, and push hooks passed
- independent staged-diff review found no new capability or operation

## Coordination

Paired pricing draft: [withceleste/celeste-pricing#21](https://github.com/withceleste/celeste-pricing/pull/21). No Chat change is included until both dependency changes merge and publish.