### PR TITLE
Add Gemini Omni 1.1 and Cloud Veo models

### DIFF
--- a/src/celeste/modalities/videos/parameters.py
+++ b/src/celeste/modalities/videos/parameters.py
@@ -18,6 +18,7 @@ class VideoParameter(StrEnum):
     REFERENCE_IMAGES = "reference_images"
     FIRST_FRAME = "first_frame"
     LAST_FRAME = "last_frame"
+    GENERATE_AUDIO = "generate_audio"
 
 
 class VideoParameters(Parameters, total=False):
@@ -37,6 +38,9 @@ class VideoParameters(Parameters, total=False):
     ]
     last_frame: Annotated[
         ImageArtifact, Field(description="Image to use as the video's last frame.")
+    ]
+    generate_audio: Annotated[
+        bool, Field(description="Whether to generate an audio track with the video.")
     ]
 
 

--- a/src/celeste/modalities/videos/providers/google/interactions.py
+++ b/src/celeste/modalities/videos/providers/google/interactions.py
@@ -1,19 +1,27 @@
 """Google videos client (Interactions API — Gemini Omni)."""
 
-from typing import Any
+import asyncio
+from typing import Any, Unpack
+from urllib.parse import urlsplit, urlunsplit
 
 from celeste.artifacts import VideoArtifact
+from celeste.http import DEFAULT_TIMEOUT
 from celeste.mime_types import VideoMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
 from celeste.providers.google.interactions import config
 from celeste.providers.google.interactions.client import (
     GoogleInteractionsClient as GoogleInteractionsMixin,
 )
-from celeste.providers.google.utils import build_content_part
+from celeste.providers.google.utils import (
+    build_content_part,
+    get_with_auth_safe_redirects,
+)
 from celeste.types import VideoContent
 
 from ...client import VideosClient
 from ...io import VideoInput
+from ...parameters import VideoParameters
 from .parameters import GOOGLE_INTERACTIONS_PARAMETER_MAPPERS
 
 
@@ -37,7 +45,32 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             build_content_part(inputs.video, "video"),
             {"type": "text", "text": inputs.prompt},
         ]
-        request["generation_config"] = {"video_config": {"task": "edit"}}
+        if self.model.id == "gemini-omni-flash-preview":
+            request["generation_config"] = {"video_config": {"task": "edit"}}
+        return request
+
+    def _build_request(
+        self,
+        inputs: VideoInput,
+        extra_body: dict[str, Any] | None = None,
+        streaming: bool = False,
+        **parameters: Unpack[VideoParameters],
+    ) -> dict[str, Any]:
+        """Build a request and select URI delivery for Developer high-res video."""
+        request = super()._build_request(
+            inputs,
+            extra_body=extra_body,
+            streaming=streaming,
+            **parameters,
+        )
+        response_format = request.get("response_format")
+        if (
+            not isinstance(self.auth, GoogleADC)
+            and self.model.id == "gemini-omni-1.1-flash"
+            and isinstance(response_format, dict)
+            and response_format.get("resolution") in ("1080p", "4k")
+        ):
+            response_format["delivery"] = "uri"
         return request
 
     def _parse_content(
@@ -70,11 +103,56 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             raise ValueError(msg)
 
         headers = self.auth.get_headers()
-        response = await self.http_client.get(
-            artifact.url, headers=headers, follow_redirects=True
+        status_url = self._file_status_url(artifact.url)
+        while status_url is not None:
+            status_response = await get_with_auth_safe_redirects(
+                self.http_client,
+                status_url,
+                headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            self._handle_error_response(status_response)
+            state = status_response.json().get("state")
+            if state == "ACTIVE":
+                break
+            if state == "FAILED":
+                raise ValueError("Google Files video processing failed")
+            await asyncio.sleep(config.FILE_POLL_INTERVAL)
+
+        download_url = artifact.url
+        if status_url is not None and not urlsplit(download_url).path.endswith(
+            ":download"
+        ):
+            download_url = f"{status_url}:download?alt=media"
+        if download_url.startswith("gs://"):
+            download_url = download_url.replace("gs://", config.STORAGE_BASE_URL, 1)
+        response = await get_with_auth_safe_redirects(
+            self.http_client,
+            download_url,
+            headers,
+            timeout=DEFAULT_TIMEOUT,
         )
         self._handle_error_response(response)
         return VideoArtifact(data=response.content, mime_type=artifact.mime_type)
+
+    @staticmethod
+    def _file_status_url(url: str) -> str | None:
+        """Return the Files metadata URL for a Developer API download URI."""
+        parsed = urlsplit(url)
+        if (
+            parsed.netloc != "generativelanguage.googleapis.com"
+            or "/v1beta/files/" not in parsed.path
+        ):
+            return None
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path.removesuffix(":download"),
+                "",
+                "",
+            )
+        )
 
 
 __all__ = ["GoogleInteractionsVideosClient"]

--- a/src/celeste/modalities/videos/providers/google/interactions.py
+++ b/src/celeste/modalities/videos/providers/google/interactions.py
@@ -93,6 +93,26 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
         msg = "No video content in response"
         raise ValueError(msg)
 
+    async def _make_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        endpoint: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        **parameters: Unpack[VideoParameters],
+    ) -> dict[str, Any]:
+        """Wait for a returned Developer File before exposing its download URI."""
+        response_data = await super()._make_request(
+            request_body,
+            endpoint=endpoint,
+            extra_headers=extra_headers,
+            **parameters,
+        )
+        artifact = self._parse_content(response_data)
+        if artifact.url is not None:
+            await self._wait_until_file_active(artifact.url)
+        return response_data
+
     async def download_content(self, artifact: VideoArtifact) -> VideoArtifact:
         """Download video content from the response URI."""
         if artifact.data is not None:
@@ -103,21 +123,7 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             raise ValueError(msg)
 
         headers = self.auth.get_headers()
-        status_url = self._file_status_url(artifact.url)
-        while status_url is not None:
-            status_response = await get_with_auth_safe_redirects(
-                self.http_client,
-                status_url,
-                headers,
-                timeout=DEFAULT_TIMEOUT,
-            )
-            self._handle_error_response(status_response)
-            state = status_response.json().get("state")
-            if state == "ACTIVE":
-                break
-            if state == "FAILED":
-                raise ValueError("Google Files video processing failed")
-            await asyncio.sleep(config.FILE_POLL_INTERVAL)
+        status_url = await self._wait_until_file_active(artifact.url)
 
         download_url = artifact.url
         if status_url is not None and not urlsplit(download_url).path.endswith(
@@ -134,6 +140,42 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
         )
         self._handle_error_response(response)
         return VideoArtifact(data=response.content, mime_type=artifact.mime_type)
+
+    async def _wait_until_file_active(self, url: str) -> str | None:
+        """Wait until a Developer File is ready and return its metadata URL."""
+        status_url = self._file_status_url(url)
+        if status_url is None:
+            return None
+        headers = self.auth.get_headers()
+
+        try:
+            async with asyncio.timeout(config.FILE_POLL_TIMEOUT):
+                while True:
+                    status_response = await get_with_auth_safe_redirects(
+                        self.http_client,
+                        status_url,
+                        headers,
+                        timeout=DEFAULT_TIMEOUT,
+                    )
+                    self._handle_error_response(status_response)
+                    status_data = status_response.json()
+                    state = status_data.get("state", "STATE_UNSPECIFIED")
+                    if state == "ACTIVE":
+                        return status_url
+                    if state == "FAILED":
+                        error = status_data.get("error", {})
+                        detail = error.get("message", "Unknown error")
+                        raise ValueError(
+                            f"Google Files video processing failed: {detail}"
+                        )
+                    if state not in ("PROCESSING", "STATE_UNSPECIFIED"):
+                        raise ValueError(f"Unexpected Google Files state: {state}")
+                    await asyncio.sleep(config.FILE_POLL_INTERVAL)
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"Google Files video processing timed out after "
+                f"{config.FILE_POLL_TIMEOUT} seconds"
+            ) from exc
 
     @staticmethod
     def _file_status_url(url: str) -> str | None:

--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -1,6 +1,6 @@
 """Google models for videos modality."""
 
-from celeste.constraints import Choice, ImageConstraint, ImagesConstraint, Range
+from celeste.constraints import Bool, Choice, ImageConstraint, ImagesConstraint, Range
 from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import ImageMimeType
 from celeste.models import Model
@@ -20,7 +20,7 @@ GOOGLE_VEO_MODELS: list[Model] = [
         id="veo-3.1-generate-preview",
         provider=Provider.GOOGLE,
         display_name="Veo 3.1 (Preview)",
-        operations={Modality.VIDEOS: {Operation.GENERATE}},
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p", "4k"]),
@@ -41,11 +41,15 @@ GOOGLE_VEO_MODELS: list[Model] = [
         id="veo-3.1-fast-generate-preview",
         provider=Provider.GOOGLE,
         display_name="Veo 3.1 Fast (Preview)",
-        operations={Modality.VIDEOS: {Operation.GENERATE}},
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p", "4k"]),
             VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+                max_count=3,
+            ),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
             ),
@@ -63,10 +67,68 @@ GOOGLE_VEO_MODELS: list[Model] = [
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
             VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.FIRST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+            VideoParameter.LAST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+        },
+    ),
+    Model(
+        id="veo-3.1-generate-001",
+        provider=Provider.GOOGLE,
+        display_name="Veo 3.1",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p", "4k"]),
+            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.GENERATE_AUDIO: Bool(),
             VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
                 supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
                 max_count=3,
             ),
+            VideoParameter.FIRST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+            VideoParameter.LAST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+        },
+    ),
+    Model(
+        id="veo-3.1-fast-generate-001",
+        provider=Provider.GOOGLE,
+        display_name="Veo 3.1 Fast",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
+            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.GENERATE_AUDIO: Bool(),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+                max_count=3,
+            ),
+            VideoParameter.FIRST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+            VideoParameter.LAST_FRAME: ImageConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+            ),
+        },
+    ),
+    Model(
+        id="veo-3.1-lite-generate-001",
+        provider=Provider.GOOGLE,
+        display_name="Veo 3.1 Lite",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
+            VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.GENERATE_AUDIO: Bool(),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
             ),
@@ -88,6 +150,34 @@ GOOGLE_OMNI_MODELS: list[Model] = [
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.DURATION: Range(min=3, max=10),
             VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
+        },
+    ),
+    Model(
+        id="gemini-omni-1.1-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini Omni 1.1 Flash",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["360p", "720p", "1080p", "4k"]),
+            VideoParameter.DURATION: Range(min=3, max=10),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.LAST_FRAME: ImageConstraint(),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
+        },
+    ),
+    Model(
+        id="gemini-omni-1.1-flash-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini Omni 1.1 Flash (Cloud Preview)",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.RESOLUTION: Choice(options=["360p", "720p", "1080p", "4k"]),
+            VideoParameter.DURATION: Range(min=3, max=10),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.LAST_FRAME: ImageConstraint(),
             VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
         },
     ),

--- a/src/celeste/modalities/videos/providers/google/parameters.py
+++ b/src/celeste/modalities/videos/providers/google/parameters.py
@@ -16,6 +16,9 @@ from celeste.providers.google.interactions.parameters import (
 from celeste.providers.google.interactions.parameters import (
     ReferenceImagesMapper as _InteractionsReferenceImagesMapper,
 )
+from celeste.providers.google.interactions.parameters import (
+    ResolutionMapper as _InteractionsResolutionMapper,
+)
 from celeste.providers.google.veo.parameters import (
     AspectRatioMapper as _VeoAspectRatioMapper,
 )
@@ -24,6 +27,9 @@ from celeste.providers.google.veo.parameters import (
 )
 from celeste.providers.google.veo.parameters import (
     FirstFrameMapper as _VeoFirstFrameMapper,
+)
+from celeste.providers.google.veo.parameters import (
+    GenerateAudioMapper as _VeoGenerateAudioMapper,
 )
 from celeste.providers.google.veo.parameters import (
     LastFrameMapper as _VeoLastFrameMapper,
@@ -57,6 +63,12 @@ class VeoDurationMapper(_VeoDurationSecondsMapper):
     name = VideoParameter.DURATION
 
 
+class VeoGenerateAudioMapper(_VeoGenerateAudioMapper):
+    """Map generate_audio to Google Veo's generateAudio parameter."""
+
+    name = VideoParameter.GENERATE_AUDIO
+
+
 class VeoReferenceImagesMapper(_VeoReferenceImagesMapper):
     """Map reference_images to Google Veo's referenceImages parameter."""
 
@@ -79,6 +91,7 @@ GOOGLE_VEO_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
     VeoAspectRatioMapper(),
     VeoResolutionMapper(),
     VeoDurationMapper(),
+    VeoGenerateAudioMapper(),
     VeoReferenceImagesMapper(),
     VeoFirstFrameMapper(),
     VeoLastFrameMapper(),
@@ -95,6 +108,12 @@ class InteractionsDurationMapper(_InteractionsDurationMapper):
     """Map duration to Google Interactions response_format.duration."""
 
     name = VideoParameter.DURATION
+
+
+class InteractionsResolutionMapper(_InteractionsResolutionMapper):
+    """Map resolution to Google Interactions response_format.resolution."""
+
+    name = VideoParameter.RESOLUTION
 
 
 class InteractionsFirstFrameMapper(_InteractionsFirstFrameMapper):
@@ -118,6 +137,7 @@ class InteractionsReferenceImagesMapper(_InteractionsReferenceImagesMapper):
 GOOGLE_INTERACTIONS_PARAMETER_MAPPERS: list[ParameterMapper[VideoContent]] = [
     InteractionsAspectRatioMapper(),
     InteractionsDurationMapper(),
+    InteractionsResolutionMapper(),
     InteractionsFirstFrameMapper(),
     InteractionsLastFrameMapper(),
     InteractionsReferenceImagesMapper(),

--- a/src/celeste/modalities/videos/providers/google/veo.py
+++ b/src/celeste/modalities/videos/providers/google/veo.py
@@ -5,6 +5,7 @@ from typing import Any
 from celeste.artifacts import VideoArtifact
 from celeste.mime_types import VideoMimeType
 from celeste.parameters import ParameterMapper
+from celeste.providers.google.auth import GoogleADC
 from celeste.providers.google.veo import config
 from celeste.providers.google.veo.client import GoogleVeoClient as GoogleVeoMixin
 from celeste.types import VideoContent
@@ -18,6 +19,7 @@ class GoogleVeoVideosClient(GoogleVeoMixin, VideosClient):
     """Google videos client (Veo API)."""
 
     _generate_endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
+    _edit_endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[VideoContent]]:
@@ -25,9 +27,27 @@ class GoogleVeoVideosClient(GoogleVeoMixin, VideosClient):
 
     def _init_request(self, inputs: VideoInput) -> dict[str, Any]:
         """Initialize request from Google Veo API format."""
-        return {
-            "instances": [{"prompt": inputs.prompt}],
-        }
+        instance: dict[str, Any] = {"prompt": inputs.prompt}
+        if inputs.video is not None:
+            mime_type = (inputs.video.mime_type or VideoMimeType.MP4).value
+            if inputs.video.url is not None:
+                uri_field = "gcsUri" if isinstance(self.auth, GoogleADC) else "uri"
+                instance["video"] = {
+                    uri_field: inputs.video.url,
+                    "mimeType": mime_type,
+                }
+            else:
+                encoded = inputs.video.get_base64()
+                if isinstance(self.auth, GoogleADC):
+                    instance["video"] = {
+                        "bytesBase64Encoded": encoded,
+                        "mimeType": mime_type,
+                    }
+                else:
+                    instance["video"] = {
+                        "inlineData": {"data": encoded, "mimeType": mime_type}
+                    }
+        return {"instances": [instance]}
 
     def _parse_content(
         self,

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -7,6 +7,7 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.io import FinishReason
 
+from ..auth import GoogleADC
 from . import config
 
 
@@ -52,7 +53,29 @@ class GoogleInteractionsClient(APIMixin):
         request_body["model"] = self.model.id
         if streaming:
             request_body["stream"] = True
+        response_format = request_body.get("response_format")
+        if (
+            isinstance(self.auth, GoogleADC)
+            and isinstance(response_format, dict)
+            and response_format.get("type") == "video"
+        ):
+            request_body["response_format"] = [response_format]
         return request_body
+
+    def _build_url(self, endpoint: str) -> str:
+        """Build the Developer or Cloud Interactions URL from auth."""
+        if not isinstance(self.auth, GoogleADC):
+            return f"{config.BASE_URL}{endpoint}"
+        project_id = self.auth.resolved_project_id
+        if project_id is None:
+            raise ValueError(
+                "Google Cloud Interactions requires a project_id. "
+                "Pass project_id to GoogleADC() or ensure credentials have a project."
+            )
+        path = config.VertexInteractionsEndpoint.CREATE_INTERACTION.format(
+            project_id=project_id
+        )
+        return f"{config.VERTEX_BASE_URL}{path}"
 
     async def _make_request(
         self,
@@ -68,7 +91,7 @@ class GoogleInteractionsClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
         response = await self.http_client.post(
-            f"{config.BASE_URL}{endpoint}",
+            self._build_url(endpoint),
             headers=headers,
             json_body=request_body,
         )
@@ -90,7 +113,7 @@ class GoogleInteractionsClient(APIMixin):
 
         headers = self._json_headers(extra_headers)
         return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
+            self._build_url(endpoint),
             headers=headers,
             json_body=request_body,
         )

--- a/src/celeste/providers/google/interactions/config.py
+++ b/src/celeste/providers/google/interactions/config.py
@@ -20,3 +20,4 @@ BASE_URL = "https://generativelanguage.googleapis.com"
 VERTEX_BASE_URL = "https://aiplatform.googleapis.com"
 STORAGE_BASE_URL = "https://storage.googleapis.com/"
 FILE_POLL_INTERVAL = 5
+FILE_POLL_TIMEOUT = 300

--- a/src/celeste/providers/google/interactions/config.py
+++ b/src/celeste/providers/google/interactions/config.py
@@ -10,4 +10,13 @@ class GoogleInteractionsEndpoint(StrEnum):
     CREATE_INTERACTION = "/v1beta/interactions"
 
 
+class VertexInteractionsEndpoint(StrEnum):
+    """Endpoints for Google Cloud Interactions API."""
+
+    CREATE_INTERACTION = "/v1beta1/projects/{project_id}/locations/global/interactions"
+
+
 BASE_URL = "https://generativelanguage.googleapis.com"
+VERTEX_BASE_URL = "https://aiplatform.googleapis.com"
+STORAGE_BASE_URL = "https://storage.googleapis.com/"
+FILE_POLL_INTERVAL = 5

--- a/src/celeste/providers/google/interactions/parameters.py
+++ b/src/celeste/providers/google/interactions/parameters.py
@@ -296,6 +296,25 @@ class AspectRatioMapper[Content](ParameterMapper[Content]):
         return request
 
 
+class ResolutionMapper(ParameterMapper[VideoContent]):
+    """Map resolution to Google Interactions response_format.resolution field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform resolution into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        response_format = request.setdefault("response_format", {"type": "video"})
+        response_format["resolution"] = validated_value
+        return request
+
+
 class ImageSizeMapper(ParameterMapper[ImageContent]):
     """Map image_size to Google Interactions response_format.image_size field."""
 
@@ -543,6 +562,7 @@ __all__ = [
     "MaxOutputTokensMapper",
     "MediaContentMapper",
     "ReferenceImagesMapper",
+    "ResolutionMapper",
     "ResponseFormatMapper",
     "SeedMapper",
     "TemperatureMapper",

--- a/src/celeste/providers/google/utils.py
+++ b/src/celeste/providers/google/utils.py
@@ -2,9 +2,51 @@
 
 import base64
 from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
 
 from celeste.artifacts import Artifact
+from celeste.http import HTTPClient
 from celeste.utils import detect_mime_type
+
+_MAX_REDIRECTS = 20
+_AUTHENTICATED_DOWNLOAD_HOSTS = frozenset(
+    {"generativelanguage.googleapis.com", "storage.googleapis.com"}
+)
+
+
+async def get_with_auth_safe_redirects(
+    client: HTTPClient,
+    url: str,
+    headers: dict[str, str],
+    *,
+    timeout: float,
+) -> httpx.Response:
+    """Follow GET redirects without forwarding credentials across origins."""
+    current_url = url
+    parsed = urlsplit(current_url)
+    current_headers = (
+        headers
+        if parsed.scheme == "https" and parsed.hostname in _AUTHENTICATED_DOWNLOAD_HOSTS
+        else {}
+    )
+    for _ in range(_MAX_REDIRECTS):
+        response = await client.get(
+            current_url,
+            headers=current_headers,
+            timeout=timeout,
+            follow_redirects=False,
+        )
+        if not response.is_redirect or "location" not in response.headers:
+            return response
+        redirect_url = urljoin(current_url, response.headers["location"])
+        if urlsplit(redirect_url)[:2] != urlsplit(current_url)[:2]:
+            current_headers = {}
+        current_url = redirect_url
+    raise httpx.TooManyRedirects(
+        "Exceeded maximum allowed redirects", request=response.request
+    )
 
 
 def build_media_part(artifact: Artifact) -> dict[str, Any]:

--- a/src/celeste/providers/google/veo/client.py
+++ b/src/celeste/providers/google/veo/client.py
@@ -10,6 +10,7 @@ from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
 
 from ..auth import GoogleADC
+from ..utils import get_with_auth_safe_redirects
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -221,11 +222,11 @@ class GoogleVeoClient(APIMixin):
 
         headers = self._merge_headers(self.auth.get_headers(), extra_headers)
 
-        response = await self.http_client.get(
+        response = await get_with_auth_safe_redirects(
+            self.http_client,
             download_url,
-            headers=headers,
+            headers,
             timeout=config.DEFAULT_TIMEOUT,
-            follow_redirects=True,
         )
 
         self._handle_error_response(response)

--- a/src/celeste/providers/google/veo/parameters.py
+++ b/src/celeste/providers/google/veo/parameters.py
@@ -47,6 +47,22 @@ class ResolutionMapper(ParameterMapper[VideoContent]):
         return request
 
 
+class GenerateAudioMapper(ParameterMapper[VideoContent]):
+    """Map generate_audio to Google Veo parameters.generateAudio field."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform generate_audio into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is not None:
+            request.setdefault("parameters", {})["generateAudio"] = validated_value
+        return request
+
+
 class DurationSecondsMapper(ParameterMapper[VideoContent]):
     """Map duration to Google Veo parameters.durationSeconds field."""
 
@@ -169,6 +185,7 @@ __all__ = [
     "AspectRatioMapper",
     "DurationSecondsMapper",
     "FirstFrameMapper",
+    "GenerateAudioMapper",
     "LastFrameMapper",
     "ReferenceImagesMapper",
     "ResolutionMapper",

--- a/tests/unit_tests/test_google_videos_interactions.py
+++ b/tests/unit_tests/test_google_videos_interactions.py
@@ -9,11 +9,14 @@ from celeste.auth import AuthHeader
 from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import ImageMimeType, VideoMimeType
 from celeste.modalities.videos.io import VideoInput
+from celeste.modalities.videos.parameters import VideoParameter
 from celeste.modalities.videos.providers.google.client import GoogleVideosClient
 from celeste.modalities.videos.providers.google.interactions import (
     GoogleInteractionsVideosClient,
 )
+from celeste.modalities.videos.providers.google.models import MODELS
 from celeste.modalities.videos.providers.google.veo import GoogleVeoVideosClient
+from celeste.providers.google.auth import GoogleADC
 
 IMAGE = ImageArtifact(data=b"img", mime_type=ImageMimeType.PNG)
 
@@ -47,6 +50,25 @@ def test_omni_model_dispatches_to_interactions_strategy() -> None:
     assert isinstance(client._strategy, GoogleInteractionsVideosClient)
     assert client._generate_endpoint == client._strategy._generate_endpoint
     assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+@pytest.mark.parametrize(
+    "model_id", ["gemini-omni-1.1-flash", "gemini-omni-1.1-flash-preview"]
+)
+def test_omni_1_1_models_dispatch_to_interactions_strategy(model_id: str) -> None:
+    assert isinstance(_client(model_id)._strategy, GoogleInteractionsVideosClient)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "veo-3.1-generate-001",
+        "veo-3.1-fast-generate-001",
+        "veo-3.1-lite-generate-001",
+    ],
+)
+def test_cloud_veo_models_dispatch_to_veo_strategy(model_id: str) -> None:
+    assert isinstance(_client(model_id)._strategy, GoogleVeoVideosClient)
 
 
 def test_unknown_model_raises() -> None:
@@ -83,6 +105,20 @@ def test_interactions_init_request_edit_sends_video_part_and_task() -> None:
     assert request["response_format"] == {"type": "video"}
 
 
+@pytest.mark.parametrize(
+    "model_id", ["gemini-omni-1.1-flash", "gemini-omni-1.1-flash-preview"]
+)
+def test_omni_1_1_source_video_relies_on_task_inference(model_id: str) -> None:
+    request = _client(model_id)._init_request(
+        VideoInput(
+            prompt="continue the scene",
+            video=VideoArtifact(data=b"vid", mime_type=VideoMimeType.MP4),
+        )
+    )
+
+    assert "generation_config" not in request
+
+
 def test_interactions_build_request_first_and_last_frame() -> None:
     client = _client("gemini-omni-flash-preview")
 
@@ -111,6 +147,92 @@ def test_interactions_build_request_reference_images() -> None:
     parts = request["input"]
     assert [p["type"] for p in parts] == ["image", "image", "text"]
     assert request["generation_config"]["video_config"]["task"] == "reference_to_video"
+
+
+def test_interactions_high_resolution_uses_developer_uri_delivery() -> None:
+    request = _client("gemini-omni-1.1-flash")._build_request(
+        VideoInput(prompt="a mountain"), resolution="1080p"
+    )
+
+    assert request["response_format"] == {
+        "type": "video",
+        "resolution": "1080p",
+        "delivery": "uri",
+    }
+
+
+def test_cloud_interactions_uses_global_route_body_shape() -> None:
+    client = GoogleVideosClient(
+        model=_model("gemini-omni-1.1-flash-preview"),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="test-project"),
+    )
+
+    request = client._build_request(
+        VideoInput(prompt="a mountain"),
+        resolution="1080p",
+    )
+
+    assert request["response_format"] == [{"type": "video", "resolution": "1080p"}]
+
+
+def test_veo_edit_maps_video_for_each_auth_surface() -> None:
+    direct = _client("veo-3.1-generate-preview")._init_request(
+        VideoInput(
+            prompt="continue",
+            video=VideoArtifact(data=b"vid", mime_type=VideoMimeType.MP4),
+        )
+    )
+    cloud_client = GoogleVideosClient(
+        model=_model("veo-3.1-generate-001"),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="test-project"),
+    )
+    cloud = cloud_client._init_request(
+        VideoInput(
+            prompt="continue",
+            video=VideoArtifact(
+                url="gs://bucket/generated.mp4", mime_type=VideoMimeType.MP4
+            ),
+        )
+    )
+
+    assert direct["instances"][0]["video"] == {
+        "inlineData": {"data": "dmlk", "mimeType": "video/mp4"}
+    }
+    assert cloud["instances"][0]["video"] == {
+        "gcsUri": "gs://bucket/generated.mp4",
+        "mimeType": "video/mp4",
+    }
+
+
+def test_google_video_catalog_capability_matrix() -> None:
+    by_id = {model.id: model for model in MODELS}
+    references = {
+        model_id
+        for model_id, model in by_id.items()
+        if VideoParameter.REFERENCE_IMAGES in model.supported_parameters
+    }
+    audio_toggle = {
+        model_id
+        for model_id, model in by_id.items()
+        if VideoParameter.GENERATE_AUDIO in model.supported_parameters
+    }
+
+    assert references == {
+        "veo-3.1-generate-preview",
+        "veo-3.1-fast-generate-preview",
+        "veo-3.1-generate-001",
+        "veo-3.1-fast-generate-001",
+        "gemini-omni-flash-preview",
+        "gemini-omni-1.1-flash",
+        "gemini-omni-1.1-flash-preview",
+    }
+    assert audio_toggle == {
+        "veo-3.1-generate-001",
+        "veo-3.1-fast-generate-001",
+        "veo-3.1-lite-generate-001",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_http.py
+++ b/tests/unit_tests/test_http.py
@@ -20,6 +20,7 @@ from celeste.http import (
     get_http_client,
 )
 from celeste.mime_types import VideoMimeType
+from celeste.modalities.videos.providers.google.client import GoogleVideosClient
 from celeste.modalities.videos.providers.google.interactions import (
     GoogleInteractionsVideosClient,
 )
@@ -118,7 +119,7 @@ async def test_google_files_download_polls_and_drops_auth_on_redirect(
         ),
         httpx.Response(200, content=b"video"),
     ]
-    client = GoogleInteractionsVideosClient(
+    client = GoogleVideosClient(
         model=Model(id="gemini-omni-1.1-flash", display_name="Omni"),
         provider=Provider.GOOGLE,
         auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
@@ -151,6 +152,83 @@ async def test_google_files_download_polls_and_drops_auth_on_redirect(
             follow_redirects=False,
         ),
     ]
+
+
+async def test_google_generation_waits_for_file_before_returning_uri(
+    transport: AsyncMock,
+) -> None:
+    uri = (
+        "https://generativelanguage.googleapis.com/v1beta/files/abc:download?alt=media"
+    )
+    transport.post.return_value = httpx.Response(
+        200,
+        json={
+            "status": "completed",
+            "steps": [
+                {
+                    "type": "model_output",
+                    "content": [
+                        {"type": "video", "mime_type": "video/mp4", "uri": uri}
+                    ],
+                }
+            ],
+        },
+    )
+    transport.get.side_effect = [
+        httpx.Response(200, json={"state": "PROCESSING"}),
+        httpx.Response(200, json={"state": "ACTIVE"}),
+    ]
+    client = GoogleVideosClient(
+        model=Model(id="gemini-omni-1.1-flash", display_name="Omni"),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        patch(
+            "celeste.modalities.videos.providers.google.interactions.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        output = await client.generate("a mountain", resolution="1080p")
+
+    assert output.content.url == uri
+    status_url = "https://generativelanguage.googleapis.com/v1beta/files/abc"
+    assert transport.get.call_args_list == [
+        call(
+            status_url,
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+        call(
+            status_url,
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+    ]
+
+
+async def test_google_file_polling_is_bounded(transport: AsyncMock) -> None:
+    transport.get.return_value = httpx.Response(200, json={"state": "PROCESSING"})
+    client = GoogleInteractionsVideosClient(
+        model=Model(id="gemini-omni-1.1-flash", display_name="Omni"),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+    uri = "https://generativelanguage.googleapis.com/v1beta/files/abc"
+
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        patch(
+            "celeste.modalities.videos.providers.google.interactions.config.FILE_POLL_TIMEOUT",
+            0,
+        ),
+        pytest.raises(TimeoutError, match="timed out after 0 seconds"),
+    ):
+        await client._wait_until_file_active(uri)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_http.py
+++ b/tests/unit_tests/test_http.py
@@ -5,8 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 import celeste.http as http_module
+from celeste.artifacts import VideoArtifact
+from celeste.auth import AuthHeader
 from celeste.core import Modality, Provider
 from celeste.http import (
     DEFAULT_TIMEOUT,
@@ -16,6 +19,12 @@ from celeste.http import (
     close_all_http_clients,
     get_http_client,
 )
+from celeste.mime_types import VideoMimeType
+from celeste.modalities.videos.providers.google.interactions import (
+    GoogleInteractionsVideosClient,
+)
+from celeste.models import Model
+from celeste.providers.google.utils import get_with_auth_safe_redirects
 
 
 @pytest.fixture
@@ -97,6 +106,78 @@ async def test_request_methods_forward_arguments(
                 timeout=12,
                 follow_redirects=True,
             )
+
+
+async def test_google_files_download_polls_and_drops_auth_on_redirect(
+    transport: AsyncMock,
+) -> None:
+    transport.get.side_effect = [
+        httpx.Response(200, json={"state": "ACTIVE"}),
+        httpx.Response(
+            302, headers={"location": "https://storage.googleapis.com/video.mp4"}
+        ),
+        httpx.Response(200, content=b"video"),
+    ]
+    client = GoogleInteractionsVideosClient(
+        model=Model(id="gemini-omni-1.1-flash", display_name="Omni"),
+        provider=Provider.GOOGLE,
+        auth=AuthHeader(secret=SecretStr("test"), header="x-goog-api-key", prefix=""),
+    )
+    uri = "https://generativelanguage.googleapis.com/v1beta/files/abc"
+
+    with patch("celeste.http.httpx.AsyncClient", return_value=transport):
+        artifact = await client.download_content(
+            VideoArtifact(url=uri, mime_type=VideoMimeType.MP4)
+        )
+
+    assert artifact.data == b"video"
+    assert transport.get.call_args_list == [
+        call(
+            "https://generativelanguage.googleapis.com/v1beta/files/abc",
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+        call(
+            f"{uri}:download?alt=media",
+            headers={"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+        call(
+            "https://storage.googleapis.com/video.mp4",
+            headers={},
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/provider-output.mp4",
+        "http://generativelanguage.googleapis.com/v1beta/files/abc",
+    ],
+)
+async def test_google_download_does_not_authenticate_untrusted_initial_url(
+    transport: AsyncMock, url: str
+) -> None:
+    transport.get.return_value = httpx.Response(200)
+    with patch("celeste.http.httpx.AsyncClient", return_value=transport):
+        await get_with_auth_safe_redirects(
+            HTTPClient(),
+            url,
+            {"x-goog-api-key": "test"},
+            timeout=DEFAULT_TIMEOUT,
+        )
+
+    assert transport.get.call_args == call(
+        url,
+        headers={},
+        timeout=DEFAULT_TIMEOUT,
+        follow_redirects=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -154,6 +154,7 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
         (VIDEOS_VEO, V.ASPECT_RATIO, "16:9", ("parameters", "aspectRatio"), "16:9"),
         (VIDEOS_VEO, V.RESOLUTION, "1080p", ("parameters", "resolution"), "1080p"),
         (VIDEOS_VEO, V.DURATION, 6, ("parameters", "durationSeconds"), 6),
+        (VIDEOS_VEO, V.GENERATE_AUDIO, False, ("parameters", "generateAudio"), False),
         (
             VIDEOS_INTERACTIONS,
             V.ASPECT_RATIO,
@@ -167,6 +168,13 @@ def _at(data: dict[str, Any], path: tuple[str, ...]) -> Any:  # noqa: ANN401
             5,
             ("response_format", "duration"),
             "5s",
+        ),
+        (
+            VIDEOS_INTERACTIONS,
+            V.RESOLUTION,
+            "1080p",
+            ("response_format", "resolution"),
+            "1080p",
         ),
         (
             VIDEOS_INTERACTIONS,

--- a/tests/unit_tests/test_vertex_routing.py
+++ b/tests/unit_tests/test_vertex_routing.py
@@ -20,6 +20,8 @@ from celeste.providers.google.generate_content import config as generate_config
 from celeste.providers.google.generate_content.client import GoogleGenerateContentClient
 from celeste.providers.google.imagen import config as imagen_config
 from celeste.providers.google.imagen.client import GoogleImagenClient
+from celeste.providers.google.interactions import config as interactions_config
+from celeste.providers.google.interactions.client import GoogleInteractionsClient
 from celeste.providers.google.veo import config as veo_config
 from celeste.providers.google.veo.client import GoogleVeoClient
 from celeste.providers.mistral.chat import config as mistral_config
@@ -120,6 +122,12 @@ def test_vertex_url_requires_project() -> None:
             "generativelanguage.googleapis.com/v1beta/models/veo-3.1-generate-preview:predictLongRunning",
         ),
         (
+            GoogleInteractionsClient,
+            interactions_config.GoogleInteractionsEndpoint.CREATE_INTERACTION,
+            "gemini-omni-1.1-flash",
+            "generativelanguage.googleapis.com/v1beta/interactions",
+        ),
+        (
             MistralChatClient,
             mistral_config.MistralChatEndpoint.CREATE_CHAT_COMPLETION,
             "mistral-large-2411",
@@ -186,6 +194,19 @@ def test_adc_routes_through_vertex(
     url = _build_url(client_type, endpoint, model_id, _adc())
     assert url.startswith("https://us-central1-aiplatform.googleapis.com")
     assert all(fragment in url for fragment in fragments)
+
+
+def test_adc_interactions_uses_global_cloud_endpoint() -> None:
+    url = _build_url(
+        GoogleInteractionsClient,
+        interactions_config.GoogleInteractionsEndpoint.CREATE_INTERACTION,
+        "gemini-omni-1.1-flash-preview",
+        _adc(),
+    )
+    assert url == (
+        "https://aiplatform.googleapis.com/v1beta1/projects/test-project/"
+        "locations/global/interactions"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add Gemini Omni 1.1 Flash GA for the Developer API and the Cloud preview model
- add current Cloud Veo 3.1 Standard, Fast, and Lite model IDs with their documented capability matrices
- support Omni resolution and URI delivery, Veo source-video edit/extension payloads, and Cloud `generateAudio`
- wait for Developer Files readiness with terminal-state handling and a bounded timeout before exposing URI artifacts
- correct Developer Veo reference-image and extension capabilities while retaining historical preview IDs

## Evidence

- [Gemini API changelog](https://ai.google.dev/gemini-api/docs/changelog)
- [Gemini Omni 1.1 Flash](https://ai.google.dev/gemini-api/docs/omni)
- [Veo in the Gemini API](https://ai.google.dev/gemini-api/docs/veo)
- [Cloud Gemini Omni 1.1 Flash](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/omni-1-1-flash)
- [Cloud Veo 3.1](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate)

## Validation

- 605 tests passed
- Ruff lint and format passed
- mypy passed for source and tests
- Bandit passed
- push hook passed the full test, coverage, lint, type, and security suite
- independent focused rereview: 188 tests, Ruff, and mypy passed

## Dependency

Depends on #365. Because automation PRs target `main`, this draft temporarily includes the groundwork commit; its diff will shrink after #365 merges.
