### PR TITLE
feat(openai): add GPT Transcribe audio support

### DIFF
--- a/src/celeste/modalities/audio/providers/openai/models.py
+++ b/src/celeste/modalities/audio/providers/openai/models.py
@@ -83,6 +83,14 @@ MODELS: list[Model] = [
         },
     ),
     Model(
+        id="gpt-transcribe",
+        provider=Provider.OPENAI,
+        display_name="GPT Transcribe",
+        streaming=False,
+        operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
+        parameter_constraints=_TRANSCRIBE_CONSTRAINTS,
+    ),
+    Model(
         id="gpt-4o-mini-transcribe",
         provider=Provider.OPENAI,
         display_name="GPT-4o Mini Transcribe",

--- a/src/celeste/providers/openai/audio/parameters.py
+++ b/src/celeste/providers/openai/audio/parameters.py
@@ -91,7 +91,8 @@ class LanguageMapper[Content](ParameterMapper[Content]):
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
-        request["language"] = validated_value
+        field = "languages[]" if model.id == "gpt-transcribe" else "language"
+        request[field] = validated_value
         return request
 
 

--- a/tests/unit_tests/test_openai_audio_transcribe.py
+++ b/tests/unit_tests/test_openai_audio_transcribe.py
@@ -8,15 +8,16 @@ from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import AudioMimeType
 from celeste.modalities.audio.io import AudioInput
 from celeste.modalities.audio.providers.openai.client import OpenAIAudioClient
+from celeste.modalities.audio.providers.openai.models import MODELS
 from celeste.models import Model
 
 
-def _client() -> OpenAIAudioClient:
+def _client(model_id: str = "gpt-4o-mini-transcribe") -> OpenAIAudioClient:
     return OpenAIAudioClient(
         model=Model(
-            id="gpt-4o-mini-transcribe",
+            id=model_id,
             provider=Provider.OPENAI,
-            display_name="GPT-4o Mini Transcribe",
+            display_name=model_id,
             operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
         ),
         auth=AuthHeader(secret=SecretStr("test")),
@@ -38,6 +39,21 @@ def test_build_request_adds_model_and_default_response_format() -> None:
     assert request["model"] == "gpt-4o-mini-transcribe"
     assert request["response_format"] == "json"
     assert request["language"] == "en"
+
+
+def test_gpt_transcribe_uses_plural_language_field() -> None:
+    audio = AudioArtifact(data=b"fake-audio", mime_type=AudioMimeType.WAV)
+    request = _client("gpt-transcribe")._build_request(
+        AudioInput(audio=audio), language="en"
+    )
+    assert request["languages[]"] == "en"
+    assert "language" not in request
+
+
+def test_gpt_transcribe_is_registered_for_file_transcription() -> None:
+    model = next(model for model in MODELS if model.id == "gpt-transcribe")
+    assert model.operations == {Modality.AUDIO: {Operation.TRANSCRIBE}}
+    assert model.streaming is False
 
 
 def test_parse_content_returns_transcript_text() -> None:


### PR DESCRIPTION
## Summary

- Register `gpt-transcribe` for Celeste Audio `TRANSCRIBE` on OpenAI's existing `POST /v1/audio/transcriptions` multipart path.
- Map Celeste's single `language` hint to `languages[]` for this model only; existing OpenAI transcription models keep the singular `language` wire field.
- Keep `streaming=False`: OpenAI supports streamed file transcripts, but Celeste's Audio adapter does not yet implement that SSE contract.

OpenAI released `gpt-transcribe` on 2026-07-28 as the recommended high-accuracy model for completed-file transcription. The default Celeste response remains JSON text; callers may continue to select another supported response format through the existing request override.

## Official evidence

- https://developers.openai.com/api/docs/changelog
- https://developers.openai.com/api/docs/models/gpt-transcribe
- https://developers.openai.com/api/docs/guides/speech-to-text
- https://developers.openai.com/api/reference/python/resources/audio/subresources/transcriptions/methods/create

Realtime-only models and sessions are not added because this repository has no Celeste Audio Realtime/session transport. Speaker diarization is also outside this patch because its chunking, response-format, and segment contract is distinct.

## Validation

- `uv run pytest tests/unit_tests/test_openai_audio_transcribe.py -q` — 8 passed
- Relevant mapper/registry/client tests — 138 passed
- `make lint` — passed
- `make typecheck` — passed
- `make test` — 587 passed; coverage 69.28% (minimum 65%)
- Fresh independent diff/evidence review — passed

Coordinated pricing: withceleste/celeste-pricing#24. Downstream Chat exposure remains intentionally deferred until that package is published and seeded.
