### PR TITLE
fix(google): preserve all Vertex text response parts

### DIFF
--- a/src/celeste/modalities/text/providers/google/vertex.py
+++ b/src/celeste/modalities/text/providers/google/vertex.py
@@ -164,16 +164,14 @@ class GoogleVertexTextClient(GoogleGenerateContentMixin, TextClient):
         self,
         response_data: dict[str, Any],
     ) -> TextContent:
-        """Parse content from response."""
+        """Join non-thought text from every Part of the first candidate."""
         candidates = super()._parse_content(response_data)
         parts = candidates[0].get("content", {}).get("parts", [])
-        for p in parts:
-            if p.get("thought"):
-                continue
-            text = p.get("text")
-            if text is not None:
-                return text
-        return ""
+        return "".join(
+            part["text"]
+            for part in parts
+            if not part.get("thought") and part.get("text") is not None
+        )
 
     def _parse_reasoning(
         self, response_data: dict[str, Any]

--- a/src/celeste/providers/google/generate_content/streaming.py
+++ b/src/celeste/providers/google/generate_content/streaming.py
@@ -41,7 +41,7 @@ class GoogleGenerateContentStream:
         return super()._parse_chunk(event_data)  # type: ignore[misc]
 
     def _parse_chunk_content(self, event_data: dict[str, Any]) -> str | None:
-        """Extract content from SSE event."""
+        """Join non-thought text from every Part of the first candidate."""
         candidates = event_data.get("candidates", [])
         if not candidates:
             return None
@@ -50,14 +50,12 @@ class GoogleGenerateContentStream:
         content = candidate.get("content", {})
         parts = content.get("parts", [])
 
-        for p in parts:
-            if p.get("thought"):
-                continue
-            text = p.get("text")
-            if text is not None:
-                return text
-
-        return None
+        texts = [
+            part["text"]
+            for part in parts
+            if not part.get("thought") and part.get("text") is not None
+        ]
+        return "".join(texts) if texts else None
 
     def _parse_chunk_reasoning(self, event_data: dict[str, Any]) -> str | None:
         """Extract thought content from SSE event."""

--- a/tests/unit_tests/test_google_native_replay.py
+++ b/tests/unit_tests/test_google_native_replay.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncIterator
 from typing import Any
 
+import pytest
 from pydantic import SecretStr
 
 from celeste import Model
@@ -84,3 +85,44 @@ async def test_google_stream_replays_native_tool_parts_verbatim() -> None:
 
     assert request["contents"][0] == {"role": "model", "parts": parts}
     assert request["contents"][1]["parts"][0]["functionResponse"]["id"] == "audio-1"
+
+
+@pytest.mark.parametrize("bundled", [False, True])
+async def test_google_vertex_preserves_all_text_parts(bundled: bool) -> None:
+    parts = [
+        {"text": "private thought", "thought": True, "thoughtSignature": "sig"},
+        {"text": "Let me calculate. "},
+        {"executableCode": {"language": "PYTHON", "code": "print(2 + 2)"}},
+        {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "4\n"}},
+        {"text": "The answer is 4."},
+    ]
+    other_candidate = {"content": {"parts": [{"text": "ignore alternative"}]}}
+    response = {
+        "candidates": [{"content": {"parts": parts}}, other_candidate],
+    }
+    client = object.__new__(GoogleVertexTextClient)
+    expected = "Let me calculate. The answer is 4."
+    assert client._parse_content(response) == expected
+    assert client._parse_reasoning(response) == ("private thought", parts)
+
+    groups = [parts] if bundled else [[part] for part in parts]
+    events: list[dict[str, Any]] = [
+        {"candidates": [{"content": {"parts": group}}, other_candidate]}
+        for group in groups
+    ]
+    events.append({"candidates": [{"finishReason": "STOP"}]})
+    stream = GoogleVertexTextStream(_async_iter(events))
+    chunks = [chunk async for chunk in stream]
+    assert "".join(chunk.content for chunk in chunks) == expected
+    assert stream.output.content == expected
+    assert stream.output.reasoning == "private thought"
+    assert stream.output.signature == parts
+
+
+def test_google_vertex_non_text_parts_do_not_emit_text() -> None:
+    stream = object.__new__(GoogleVertexTextStream)
+    for parts in ([], [{"thought": True, "text": "private"}], [{"text": None}]):
+        response = {"candidates": [{"content": {"parts": parts}}]}
+        assert object.__new__(GoogleVertexTextClient)._parse_content(response) == ""
+        assert stream._parse_chunk_content(response) is None
+    assert stream._parse_chunk_content({}) is None


### PR DESCRIPTION
## Summary

Fix an API-contract mismatch in Google text responses: Celeste returned the first non-thought text Part and discarded all later text Parts. The same early return existed in unary parsing and inside each SSE event. This loses the final answer when a response contains text, native code/tool Parts, and more text.

Concatenate all non-thought text Parts from the first candidate, matching Google's SDK. Preserve first-candidate selection, empty/no-text behavior, reasoning separation, and the exact native tool transcript used for replay. No model IDs, rates, parameter mappings, or dependencies change.

## Official evidence and scope

- [Google Cloud v1 Content/Part reference](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/Content) defines multipart content, text Parts, thought Parts, executable code, and execution-result Parts.
- [Google's Python SDK](https://github.com/googleapis/python-genai/blob/main/google/genai/types.py) documents `GenerateContentResponse.text` as concatenated text from the first candidate and skips thought Parts.
- [Google Cloud release notes, August 13](https://docs.cloud.google.com/gemini-enterprise-agent-platform/release-notes#August_13_2026) establish currently available Gemini 3.7 Flash and its agentic video-processing default. Video input in a text-model interaction remains text scope; this is not video generation.

This is a correction to Celeste's handling of the current contract, not a claim that multipart content was introduced on August 13. The original effective date of that wire behavior is unknown.

Affected route: Google ADC / Vertex `v1 ...:generateContent` and `...:streamGenerateContent?alt=sse`. The shared GenerateContent stream mixin has only the Vertex text stream as a current consumer. Developer API `v1beta/interactions` already concatenates model-output text and is unchanged. No separate image/audio/video client is changed.

## Cross-repository impact

- `celeste-pricing`: no change; usage and raw-response billing metadata are untouched.
- `celeste-chat`: no change; its text authentication resolves to API-key AuthHeaders and therefore Interactions, not ADC/Vertex. Its `celeste-ai` lock remains at `9017933`; this PR is not represented as deployed Chat behavior. Existing Spark/Flow/Forge and title-model choices stay unchanged.
- No dependent PRs.

## Validation

- New regression failed on the original implementation, demonstrating loss of the final answer.
- Focused native-replay, Interactions reconstruction, stream-metadata, and dispatcher checks: **18 passed**.
- `make ci`: **588 passed**, coverage **69.62%** (required 65%); Ruff, formatting, both mypy passes, and Bandit succeeded.
- Tests cover bundled vs separate SSE Parts, unary/streamed output, thought exclusion, native replay, alternative candidates, missing candidates in streaming, and absent/null text.
- `uv run pytest tests/integration_tests/text/test_generate.py -k google -q --tb=short`: **4 failed before generation, 24 deselected**. Developer API has no configured Google credentials; ADC reports `Reauthentication is needed. Please run gcloud auth application-default login to reauthenticate.` No live-serving success is claimed.
- Fresh full-diff review against the official Content contract and SDK text semantics completed; `git diff --check` passes.
- Remote checks on `ed45b683eb99ab8d2e99265f2d2004f339408505`: **11/11 passed**, including Linux Python 3.12/3.13, macOS/Windows Python 3.12, formatting, lint, types, security, CodeQL/Actions analysis, and the review workflow. No PR comments were present at inspection.

## Separate unresolved findings

No speculative fixes are bundled for the existing Gemini 3.6 promotional-pricing surface/location ambiguity, Robotics ER 2 route/transport verification, or part-relative grounding offsets. In particular, this PR fixes visible text extraction, not the existing citation mapper's lack of part-index reconstruction; safe streaming citation rebasing still needs an authenticated multi-part trace. Native Parts remain available unchanged.

Draft only. No merge, release, publish, or deployment requested.
