### PR TITLE
Fix BytePlus Images model and response contracts

### DIFF
--- a/src/celeste/mime_types.py
+++ b/src/celeste/mime_types.py
@@ -23,6 +23,8 @@ class ImageMimeType(MimeType):
     BMP = "image/bmp"
     TIFF = "image/tiff"
     GIF = "image/gif"
+    HEIC = "image/heic"
+    HEIF = "image/heif"
 
 
 class VideoMimeType(MimeType):

--- a/src/celeste/modalities/images/providers/byteplus/client.py
+++ b/src/celeste/modalities/images/providers/byteplus/client.py
@@ -3,21 +3,30 @@
 from typing import Any, Unpack
 
 from celeste.artifacts import ImageArtifact
-from celeste.exceptions import ConstraintViolationError, ValidationError
+from celeste.exceptions import (
+    ConstraintViolationError,
+    StreamEventError,
+    ValidationError,
+)
 from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
 from celeste.providers.byteplus.images import config
 from celeste.providers.byteplus.images.client import (
     BytePlusImagesClient as BytePlusImagesMixin,
 )
+from celeste.providers.byteplus.images.client import (
+    image_item_metadata,
+)
 from celeste.providers.byteplus.images.streaming import (
     BytePlusImagesStream as _BytePlusImagesStream,
 )
 from celeste.types import ImageContent
+from celeste.utils import build_data_url, detect_mime_type
 
 from ...client import ImagesClient
 from ...io import (
     ImageChunk,
+    ImageFinishReason,
     ImageInput,
     ImageUsage,
 )
@@ -26,16 +35,31 @@ from ...streaming import ImagesStream
 from .parameters import BYTEPLUS_PARAMETER_MAPPERS
 
 
+def _image_mime_type(item: dict[str, Any]) -> ImageMimeType | None:
+    return {
+        "jpeg": ImageMimeType.JPEG,
+        "png": ImageMimeType.PNG,
+    }.get(str(item.get("output_format", "")).lower())
+
+
 class BytePlusImagesStream(_BytePlusImagesStream, ImagesStream):
     """BytePlus streaming for images modality."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._completed_usage: ImageUsage | None = None
+        self._completed_finish_reason: ImageFinishReason | None = None
         self._completed_event_data: dict[str, Any] | None = None
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> ImageChunk | None:
         """Parse one SSE event into a typed chunk."""
+        stream_error = self._parse_stream_error(event_data)
+        if stream_error and (
+            not self._is_error_event(event_data)
+            or stream_error.get("type") == "InternalServiceError"
+        ):
+            return super()._parse_chunk(event_data)
+
         # Handle error events (partial_failed)
         if self._is_error_event(event_data):
             error = self._parse_chunk_error(event_data)
@@ -46,10 +70,17 @@ class BytePlusImagesStream(_BytePlusImagesStream, ImagesStream):
                 metadata={"event_data": event_data, "error": error},
             )
 
-        # Handle completed event (usage only)
         usage = self._get_chunk_usage(event_data)
-        if usage is not None:
+        finish_reason = self._get_chunk_finish_reason(event_data)
+        if finish_reason is not None:
+            if usage is None or usage.num_images is None:
+                raise StreamEventError(
+                    "image_generation.completed is missing usage.generated_images",
+                    error_type="invalid_completion",
+                    event_data=event_data,
+                )
             self._completed_usage = usage
+            self._completed_finish_reason = finish_reason
             self._completed_event_data = event_data
             return None
 
@@ -59,41 +90,72 @@ class BytePlusImagesStream(_BytePlusImagesStream, ImagesStream):
             return None
 
         content_type = self._parse_chunk_content_type(event_data)
+        metadata = image_item_metadata(event_data)
+        mime_type = _image_mime_type(event_data)
         if content_type == "url":
-            artifact = ImageArtifact(url=content, mime_type=ImageMimeType.PNG)
+            artifact = ImageArtifact(
+                url=content,
+                mime_type=mime_type,
+                metadata=metadata,
+            )
         else:  # b64_json
-            artifact = ImageArtifact(data=content)
+            artifact = ImageArtifact(
+                data=content,
+                mime_type=mime_type,
+                metadata=metadata,
+            )
+            if artifact.mime_type is None:
+                detected = detect_mime_type(artifact.data or b"")
+                if isinstance(detected, ImageMimeType):
+                    artifact.mime_type = detected
 
         return ImageChunk(
             content=artifact,
-            finish_reason=self._get_chunk_finish_reason(event_data),
+            finish_reason=finish_reason,
             usage=None,
-            metadata={"event_data": event_data},
+            metadata={"event_data": metadata},
         )
 
-    def _aggregate_content(self, chunks: list[ImageChunk]) -> ImageArtifact:
-        """Aggregate image content from chunks."""
-        return chunks[-1].content
+    def _aggregate_content(self, chunks: list[ImageChunk]) -> ImageContent:
+        """Aggregate every successful complete image in provider index order."""
+        if self._completed_event_data is None:
+            raise StreamEventError(
+                "BytePlus image stream ended before image_generation.completed",
+                error_type="incomplete_stream",
+            )
+        images = [chunk.content for chunk in chunks if chunk.content.has_content]
+        images.sort(
+            key=lambda image: (
+                image.metadata.get("image_index")
+                if isinstance(image.metadata.get("image_index"), int)
+                else float("inf")
+            )
+        )
+        return images[0] if len(images) == 1 else images
 
     def _aggregate_usage(self, chunks: list[ImageChunk]) -> ImageUsage:
         """Override: Use usage from completed event."""
-        if self._completed_usage is not None:
-            return self._completed_usage
-        return super()._aggregate_usage(chunks)
+        return self._completed_usage or ImageUsage()
+
+    def _aggregate_finish_reason(
+        self, chunks: list[ImageChunk]
+    ) -> ImageFinishReason | None:
+        """Use the terminal completion event's finish state."""
+        return self._completed_finish_reason
 
     def _aggregate_event_data(self, chunks: list[ImageChunk]) -> list[dict[str, Any]]:
-        """Prepend completed_event_data, then delegate to base."""
-        events: list[dict[str, Any]] = []
+        """Keep provider event order, including the filtered completion event."""
+        events = super()._aggregate_event_data(chunks)
         if self._completed_event_data is not None:
             events.append(self._completed_event_data)
-        events.extend(super()._aggregate_event_data(chunks))
         return events
 
 
 class BytePlusImagesClient(BytePlusImagesMixin, ImagesClient):
-    """BytePlus images client (generate + streaming)."""
+    """BytePlus image generation and editing client."""
 
     _generate_endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
+    _edit_endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[ImageContent]]:
@@ -101,58 +163,87 @@ class BytePlusImagesClient(BytePlusImagesMixin, ImagesClient):
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
         """Initialize request from BytePlus API structure."""
-        return {
+        request = {
             "prompt": inputs.prompt,
             "response_format": "url",
         }
+        if inputs.image is not None:
+            request["image"] = build_data_url(inputs.image)
+        return request
 
     def _parse_content(
         self,
         response_data: dict[str, Any],
-    ) -> ImageArtifact:
-        """Parse content from response."""
+    ) -> ImageContent:
+        """Parse every successful image while preserving provider order and metadata."""
+        if isinstance(error := response_data.get("error"), dict):
+            code = error.get("code")
+            message = error.get("message", "Unknown error")
+            detail = f"{code}: {message}" if code else str(message)
+            raise ValidationError(f"BytePlus image generation error: {detail}")
         content = super()._parse_content(response_data)
         if not content:
             msg = "No image content found in BytePlus response"
             raise ValidationError(msg)
 
-        image_data = content[0]
-        if image_data.get("url"):
-            return ImageArtifact(
-                url=image_data["url"],
-                mime_type=ImageMimeType.PNG,
-            )
-        if image_data.get("b64_json"):
-            return ImageArtifact(
-                data=image_data["b64_json"],
-                mime_type=ImageMimeType.PNG,
-            )
+        images: list[ImageArtifact] = []
+        for image_data in content:
+            metadata = image_item_metadata(image_data)
+            mime_type = _image_mime_type(image_data)
+            if image_data.get("url"):
+                images.append(
+                    ImageArtifact(
+                        url=image_data["url"],
+                        mime_type=mime_type,
+                        metadata=metadata,
+                    )
+                )
+            elif image_data.get("b64_json"):
+                artifact = ImageArtifact(
+                    data=image_data["b64_json"],
+                    mime_type=mime_type,
+                    metadata=metadata,
+                )
+                if artifact.mime_type is None:
+                    detected = detect_mime_type(artifact.data or b"")
+                    if isinstance(detected, ImageMimeType):
+                        artifact.mime_type = detected
+                images.append(artifact)
+            elif not image_data.get("error"):
+                msg = "No image URL or base64 data in BytePlus response item"
+                raise ValidationError(msg)
 
-        msg = "No image URL or base64 data in BytePlus response"
-        raise ValidationError(msg)
+        if not images and not all(image.get("error") for image in content):
+            msg = "No successful images found in BytePlus response"
+            raise ValidationError(msg)
+        return images[0] if len(images) == 1 else images
 
-    async def _make_request(
+    def _build_request(
         self,
-        request_body: dict[str, Any],
-        *,
-        endpoint: str | None = None,
-        extra_headers: dict[str, str] | None = None,
+        inputs: ImageInput,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
         **parameters: Unpack[ImageParameters],
     ) -> dict[str, Any]:
-        """Make HTTP request with parameter validation."""
-        # Validate mutually exclusive parameters
-        if parameters.get("aspect_ratio") and parameters.get("quality"):
+        """Build a request while preserving BytePlus size-field exclusivity."""
+        if (
+            parameters.get("aspect_ratio") is not None
+            and parameters.get("quality") is not None
+        ):
             msg = (
                 "Cannot use both 'aspect_ratio' and 'quality' parameters. "
                 "BytePlus's 'size' field supports two methods that cannot be combined:\n"
-                "  • quality: Resolution class ('1K', '2K', '4K')\n"
-                "  • aspect_ratio: Exact dimensions (e.g., '2048x2048', '3840x2160')\n"
+                "  • quality: Resolution class (for example, '1K' or '2K')\n"
+                "  • aspect_ratio: Exact dimensions (for example, '2048x2048')\n"
                 "Use one or the other, not both."
             )
             raise ConstraintViolationError(msg)
 
-        return await super()._make_request(
-            request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
+        return super()._build_request(
+            inputs,
+            extra_body=extra_body,
+            streaming=streaming,
+            **parameters,
         )
 
     def _stream_class(self) -> type[ImagesStream]:

--- a/src/celeste/modalities/images/providers/byteplus/models.py
+++ b/src/celeste/modalities/images/providers/byteplus/models.py
@@ -1,6 +1,6 @@
 """BytePlus models for images modality."""
 
-from celeste.constraints import Bool, Choice, Dimensions
+from celeste.constraints import Bool, Choice, Dimensions, ImagesConstraint
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
@@ -11,7 +11,7 @@ MODELS: list[Model] = [
         id="seedream-4-0-250828",
         provider=Provider.BYTEPLUS,
         display_name="Seedream 4.0",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         streaming=True,
         parameter_constraints={
             ImageParameter.ASPECT_RATIO: Dimensions(
@@ -48,13 +48,50 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["1K", "2K", "4K"]),
             ImageParameter.WATERMARK: Bool(),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
+        },
+    ),
+    Model(
+        id="seedream-4-5-251128",
+        provider=Provider.BYTEPLUS,
+        display_name="Seedream 4.5",
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        streaming=True,
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Dimensions(
+                min_pixels=2560 * 1440,  # 3,686,400
+                max_pixels=4096 * 4096,  # 16,777,216
+                min_aspect_ratio=1 / 16,
+                max_aspect_ratio=16,
+                presets={
+                    "2K 1:1": "2048x2048",
+                    "2K 3:4": "1728x2304",
+                    "2K 4:3": "2304x1728",
+                    "2K 16:9": "2848x1600",
+                    "2K 9:16": "1600x2848",
+                    "2K 3:2": "2496x1664",
+                    "2K 2:3": "1664x2496",
+                    "2K 21:9": "3136x1344",
+                    "4K 1:1": "4096x4096",
+                    "4K 3:4": "3520x4704",
+                    "4K 4:3": "4704x3520",
+                    "4K 16:9": "5504x3040",
+                    "4K 9:16": "3040x5504",
+                    "4K 2:3": "3328x4992",
+                    "4K 3:2": "4992x3328",
+                    "4K 21:9": "6240x2656",
+                },
+            ),
+            ImageParameter.QUALITY: Choice(options=["2K", "4K"]),
+            ImageParameter.WATERMARK: Bool(),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
         },
     ),
     Model(
         id="seedream-5-0-260128",
         provider=Provider.BYTEPLUS,
         display_name="Seedream 5.0 Lite",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         streaming=True,
         parameter_constraints={
             ImageParameter.ASPECT_RATIO: Dimensions(
@@ -91,13 +128,15 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["2K", "3K", "4K"]),
             ImageParameter.WATERMARK: Bool(),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=14),
         },
     ),
     Model(
         id="dola-seedream-5-0-pro-260628",
         provider=Provider.BYTEPLUS,
         display_name="Seedream 5.0 Pro",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         streaming=False,
         parameter_constraints={
             ImageParameter.ASPECT_RATIO: Dimensions(
@@ -110,23 +149,43 @@ MODELS: list[Model] = [
                     "1K 1:1": "1024x1024",
                     "1K 4:3": "1152x864",
                     "1K 3:4": "864x1152",
-                    "1K 16:9": "1312x736",
-                    "1K 9:16": "736x1312",
+                    "1K 16:9": "1424x800",
+                    "1K 9:16": "800x1424",
                     "1K 3:2": "1248x832",
                     "1K 2:3": "832x1248",
                     "1K 21:9": "1568x672",
+                    "1.5K 1:1": "1536x1536",
+                    "1.5K 4:3": "1792x1344",
+                    "1.5K 3:4": "1344x1792",
+                    "1.5K 16:9": "2048x1152",
+                    "1.5K 9:16": "1152x2048",
+                    "1.5K 3:2": "1872x1248",
+                    "1.5K 2:3": "1248x1872",
+                    "1.5K 21:9": "2352x1008",
                     "2K 1:1": "2048x2048",
-                    "2K 4:3": "2304x1728",
-                    "2K 3:4": "1728x2304",
-                    "2K 16:9": "2848x1600",
-                    "2K 9:16": "1600x2848",
+                    "2K 4:3": "2368x1776",
+                    "2K 3:4": "1776x2368",
+                    "2K 16:9": "2816x1584",
+                    "2K 9:16": "1584x2816",
                     "2K 3:2": "2496x1664",
                     "2K 2:3": "1664x2496",
                     "2K 21:9": "3136x1344",
                 },
             ),
-            ImageParameter.QUALITY: Choice(options=["1K", "2K"]),
+            ImageParameter.QUALITY: Choice(options=["1K", "1.5K", "2K"]),
             ImageParameter.WATERMARK: Bool(),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png"]),
+            ImageParameter.BACKGROUND: Choice(options=["opaque", "transparent"]),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),
 ]
+
+MODELS.append(
+    next(model for model in MODELS if model.id == "seedream-5-0-260128").model_copy(
+        update={
+            "id": "seedream-5-0-lite-260128",
+            "display_name": "Seedream 5.0 Lite (alias)",
+        }
+    )
+)

--- a/src/celeste/modalities/images/providers/byteplus/parameters.py
+++ b/src/celeste/modalities/images/providers/byteplus/parameters.py
@@ -1,6 +1,17 @@
 """BytePlus parameter mappers for images modality."""
 
+from typing import Any
+
+from celeste.constraints import ImagesConstraint
+from celeste.exceptions import ConstraintViolationError
+from celeste.models import Model
 from celeste.parameters import ParameterMapper
+from celeste.providers.byteplus.images.parameters import (
+    BackgroundMapper as _BackgroundMapper,
+)
+from celeste.providers.byteplus.images.parameters import (
+    OutputFormatMapper as _OutputFormatMapper,
+)
 from celeste.providers.byteplus.images.parameters import (
     SizeMapper as _SizeMapper,
 )
@@ -8,6 +19,7 @@ from celeste.providers.byteplus.images.parameters import (
     WatermarkMapper as _WatermarkMapper,
 )
 from celeste.types import ImageContent
+from celeste.utils import build_data_url
 
 from ...parameters import ImageParameter
 
@@ -17,7 +29,7 @@ class AspectRatioMapper(_SizeMapper):
 
 
 class QualityMapper(_SizeMapper):
-    """Map quality to BytePlus size field with conflict resolution."""
+    """Map quality to BytePlus size field."""
 
     name = ImageParameter.QUALITY
 
@@ -26,10 +38,58 @@ class WatermarkMapper(_WatermarkMapper):
     name = ImageParameter.WATERMARK
 
 
+class OutputFormatMapper(_OutputFormatMapper):
+    name = ImageParameter.OUTPUT_FORMAT
+
+
+class BackgroundMapper(_BackgroundMapper):
+    name = ImageParameter.BACKGROUND
+
+
+class ReferenceImagesMapper(ParameterMapper[ImageContent]):
+    name = ImageParameter.REFERENCE_IMAGES
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Append ordered reference images to the primary edit image, when present."""
+        references = self._validate_value(value, model)
+        if not references:
+            return request
+
+        current = request.get("image")
+        constraint = model.parameter_constraints.get(self.name)
+        current_count = (
+            0 if current is None else (1 if isinstance(current, str) else len(current))
+        )
+        if (
+            isinstance(constraint, ImagesConstraint)
+            and constraint.max_count is not None
+            and current_count + len(references) > constraint.max_count
+        ):
+            msg = f"BytePlus accepts at most {constraint.max_count} total input images"
+            raise ConstraintViolationError(msg)
+
+        images = (
+            []
+            if current is None
+            else ([current] if isinstance(current, str) else list(current))
+        )
+        images.extend(build_data_url(image) for image in references)
+        request["image"] = images[0] if len(images) == 1 else images
+        return request
+
+
 BYTEPLUS_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     AspectRatioMapper(),
     QualityMapper(),
     WatermarkMapper(),
+    OutputFormatMapper(),
+    BackgroundMapper(),
+    ReferenceImagesMapper(),
 ]
 
 __all__ = ["BYTEPLUS_PARAMETER_MAPPERS"]

--- a/src/celeste/modalities/images/streaming.py
+++ b/src/celeste/modalities/images/streaming.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from celeste.artifacts import ImageArtifact
 from celeste.streaming import Stream
+from celeste.types import ImageContent
 
 from .io import ImageChunk, ImageFinishReason, ImageOutput, ImageUsage
 from .parameters import ImageParameters
@@ -24,7 +25,7 @@ class ImagesStream(Stream[ImageOutput, ImageParameters, ImageChunk]):
         return ImageArtifact(data=raw_content)
 
     @abstractmethod
-    def _aggregate_content(self, chunks: list[ImageChunk]) -> ImageArtifact:
+    def _aggregate_content(self, chunks: list[ImageChunk]) -> ImageContent:
         """Aggregate content from chunks into raw content (modality-specific)."""
         ...
 

--- a/src/celeste/providers/byteplus/images/client.py
+++ b/src/celeste/providers/byteplus/images/client.py
@@ -9,6 +9,15 @@ from celeste.io import FinishReason
 
 from . import config
 
+_IMAGE_PAYLOAD_FIELDS = {"b64_json", "url"}
+
+
+def image_item_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    """Return provider item metadata without retaining the image payload."""
+    return {
+        key: value for key, value in item.items() if key not in _IMAGE_PAYLOAD_FIELDS
+    }
+
 
 class BytePlusImagesClient(APIMixin):
     """Mixin for BytePlus Images API capabilities.
@@ -60,7 +69,7 @@ class BytePlusImagesClient(APIMixin):
         headers = self._json_headers(extra_headers)
 
         response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
+            f"{(self.base_url or config.BASE_URL).rstrip('/')}{endpoint}",
             headers=headers,
             json_body=request_body,
         )
@@ -83,7 +92,7 @@ class BytePlusImagesClient(APIMixin):
         headers = self._json_headers(extra_headers)
 
         return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
+            f"{(self.base_url or config.BASE_URL).rstrip('/')}{endpoint}",
             headers=headers,
             json_body=request_body,
         )
@@ -131,12 +140,21 @@ class BytePlusImagesClient(APIMixin):
         return FinishReason(reason=None)
 
     def _build_metadata(self, response_data: dict[str, Any]) -> Any:
-        """Build metadata dictionary, extracting seed if present."""
+        """Build metadata without retaining URL or base64 image payloads."""
         metadata = super()._build_metadata(response_data)
+        raw_response = metadata["raw_response"]
+        for field in self._content_fields:
+            items = response_data.get(field)
+            if isinstance(items, list):
+                raw_response[field] = [
+                    image_item_metadata(item)
+                    for item in items
+                    if isinstance(item, dict)
+                ]
         seed = response_data.get("seed")
         if seed is not None:
             metadata["seed"] = seed
         return metadata
 
 
-__all__ = ["BytePlusImagesClient"]
+__all__ = ["BytePlusImagesClient", "image_item_metadata"]

--- a/src/celeste/providers/byteplus/images/config.py
+++ b/src/celeste/providers/byteplus/images/config.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 class BytePlusImagesEndpoint(StrEnum):
     """Endpoints for BytePlus Images API."""
 
-    CREATE_IMAGE = "/api/v3/images/generations"
+    CREATE_IMAGE = "/images/generations"
 
 
-BASE_URL = "https://ark.ap-southeast.bytepluses.com"
+BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"

--- a/src/celeste/providers/byteplus/images/parameters.py
+++ b/src/celeste/providers/byteplus/images/parameters.py
@@ -16,4 +16,21 @@ class WatermarkMapper(FieldMapper[ImageContent]):
     field = "watermark"
 
 
-__all__ = ["SizeMapper", "WatermarkMapper"]
+class OutputFormatMapper(FieldMapper[ImageContent]):
+    """Map output format to BytePlus output_format field."""
+
+    field = "output_format"
+
+
+class BackgroundMapper(FieldMapper[ImageContent]):
+    """Map background handling to BytePlus background field."""
+
+    field = "background"
+
+
+__all__ = [
+    "BackgroundMapper",
+    "OutputFormatMapper",
+    "SizeMapper",
+    "WatermarkMapper",
+]

--- a/tests/unit_tests/test_byteplus_images.py
+++ b/tests/unit_tests/test_byteplus_images.py
@@ -1,0 +1,353 @@
+"""BytePlus Images request, response, and stream contracts."""
+
+import base64
+from collections.abc import AsyncIterator
+from typing import Any, ClassVar
+
+import pytest
+from pydantic import SecretStr
+
+from celeste.artifacts import ImageArtifact
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.exceptions import (
+    ConstraintViolationError,
+    StreamEventError,
+    ValidationError,
+)
+from celeste.mime_types import ImageMimeType
+from celeste.modalities.images.io import ImageInput
+from celeste.modalities.images.parameters import ImageParameter
+from celeste.modalities.images.providers.byteplus.client import (
+    BytePlusImagesClient,
+    BytePlusImagesStream,
+)
+from celeste.modalities.images.providers.byteplus.models import MODELS
+from celeste.models import Model
+from celeste.providers.byteplus.images import config
+
+_MODELS = {model.id: model for model in MODELS}
+_LITE = _MODELS["seedream-5-0-260128"]
+_LITE_ALIAS = _MODELS["seedream-5-0-lite-260128"]
+_PRO = _MODELS["dola-seedream-5-0-pro-260628"]
+
+
+def _client(
+    model: Model = _LITE, *, base_url: str | None = None
+) -> BytePlusImagesClient:
+    return BytePlusImagesClient(
+        model=model,
+        provider=Provider.BYTEPLUS,
+        auth=AuthHeader(secret=SecretStr("test")),
+        base_url=base_url,
+    )
+
+
+async def _events(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+def test_catalog_matches_current_seedream_image_operations() -> None:
+    assert set(_MODELS) == {
+        "seedream-4-0-250828",
+        "seedream-4-5-251128",
+        "seedream-5-0-260128",
+        "seedream-5-0-lite-260128",
+        "dola-seedream-5-0-pro-260628",
+    }
+    assert all(
+        model.operations[Modality.IMAGES] == {Operation.GENERATE, Operation.EDIT}
+        for model in MODELS
+    )
+    assert _PRO.streaming is False
+    assert _PRO.parameter_constraints[ImageParameter.QUALITY].options == [
+        "1K",
+        "1.5K",
+        "2K",
+    ]
+
+
+def test_lite_alias_keeps_its_exact_wire_identity() -> None:
+    request = _client(_LITE_ALIAS)._build_request(ImageInput(prompt="generate"))
+
+    assert request["model"] == "seedream-5-0-lite-260128"
+
+
+def test_edit_serializes_primary_then_ordered_references() -> None:
+    primary = ImageArtifact(data=b"primary", mime_type=ImageMimeType.PNG)
+    reference = ImageArtifact(url="https://example.com/reference.jpg")
+
+    request = _client(_PRO)._build_request(
+        ImageInput(prompt="edit", image=primary),
+        reference_images=[reference],
+        output_format="png",
+        background="transparent",
+    )
+
+    assert request["image"] == [
+        f"data:image/png;base64,{base64.b64encode(b'primary').decode()}",
+        reference.url,
+    ]
+    assert request["output_format"] == "png"
+    assert request["background"] == "transparent"
+
+
+def test_edit_enforces_total_input_image_limit() -> None:
+    primary = ImageArtifact(url="https://example.com/primary.png")
+    references = [
+        ImageArtifact(url=f"https://example.com/reference-{index}.png")
+        for index in range(10)
+    ]
+
+    with pytest.raises(ConstraintViolationError, match="at most 10 total"):
+        _client(_PRO)._build_request(
+            ImageInput(prompt="edit", image=primary),
+            reference_images=references,
+        )
+
+
+def test_empty_reference_images_leave_generation_request_unchanged() -> None:
+    request = _client()._build_request(
+        ImageInput(prompt="generate"), reference_images=[]
+    )
+
+    assert "image" not in request
+
+
+def test_size_class_and_exact_dimensions_are_mutually_exclusive_when_streaming() -> (
+    None
+):
+    with pytest.raises(ConstraintViolationError, match="Cannot use both"):
+        _client()._build_request(
+            ImageInput(prompt="generate"),
+            streaming=True,
+            aspect_ratio="2048x2048",
+            quality="2K",
+        )
+
+
+def test_unary_response_preserves_all_successes_mime_and_item_metadata() -> None:
+    client = _client()
+    response = {
+        "data": [
+            {
+                "url": "https://example.com/first.jpg",
+                "size": "2048x2048",
+                "output_format": "jpeg",
+            },
+            {"error": {"code": "OutputImageSensitiveContentDetected"}},
+            {
+                "b64_json": base64.b64encode(b"second").decode(),
+                "size": "1024x1024",
+                "output_format": "png",
+                "z_index": 1,
+            },
+        ],
+        "usage": {"generated_images": 2},
+    }
+
+    content = client._parse_content(response)
+    assert isinstance(content, list)
+    assert [image.mime_type for image in content] == [
+        ImageMimeType.JPEG,
+        ImageMimeType.PNG,
+    ]
+    assert content[1].metadata["z_index"] == 1
+
+    raw = client._build_metadata(response)["raw_response"]
+    assert raw["data"][0] == {"size": "2048x2048", "output_format": "jpeg"}
+    assert raw["data"][1]["error"]["code"] == "OutputImageSensitiveContentDetected"
+    assert "b64_json" not in raw["data"][2]
+
+
+def test_unary_all_item_failures_return_an_empty_collection() -> None:
+    client = _client()
+    response = {
+        "data": [
+            {"error": {"code": "OutputImageSensitiveContentDetected"}},
+            {"error": {"code": "OutputImageSensitiveContentDetected"}},
+        ],
+        "usage": {"generated_images": 0},
+    }
+
+    assert client._parse_content(response) == []
+    assert len(client._build_metadata(response)["raw_response"]["data"]) == 2
+
+
+def test_unary_top_level_error_preserves_provider_details() -> None:
+    with pytest.raises(ValidationError, match="InvalidParameter: bad request"):
+        _client()._parse_content(
+            {
+                "error": {
+                    "code": "InvalidParameter",
+                    "message": "bad request",
+                }
+            }
+        )
+
+
+async def test_stream_aggregates_complete_images_by_index_and_retains_failures() -> (
+    None
+):
+    events = [
+        {
+            "type": "image_generation.partial_image",
+            "partial_image_index": 0,
+            "b64_json": base64.b64encode(b"preview").decode(),
+        },
+        {
+            "type": "image_generation.partial_succeeded",
+            "image_index": 1,
+            "b64_json": base64.b64encode(b"second").decode(),
+            "size": "1024x1024",
+            "output_format": "png",
+        },
+        {
+            "type": "image_generation.partial_failed",
+            "image_index": 2,
+            "error": {"code": "sensitive", "message": "blocked"},
+        },
+        {
+            "type": "image_generation.partial_succeeded",
+            "image_index": 0,
+            "url": "https://example.com/first.png",
+            "size": "1024x1024",
+            "output_format": "png",
+        },
+        {
+            "type": "image_generation.completed",
+            "usage": {"generated_images": 2, "output_tokens": 8192},
+        },
+    ]
+    stream = BytePlusImagesStream(_events(events))
+
+    chunks = [chunk async for chunk in stream]
+
+    assert len(chunks) == 3
+    assert isinstance(stream.output.content, list)
+    assert stream.output.content[0].url == "https://example.com/first.png"
+    assert stream.output.content[1].data == b"second"
+    assert all(image.mime_type is ImageMimeType.PNG for image in stream.output.content)
+    assert [image.metadata["image_index"] for image in stream.output.content] == [0, 1]
+    assert stream.output.usage.num_images == 2
+    assert stream.output.finish_reason is not None
+    assert stream.output.finish_reason.reason == "completed"
+    raw_events = stream.output.metadata["raw_events"]
+    assert raw_events[0]["image_index"] == 2
+    assert raw_events[0]["error"]["code"] == "sensitive"
+    assert stream.output.metadata["raw_response"]["usage"]["generated_images"] == 2
+    assert all("b64_json" not in chunk.metadata["event_data"] for chunk in chunks)
+
+
+@pytest.mark.parametrize("event_type", ["error", "image_generation.completed"])
+async def test_stream_raises_request_level_errors(event_type: str) -> None:
+    stream = BytePlusImagesStream(
+        _events(
+            [
+                {
+                    "type": event_type,
+                    "error": {"code": "invalid_request", "message": "bad request"},
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(StreamEventError, match="bad request"):
+        _ = [chunk async for chunk in stream]
+
+
+async def test_stream_internal_partial_failure_is_terminal() -> None:
+    stream = BytePlusImagesStream(
+        _events(
+            [
+                {
+                    "type": "image_generation.partial_failed",
+                    "error": {
+                        "code": "InternalServiceError",
+                        "message": "try again",
+                    },
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(StreamEventError, match="try again"):
+        _ = [chunk async for chunk in stream]
+
+
+async def test_stream_requires_terminal_completion_event() -> None:
+    stream = BytePlusImagesStream(
+        _events(
+            [
+                {
+                    "type": "image_generation.partial_succeeded",
+                    "image_index": 0,
+                    "url": "https://example.com/truncated.png",
+                    "size": "1024x1024",
+                    "output_format": "png",
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(StreamEventError, match=r"before image_generation\.completed"):
+        _ = [chunk async for chunk in stream]
+
+
+async def test_stream_completion_requires_billable_usage() -> None:
+    stream = BytePlusImagesStream(
+        _events(
+            [
+                {
+                    "type": "image_generation.partial_succeeded",
+                    "image_index": 0,
+                    "url": "https://example.com/output.png",
+                    "size": "1024x1024",
+                },
+                {"type": "image_generation.completed"},
+            ]
+        )
+    )
+
+    with pytest.raises(StreamEventError, match=r"usage\.generated_images"):
+        _ = [chunk async for chunk in stream]
+
+
+class _Response:
+    is_success = True
+
+    def json(self) -> dict[str, Any]:
+        return {"data": [{"url": "https://example.com/output.png"}]}
+
+
+class _HTTPClient:
+    def __init__(self) -> None:
+        self.url: str | None = None
+
+    async def post(self, url: str, **_: object) -> _Response:
+        self.url = url
+        return _Response()
+
+
+class _RegionalClient(BytePlusImagesClient):
+    test_http_client: ClassVar[_HTTPClient] = _HTTPClient()
+
+    @property
+    def http_client(self) -> _HTTPClient:
+        return self.test_http_client
+
+
+async def test_custom_region_base_url_is_used() -> None:
+    client = _RegionalClient(
+        model=_LITE,
+        provider=Provider.BYTEPLUS,
+        auth=AuthHeader(secret=SecretStr("test")),
+        base_url="https://ark.eu-west.bytepluses.com/api/v3",
+    )
+
+    await client._make_request({}, endpoint=config.BytePlusImagesEndpoint.CREATE_IMAGE)
+
+    assert client.test_http_client.url == (
+        "https://ark.eu-west.bytepluses.com/api/v3/images/generations"
+    )

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -13,6 +13,7 @@ from celeste.modalities.audio.providers.mistral import parameters as mistral_aud
 from celeste.modalities.audio.providers.openai import parameters as openai_audio
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.bfl import parameters as bfl
+from celeste.modalities.images.providers.byteplus import parameters as byteplus_images
 from celeste.modalities.images.providers.google import parameters as google_images
 from celeste.modalities.images.providers.topazlabs import parameters as topazlabs
 from celeste.modalities.segmentation.parameters import SegmentationParameter
@@ -55,6 +56,7 @@ GROQ = groq.GROQ_PARAMETER_MAPPERS
 BYTEPLUS = byteplus.BYTEPLUS_PARAMETER_MAPPERS
 XAI = xai.XAI_PARAMETER_MAPPERS
 BFL = bfl.BFL_PARAMETER_MAPPERS
+BYTEPLUS_IMAGES = byteplus_images.BYTEPLUS_PARAMETER_MAPPERS
 TOPAZ = topazlabs.TOPAZLABS_PARAMETER_MAPPERS
 FAL = fal.FAL_PARAMETER_MAPPERS
 T, IP, V, AP, SP = (
@@ -130,6 +132,11 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (IMAGES_IMAGEN, IP.ASPECT_RATIO, "16:9", ("parameters", "aspectRatio"), "16:9"),
         (IMAGES_IMAGEN, IP.QUALITY, "2K", ("parameters", "imageSize"), "2K"),
         (IMAGES_IMAGEN, IP.NUM_IMAGES, 2, ("parameters", "sampleCount"), 2),
+        (BYTEPLUS_IMAGES, IP.ASPECT_RATIO, "2048x2048", ("size",), "2048x2048"),
+        (BYTEPLUS_IMAGES, IP.QUALITY, "2K", ("size",), "2K"),
+        (BYTEPLUS_IMAGES, IP.WATERMARK, False, ("watermark",), False),
+        (BYTEPLUS_IMAGES, IP.OUTPUT_FORMAT, "png", ("output_format",), "png"),
+        (BYTEPLUS_IMAGES, IP.BACKGROUND, "transparent", ("background",), "transparent"),
         (
             AUDIO_GOOGLE,
             AP.VOICE,
@@ -314,6 +321,7 @@ def test_scalar_parameters_use_provider_wire_shape(
         MOONSHOT,
         GROQ,
         BYTEPLUS,
+        BYTEPLUS_IMAGES,
         XAI,
         BFL,
         TOPAZ,
@@ -473,6 +481,16 @@ def test_bfl_reference_images_follow_primary_image_numbering() -> None:
         [IMAGE],
         {"input_image": "primary"},
     ) == {"input_image": "primary", "input_image_2": IMAGE.url}
+
+
+def test_byteplus_reference_images_follow_primary_order() -> None:
+    assert _map(BYTEPLUS_IMAGES, IP.REFERENCE_IMAGES, [IMAGE]) == {"image": IMAGE.url}
+    assert _map(
+        BYTEPLUS_IMAGES,
+        IP.REFERENCE_IMAGES,
+        [IMAGE],
+        {"image": "primary"},
+    ) == {"image": ["primary", IMAGE.url]}
 
 
 def test_chat_completions_reasoning_fields() -> None:


### PR DESCRIPTION
## Summary

- Add current BytePlus Images catalog coverage for `seedream-4-5-251128` and the accepted `seedream-5-0-lite-260128` alias.
- Enable generation and edit/reference-image requests through `POST /api/v3/images/generations`, preserving primary/additional image order and model limits.
- Honor configured AP/EU ModelArk base URLs and add current output/background controls and HEIC/HEIF inputs.
- Preserve every successful unary or complete streaming output in provider order, including actual MIME/size/layer metadata, completion usage, and item/request errors.

Closes #301.

## Official evidence

- [Image generation tutorial](https://docs.byteplus.com/en/docs/ModelArk/1824121)
- [Image generation API](https://docs.byteplus.com/en/docs/ModelArk/1541523)
- [Streaming response contract](https://docs.byteplus.com/en/docs/ModelArk/1824137)
- [Seedream 5.0 Pro guide](https://docs.byteplus.com/en/docs/ModelArk/2582774)
- [Region availability](https://docs.byteplus.com/en/docs/ModelArk/2191806)
- [C2PA Content Credentials](https://docs.byteplus.com/en/docs/ModelArk/c2pa-content-credentials-guide)

The model-specific Pro guide explicitly accepts `1K`, `1.5K`, and `2K` size values and publishes the exact presets. Current documentation exposes all covered IDs in AP Southeast; EU West is restricted to Seedream 5.0 Lite and uses its regional base URL. BytePlus does not publish a separate effective date for these current API facts.

## Scope

- Models: `seedream-4-0-250828`, `seedream-4-5-251128`, `seedream-5-0-260128`, `seedream-5-0-lite-260128`, `dola-seedream-5-0-pro-260628`
- Scenarios: text-to-image, reference-guided edit/fusion, sequential output where supported, and Pro layer decomposition metadata
- Response modes: unary collections and complete-image streaming events for models that declare streaming
- No video, OCR/image understanding, search, or embedding behavior is changed

## Validation

- `make ci`
  - Ruff lint/format
  - mypy
  - Bandit
  - 608 unit tests with coverage
- No provider-live test was run because no BytePlus credentials were used.
