### PR TITLE
Harden Google video routing and downloads

### DIFF
--- a/src/celeste/modalities/videos/providers/google/interactions.py
+++ b/src/celeste/modalities/videos/providers/google/interactions.py
@@ -1,19 +1,27 @@
 """Google videos client (Interactions API — Gemini Omni)."""
 
-from typing import Any
+import asyncio
+from typing import Any, Unpack
+from urllib.parse import urlsplit, urlunsplit
 
 from celeste.artifacts import VideoArtifact
+from celeste.http import DEFAULT_TIMEOUT
 from celeste.mime_types import VideoMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
 from celeste.providers.google.interactions import config
 from celeste.providers.google.interactions.client import (
     GoogleInteractionsClient as GoogleInteractionsMixin,
 )
-from celeste.providers.google.utils import build_content_part
+from celeste.providers.google.utils import (
+    build_content_part,
+    get_with_auth_safe_redirects,
+)
 from celeste.types import VideoContent
 
 from ...client import VideosClient
 from ...io import VideoInput
+from ...parameters import VideoParameters
 from .parameters import GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 
 
@@ -37,7 +45,32 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             build_content_part(inputs.video, "video"),
             {"type": "text", "text": inputs.prompt},
         ]
-        request["generation_config"] = {"video_config": {"task": "edit"}}
+        if self.model.id == "gemini-omni-flash-preview":
+            request["generation_config"] = {"video_config": {"task": "edit"}}
+        return request
+
+    def _build_request(
+        self,
+        inputs: VideoInput,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Unpack[VideoParameters],
+    ) -> dict[str, Any]:
+        """Build a request and select URI delivery for Developer high-res video."""
+        request = super()._build_request(
+            inputs,
+            extra_body=extra_body,
+            streaming=streaming,
+            **parameters,
+        )
+        response_format = request.get("response_format")
+        if (
+            not isinstance(self.auth, GoogleADC)
+            and self.model.id == "gemini-omni-1.1-flash"
+            and isinstance(response_format, dict)
+            and response_format.get("resolution") in ("1080p", "4k")
+        ):
+            response_format["delivery"] = "uri"
         return request
 
     def _parse_content(
@@ -70,11 +103,56 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             raise ValueError(msg)
 
         headers = self.auth.get_headers()
-        response = await self.http_client.get(
-            artifact.url, headers=headers, follow_redirects=True
+        status_url = self._file_status_url(artifact.url)
+        while status_url is not None:
+            status_response = await get_with_auth_safe_redirects(
+                self.http_client,
+                status_url,
+                headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            self._handle_error_response(status_response)
+            state = status_response.json().get("state")
+            if state == "ACTIVE":
+                break
+            if state == "FAILED":
+                raise ValueError("Google Files video processing failed")
+            await asyncio.sleep(config.FILE_POLL_INTERVAL)
+
+        download_url = artifact.url
+        if status_url is not None and not urlsplit(download_url).path.endswith(
+            ":download"
+        ):
+            download_url = f"{status_url}:download?alt=media"
+        if download_url.startswith("gs://"):
+            download_url = download_url.replace("gs://", config.STORAGE_BASE_URL, 1)
+        response = await get_with_auth_safe_redirects(
+            self.http_client,
+            download_url,
+            headers,
+            timeout=DEFAULT_TIMEOUT,
         )
         self._handle_error_response(response)
         return VideoArtifact(data=response.content, mime_type=artifact.mime_type)
+
+    @staticmethod
+    def _file_status_url(url: str) -> str | None:
+        """Return the Files metadata URL for a Developer API download URI."""
+        parsed = urlsplit(url)
+        if (
+            parsed.netloc != "generativelanguage.googleapis.com"
+            or "/v1beta/files/" not in parsed.path
+        ):
+            return None
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path.removesuffix(":download"),
+                "",
+                "",
+            )
+        )
 
 
 __all__ = ["GoogleInteractionsVideosClient"]

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -7,6 +7,7 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 
+from ..auth import GoogleADC
 from . import config
 
 
@@ -52,7 +53,29 @@ class GoogleInteractionsClient(APIMixin):
         request_body["model"] = self.model.id
         if streaming:
             request_body["stream"] = True
+        response_format = request_body.get("response_format")
+        if (
+            isinstance(self.auth, GoogleADC)
+            and isinstance(response_format, dict)
+            and response_format.get("type") == "video"
+        ):
+            request_body["response_format"] = [response_format]
         return request_body
+
+    def _build_url(self, endpoint: str) -> str:
+        """Build the Developer or Cloud Interactions URL from auth."""
+        if not isinstance(self.auth, GoogleADC):
+            return f"{config.BASE_URL}{endpoint}"
+        project_id = self.auth.resolved_project_id
+        if project_id is None:
+            raise ValueError(
+                "Google Cloud Interactions requires a project_id. "
+                "Pass project_id to GoogleADC() or ensure credentials have a project."
+            )
+        path = config.VertexInteractionsEndpoint.CREATE_INTERACTION.format(
+            project_id=project_id
+        )
+        return f"{config.VERTEX_BASE_URL}{path}"
 
     async def _make_request(
         self,
@@ -68,7 +91,7 @@ class GoogleInteractionsClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
         response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
+            self._build_url(endpoint),
             headers=headers,
             json_body=request_body,
         )
@@ -90,7 +113,7 @@ class GoogleInteractionsClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
         return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
+            self._build_url(endpoint),
             headers=headers,
             json_body=request_body,
         )

--- a/src/celeste/providers/google/interactions/config.py
+++ b/src/celeste/providers/google/interactions/config.py
@@ -10,4 +10,13 @@ class GoogleInteractionsEndpoint(StrEnum):
     CREATE_INTERACTION = "/v1beta/interactions"
 
 
+class VertexInteractionsEndpoint(StrEnum):
+    """Endpoints for Google Cloud Interactions API."""
+
+    CREATE_INTERACTION = "/v1beta1/projects/{project_id}/locations/global/interactions"
+
+
 BASE_URL = "https://generativelanguage.googleapis.com"
+VERTEX_BASE_URL = "https://aiplatform.googleapis.com"
+STORAGE_BASE_URL = "https://storage.googleapis.com/"
+FILE_POLL_INTERVAL = 5

--- a/src/celeste/providers/google/utils.py
+++ b/src/celeste/providers/google/utils.py
@@ -2,9 +2,51 @@
 
 import base64
 from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
 
 from celeste.artifacts import Artifact
+from celeste.http import HTTPClient
 from celeste.utils import detect_mime_type
+
+_MAX_REDIRECTS = 20
+_AUTHENTICATED_DOWNLOAD_HOSTS = frozenset(
+    {"generativelanguage.googleapis.com", "storage.googleapis.com"}
+)
+
+
+async def get_with_auth_safe_redirects(
+    client: HTTPClient,
+    url: str,
+    headers: dict[str, str],
+    *,
+    timeout: float,
+) -> httpx.Response:
+    """Follow GET redirects without forwarding credentials across origins."""
+    current_url = url
+    parsed = urlsplit(current_url)
+    current_headers = (
+        headers
+        if parsed.scheme == "https" and parsed.hostname in _AUTHENTICATED_DOWNLOAD_HOSTS
+        else {}
+    )
+    for _ in range(_MAX_REDIRECTS):
+        response = await client.get(
+            current_url,
+            headers=current_headers,
+            timeout=timeout,
+            follow_redirects=False,
+        )
+        if not response.is_redirect or "location" not in response.headers:
+            return response
+        redirect_url = urljoin(current_url, response.headers["location"])
+        if urlsplit(redirect_url)[:2] != urlsplit(current_url)[:2]:
+            current_headers = {}
+        current_url = redirect_url
+    raise httpx.TooManyRedirects(
+        "Exceeded maximum allowed redirects", request=response.request
+    )
 
 
 def build_media_part(artifact: Artifact) -> dict[str, Any]:

--- a/src/celeste/providers/google/veo/client.py
+++ b/src/celeste/providers/google/veo/client.py
@@ -10,6 +10,7 @@ from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
 
 from ..auth import GoogleADC
+from ..utils import get_with_auth_safe_redirects
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -221,11 +222,11 @@ class GoogleVeoClient(APIMixin):
 
         headers = self._merge_headers(self.auth.get_headers(), extra_headers)
 
-        response = await self.http_client.get(
+        response = await get_with_auth_safe_redirects(
+            self.http_client,
             download_url,
-            headers=headers,
+            headers,
             timeout=config.DEFAULT_TIMEOUT,
-            follow_redirects=True,
         )
 
         self._handle_error_response(response)

--- a/tests/unit_tests/test_http.py
+++ b/tests/unit_tests/test_http.py
@@ -5,8 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 import celeste.http as http_module
+from celeste.artifacts import VideoArtifact
+from celeste.auth import AuthHeader
 from celeste.core import Modality, Provider
 from celeste.http import (
     DEFAULT_TIMEOUT,
@@ -16,6 +19,12 @@ from celeste.http import (
     close_all_http_clients,
     get_http_client,
 )
+from celeste.mime_types import VideoMimeType
+from celeste.modalities.videos.providers.google.interactions import (
+    GoogleInteractionsVideosClient,
+)
+from celeste.models import Model
+from celeste.providers.google.utils import get_with_auth_safe_redirects
 
 
 @pytest.fixture
@@ -97,6 +106,78 @@ async def test_request_methods_forward_arguments(
                 timeout=12,
                 follow_redirects=True,
             )
+
+
+async def test_google_files_download_polls_and_drops_auth_on_redirect(
+    transport: AsyncMock,
+) -> None:
+    transport.get.side_effect = [
+        httpx.Response(200, json={"state": "ACTIVE"}),
+        httpx.Response(
+            302, headers={"location": "https://storage.googleapis.com/video.mp4"}
+        ),
+        httpx.Response(200, content=b"video"),
+    ]
+    client = GoogleInteractionsVideosClient(
+        model=Model(id="gemini-omni-1.1-flash", display_name="Omni"),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+    uri = "https://generativelanguage.googleapis.com/v1beta/files/abc"
+
+    with patch("celeste.http.httpx.AsyncClient", return_value=transport):
+        artifact = await client.download_content(
+            VideoArtifact(url=uri, mime_type=VideoMimeType.MP4)
+        )
+
+    assert artifact.data == b"video"
+    assert transport.get.call_args_list == [
+        call(
+            "https://generativelanguage.googleapis.com/v1beta/files/abc",
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+        call(
+            f"{uri}:download?alt=media",
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+        call(
+            "https://storage.googleapis.com/video.mp4",
+            headers={},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/provider-output.mp4",
+        "http://generativelanguage.googleapis.com/v1beta/files/abc",
+    ],
+)
+async def test_google_download_does_not_authenticate_untrusted_initial_url(
+    transport: AsyncMock, url: str
+) -> None:
+    transport.get.return_value = httpx.Response(200)
+    with patch("celeste.http.httpx.AsyncClient", return_value=transport):
+        await get_with_auth_safe_redirects(
+            HTTPClient(),
+            url,
+            {"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+        )
+
+    assert transport.get.call_args == call(
+        url,
+        headers={},
+        timeout=DEFAULT_TIMEOUT,
+        follow_redirects=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_vertex_routing.py
+++ b/tests/unit_tests/test_vertex_routing.py
@@ -20,6 +20,8 @@ from celeste.providers.google.generate_content import config as generate_config
 from celeste.providers.google.generate_content.client import GoogleGenerateContentClient
 from celeste.providers.google.imagen import config as imagen_config
 from celeste.providers.google.imagen.client import GoogleImagenClient
+from celeste.providers.google.interactions import config as interactions_config
+from celeste.providers.google.interactions.client import GoogleInteractionsClient
 from celeste.providers.google.veo import config as veo_config
 from celeste.providers.google.veo.client import GoogleVeoClient
 from celeste.providers.mistral.chat import config as mistral_config
@@ -120,6 +122,12 @@ def test_vertex_url_requires_project() -> None:
             "generativelanguage.googleapis.com/v1beta/models/veo-3.1-generate-preview:predictLongRunning",
         ),
         (
+            GoogleInteractionsClient,
+            interactions_config.GoogleInteractionsEndpoint.CREATE_INTERACTION,
+            "gemini-omni-1.1-flash",
+            "generativelanguage.googleapis.com/v1beta/interactions",
+        ),
+        (
             MistralChatClient,
             mistral_config.MistralChatEndpoint.CREATE_CHAT_COMPLETION,
             "mistral-large-2411",
@@ -186,6 +194,19 @@ def test_adc_routes_through_vertex(
     url = _build_url(client_type, endpoint, model_id, _adc())
     assert url.startswith("https://us-central1-aiplatform.googleapis.com")
     assert all(fragment in url for fragment in fragments)
+
+
+def test_adc_interactions_uses_global_cloud_endpoint() -> None:
+    url = _build_url(
+        GoogleInteractionsClient,
+        interactions_config.GoogleInteractionsEndpoint.CREATE_INTERACTION,
+        "gemini-omni-1.1-flash-preview",
+        _adc(),
+    )
+    assert url == (
+        "https://aiplatform.googleapis.com/v1beta1/projects/test-project/"
+        "locations/global/interactions"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- route Google Interactions requests through the global Cloud endpoint when using ADC
- normalize Cloud video `response_format` to the documented list shape
- poll Developer Files outputs until `ACTIVE` before download
- keep Google credentials on trusted HTTPS origins only and strip them on cross-origin redirects
- apply the same credential-safe download path to existing Veo outputs

## Evidence

Google's current Cloud Interactions contract uses `POST /v1beta1/projects/{project}/locations/global/interactions`, while Developer URI-delivered Omni videos require Files-state polling before `:download` retrieval:

- https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/interactions-api
- https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/generate-videos-from-text
- https://ai.google.dev/gemini-api/docs/omni

## Validation

- `make ci` passed before commit
- pre-push full tests with coverage passed
- independent review covered Developer Files, Cloud Storage, redirects, MIME preservation, and ADC/API-key routing

This is provider-wide groundwork for the model catalog follow-up. It intentionally adds no model IDs.
