### PR TITLE
fix(openai): correct reasoning effort choices

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -73,7 +73,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high", "xhigh"]
+                options=["none", "low", "medium", "high", "xhigh"]
             ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -90,9 +90,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high", "xhigh"]
-            ),
+            TextParameter.THINKING_BUDGET: Choice(options=["medium", "high", "xhigh"]),
             TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -176,7 +174,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high"]
+                options=["none", "low", "medium", "high"]
             ),
             TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
@@ -321,7 +319,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high", "xhigh"]
+                options=["none", "low", "medium", "high", "xhigh"]
             ),
             TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
@@ -355,7 +353,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high"]
+                options=["none", "low", "medium", "high", "xhigh"]
             ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -373,7 +371,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high"]
+                options=["none", "low", "medium", "high", "xhigh"]
             ),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.OUTPUT_SCHEMA: Schema(),
@@ -390,7 +388,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high", "xhigh"]
+                options=["none", "low", "medium", "high", "xhigh"]
             ),
             TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
@@ -408,9 +406,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.MAX_TOKENS: Range(min=1, max=128000),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high", "xhigh"]
-            ),
+            TextParameter.THINKING_BUDGET: Choice(options=["medium", "high", "xhigh"]),
             TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),


### PR DESCRIPTION
Celeste rejected supported `none` and `xhigh` reasoning settings on existing OpenAI models, while two Pro entries advertised unsupported lower-effort settings. The shared mapper forwards these catalog values unchanged to `reasoning.effort`, so the catalog directly controls which requests users can make.

This draft corrects only `THINKING_BUDGET` choices for eight existing model IDs:

| Models | Supported choices |
| --- | --- |
| gpt-5.1 | none, low, medium, high |
| gpt-5.2, gpt-5.4, gpt-5.5 | none, low, medium, high, xhigh |
| gpt-5.4-mini, gpt-5.4-nano | none, low, medium, high, xhigh |
| gpt-5.2-pro, gpt-5.4-pro | medium, high, xhigh |

No shared mapper, transport, streaming flag, default, model identity, or price changes. Original GPT-5 and GPT-5.6 choices are unchanged. This is a correction to current documented support, verified August 31, 2026; no availability date is inferred.

Change family: **Parameters**.
Closes #368.

### Official evidence

The [generated request schema](https://github.com/openai/openai-python/blob/main/src/openai/types/shared_params/reasoning.py) establishes the wire literals and directs callers to model-specific support. The [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning#reasoning-effort) and these current model pages establish the exact subsets:

- [GPT-5.1](https://developers.openai.com/api/docs/models/gpt-5.1)
- [GPT-5.2](https://developers.openai.com/api/docs/models/gpt-5.2) and [GPT-5.2 Pro](https://developers.openai.com/api/docs/models/gpt-5.2-pro)
- [GPT-5.4](https://developers.openai.com/api/docs/models/gpt-5.4), [Mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini), [nano](https://developers.openai.com/api/docs/models/gpt-5.4-nano), and [Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro)
- [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5)

### Validation

- 126 focused model, mapper, and parameter tests passed.
- Full `make ci`: 585 unit tests passed, 69.28% coverage; Ruff, formatting, source/test mypy, and Bandit passed. Used a writable `UV_CACHE_DIR` and the freshly synced all-extras environment.
- An independent request-building check exercised all 70 supported model/effort/mode combinations across unary and streaming request construction, rejection of unsupported values, omission of unset effort, and unchanged neighboring catalog entries.
- Reopened every model evidence page after implementation and checked the complete diff against it.
- All 11 hosted checks passed, including the four Python/OS test combinations, lint/format, type checking, Bandit, CodeQL, and automated review.
- No live inference call was made; this patch changes catalog data only. No new tests were added to the repository.

### Cross-repository impact

No dependent PRs. `celeste-pricing` needs no rate change for these effort choices; its 96 current GPT-5.6 token-price cells match official pricing. `celeste-chat` serves Sol/Forge, Terra/Flow, and Luna/Spark, whose constraints and role assignments are unchanged.

Existing hosted-tool billing drafts [#362](https://github.com/withceleste/celeste-python/pull/362) and [pricing #18](https://github.com/withceleste/celeste-pricing/pull/18) remain separate and are not dependencies.
