### PR TITLE
fix(bfl): honor settled image costs and terminal polling states

### DIFF
--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -5,6 +5,8 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
+import httpx
+
 from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import StreamingNotSupportedError
@@ -70,8 +72,19 @@ class BFLImagesClient(APIMixin):
         submit_data = submit_response.json()
         polling_url = submit_data.get("polling_url")
 
-        if not polling_url:
+        if not isinstance(polling_url, str) or not polling_url:
             msg = f"No polling_url in {self.provider} response"
+            raise ValueError(msg)
+
+        parsed_url = httpx.URL(polling_url)
+        if (
+            parsed_url.scheme != "https"
+            or parsed_url.host not in {"api.bfl.ai", "api.eu.bfl.ai", "api.us.bfl.ai"}
+            or parsed_url.port not in {None, 443}
+            or parsed_url.username
+            or parsed_url.password
+        ):
+            msg = f"Untrusted polling_url in {self.provider} response"
             raise ValueError(msg)
 
         # Phase 2: Poll for completion
@@ -90,6 +103,7 @@ class BFLImagesClient(APIMixin):
             poll_response = await self.http_client.get(
                 polling_url,
                 headers=poll_headers,
+                follow_redirects=False,
             )
 
             self._handle_error_response(poll_response)
@@ -102,9 +116,15 @@ class BFLImagesClient(APIMixin):
                     **poll_data,
                     "_submit_metadata": submit_data,
                 }
-            elif status in ("Error", "Failed"):
-                error_msg = poll_data.get("error", "Unknown error")
-                msg = f"{self.provider} image generation failed: {error_msg}"
+            elif status in (
+                "Error",
+                "Failed",
+                "Request Moderated",
+                "Content Moderated",
+                "Task not found",
+            ):
+                error_msg = poll_data.get("error") or poll_data.get("details") or status
+                msg = f"{self.provider} image generation failed ({status}): {error_msg}"
                 raise ValueError(msg)
 
             await asyncio.sleep(config.POLLING_INTERVAL)
@@ -142,9 +162,11 @@ class BFLImagesClient(APIMixin):
     def _parse_usage(
         self, response_data: dict[str, Any]
     ) -> dict[str, int | float | None]:
-        """Extract usage data from BFL response."""
-        submit_metadata = response_data.get("_submit_metadata", {})
-        return BFLImagesClient.map_usage_fields(submit_metadata)
+        """Prefer settled credits and retain submission megapixel telemetry."""
+        usage_data = dict(response_data.get("_submit_metadata", {}))
+        if response_data.get("cost") is not None:
+            usage_data["cost"] = response_data["cost"]
+        return BFLImagesClient.map_usage_fields(usage_data)
 
     def _parse_content(self, response_data: dict[str, Any]) -> Any:
         """Parse result from response."""

--- a/tests/unit_tests/test_http.py
+++ b/tests/unit_tests/test_http.py
@@ -5,9 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 import celeste.http as http_module
-from celeste.core import Modality, Provider
+from celeste.artifacts import ImageArtifact
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
 from celeste.http import (
     DEFAULT_TIMEOUT,
     MAX_RETRIES,
@@ -16,6 +19,9 @@ from celeste.http import (
     close_all_http_clients,
     get_http_client,
 )
+from celeste.modalities.images.providers.bfl.client import BFLImagesClient
+from celeste.modalities.images.providers.bfl.models import MODELS as BFL_MODELS
+from celeste.models import Model
 
 
 @pytest.fixture
@@ -302,3 +308,160 @@ async def test_ndjson_error_body_remains_readable(transport: AsyncMock) -> None:
         async for _ in HTTPClient().stream_post_ndjson("https://example.com", {}, {}):
             pass
     assert error.value.response.json()["error"]["message"] == "forbidden"
+
+
+@pytest.fixture
+def bfl_client() -> BFLImagesClient:
+    return BFLImagesClient(
+        model=next(model for model in BFL_MODELS if model.id == "flux-2-max"),
+        provider=Provider.BFL,
+        auth=AuthHeader(secret=SecretStr("test-key"), header="x-key", prefix=""),
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "operation"),
+    [
+        (model, operation)
+        for model in BFL_MODELS
+        for operation in sorted(model.operations[Modality.IMAGES])
+    ],
+    ids=lambda value: value.id if isinstance(value, Model) else value,
+)
+async def test_bfl_polling_preserves_result_and_billing_metadata(
+    transport: AsyncMock,
+    bfl_client: BFLImagesClient,
+    model: Model,
+    operation: Operation,
+) -> None:
+    bfl_client.model = model
+    polling_url = "https://api.eu.bfl.ai/v1/get_result?id=task&region=eu"
+    submitted = {"id": "task", "polling_url": polling_url, "cost": 5, "input_mp": 1}
+    settled: dict[str, Any] = {
+        "id": "task",
+        "status": "Ready",
+        "cost": 2.5,
+        "result": {"sample": "https://delivery.eu.bfl.ai/image.png?signature=test"},
+    }
+    transport.post.return_value = httpx.Response(200, json=submitted)
+    transport.get.side_effect = [
+        httpx.Response(200, json={"status": status})
+        for status in ("Pending", "Reasoning", "Generating")
+    ] + [httpx.Response(200, json=settled)]
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        patch("celeste.providers.bfl.images.client.asyncio.sleep", new=AsyncMock()),
+    ):
+        if operation == Operation.EDIT:
+            output = await bfl_client.edit(
+                ImageArtifact(url="https://example.com/input.png"), "edit"
+            )
+        else:
+            output = await bfl_client.generate("generate")
+
+    assert transport.post.call_args.args == (f"https://api.bfl.ai/v1/{model.id}",)
+    assert len(transport.get.call_args_list) == 4
+    assert all(
+        request.args == (polling_url,)
+        and request.kwargs["headers"]["x-key"] == "test-key"
+        and request.kwargs["follow_redirects"] is False
+        for request in transport.get.call_args_list
+    )
+    assert isinstance(output.content, ImageArtifact)
+    assert output.content.url == settled["result"]["sample"]
+    assert (
+        output.finish_reason is not None and output.finish_reason.reason == "COMPLETE"
+    )
+    assert output.usage.billed_units == 2.5
+    assert output.usage.input_mp == 1
+    assert output.metadata["raw_response"]["cost"] == 2.5
+    assert output.metadata["raw_response"]["_submit_metadata"] == submitted
+    assert "result" not in output.metadata["raw_response"]
+
+
+@pytest.mark.parametrize(
+    ("settled", "expected"),
+    [({"cost": 2.5}, 2.5), ({"cost": 0}, 0), ({"cost": None}, 5), ({}, 5)],
+)
+def test_bfl_settled_credits_override_submission_estimates(
+    bfl_client: BFLImagesClient, settled: dict[str, Any], expected: float
+) -> None:
+    submitted = {"cost": 5, "input_mp": 1, "output_mp": 2}
+    assert bfl_client._parse_usage({**settled, "_submit_metadata": submitted}) == {
+        "billed_units": expected,
+        "input_mp": 1,
+        "output_mp": 2,
+    }
+    assert submitted["cost"] == 5
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["Error", "Failed", "Request Moderated", "Content Moderated", "Task not found"],
+)
+async def test_bfl_terminal_failures_stop_polling_with_details(
+    transport: AsyncMock, bfl_client: BFLImagesClient, status: str
+) -> None:
+    transport.post.return_value = httpx.Response(
+        200, json={"polling_url": "https://api.bfl.ai/v1/get_result?id=task"}
+    )
+    transport.get.side_effect = [
+        httpx.Response(200, json={"status": status, "details": {"reason": "blocked"}}),
+        AssertionError("Terminal response must not be polled again"),
+    ]
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        patch("celeste.providers.bfl.images.client.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(ValueError, match="blocked") as error,
+    ):
+        await bfl_client.generate("generate")
+    assert status in str(error.value)
+    transport.get.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "polling_url",
+    [
+        None,
+        1,
+        "",
+        "/v1/get_result?id=task",
+        "http://api.bfl.ai/v1/get_result?id=task",
+        "https://api.bfl.ai:8443/v1/get_result?id=task",
+        "https://user:password@api.bfl.ai/v1/get_result?id=task",
+        "https://api.bfl.ai.evil.example/v1/get_result?id=task",
+        "https://api.bfl.ai@evil.example/v1/get_result?id=task",
+        "https://delivery.eu.bfl.ai/image.png",
+    ],
+)
+async def test_bfl_rejects_untrusted_polling_urls_before_sending_credentials(
+    transport: AsyncMock, bfl_client: BFLImagesClient, polling_url: object
+) -> None:
+    transport.post.return_value = httpx.Response(200, json={"polling_url": polling_url})
+    transport.get.side_effect = AssertionError("Untrusted URL must not be requested")
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        pytest.raises(ValueError, match="polling_url"),
+    ):
+        await bfl_client.generate("generate")
+    transport.get.assert_not_awaited()
+
+
+@pytest.mark.parametrize("host", ["api.bfl.ai", "api.eu.bfl.ai", "api.us.bfl.ai"])
+async def test_bfl_does_not_follow_authenticated_polling_redirects(
+    transport: AsyncMock, bfl_client: BFLImagesClient, host: str
+) -> None:
+    polling_url = f"https://{host}/v1/get_result?id=task"
+    transport.post.return_value = httpx.Response(200, json={"polling_url": polling_url})
+    transport.get.return_value = httpx.Response(
+        302,
+        request=httpx.Request("GET", polling_url),
+        headers={"Location": "https://delivery.eu.bfl.ai/image.png"},
+    )
+    with (
+        patch("celeste.http.httpx.AsyncClient", return_value=transport),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        await bfl_client.generate("generate")
+    transport.get.assert_awaited_once()
+    assert transport.get.call_args.kwargs["follow_redirects"] is False


### PR DESCRIPTION
BFL's current hosted Images API reports settled credits in the final poll, but Celeste only reads submission cost. Moderated and missing tasks also keep polling until timeout, and authenticated polling currently follows redirects.

This fixes the existing BFL Images transport without introducing the video transport from draft #346:

- Stop on `Request Moderated`, `Content Moderated`, and `Task not found`, alongside the existing `Error`/`Failed` handling; include the provider's error/details and status.
- Prefer final top-level `cost`, including zero, with submission fallback when absent/null. Retain submission megapixel telemetry: the settled response schema documents `cost`, not settled megapixel fields.
- Poll the exact returned URL with its query intact, allowing only HTTPS `api.bfl.ai`, `api.eu.bfl.ai`, or `api.us.bfl.ai` on the default HTTPS port, without userinfo. Disable redirects so the API key cannot follow an untrusted host or delivery URL.

Scope: all 12 currently registered BFL hosted Images models, covering their 21 generation/editing combinations (FLUX.2 fixed/preview, Kontext, and legacy endpoints). Submission still uses the existing global API path. No new model, operation, streaming, webhook, video, or Chat product-role support is added. The API behavior is current as verified on 2026-08-31; its introduction date is unknown. Undocumented polling hosts fail closed rather than receiving credentials.

Evidence:

- [Get Result](https://docs.bfl.ai/api-reference/utility/get-result): settled credits, terminal statuses, and details.
- [Current OpenAPI](https://api.bfl.ai/openapi.json): `SettledCostResultResponse` versus `ResultResponse` and `AsyncResponse`.
- [Integration guide](https://docs.bfl.ai/api_integration/integration_guidelines): exact returned polling URL, documented global/regional API hosts, separate temporary delivery URLs.

Validation:

- `uv run pytest tests/unit_tests/test_http.py -q`: 63 passed. Exercises every registered generation/editing combination, intermediate states, terminal failures, settled and zero cost, raw billing metadata, trusted hosts, untrusted URLs, and redirects.
- `make ci`: passed lint, formatting, source/test mypy, Bandit, and 628 unit tests; coverage 69.96% (65% required).
- Fresh independent review reopened the evidence, inspected the full diff and shared callers, and reran the HTTP tests. No actionable findings.
- Combined with parameter draft #378 in a separate scratch worktree: `make ci` passes 687 tests with 70.21% coverage; 280 focused HTTP/parameter/wire/constraint tests and all 21 Chat tool schemas pass. Both published branches remain unchanged.
- GitHub checks at `59422f1e1c8110f6769bc3d69ab51cb558e7cb95` passed: formatting, lint, types, Bandit, all four Python/OS test jobs, CodeQL/Actions analysis, and the automated review job. No review comments were present when inspected.
- No live billed BFL generation was run.

Related work: draft #346 overlaps some BFL polling/cost behavior but also adds video; it should preserve this Images policy when rebased. The separate [family-parameter draft #378](https://github.com/withceleste/celeste-python/pull/378) and [settled-cost pricing draft #26](https://github.com/withceleste/celeste-pricing/pull/26) are independently correct. Chat already retains the raw response and routes both image operations correctly, and will need dependency refreshes after upstream merge/release. No dependency sources are changed here; no merge, release, or deployment is included.
