### PR TITLE
fix(images): route sync and stream operations correctly

### DIFF
--- a/src/celeste/modalities/images/client.py
+++ b/src/celeste/modalities/images/client.py
@@ -103,6 +103,7 @@ class ImagesStreamNamespace:
         return self._client._stream(
             inputs,
             stream_class=self._client._stream_class(),
+            endpoint=self._client._generate_endpoint,
             extra_body=extra_body,
             extra_headers=extra_headers,
             **parameters,
@@ -118,10 +119,14 @@ class ImagesStreamNamespace:
         **parameters: Unpack[ImageParameters],
     ) -> ImagesStream:
         """Stream image editing."""
+        if self._client._edit_endpoint is None:
+            msg = f"Model {self._client.model.id} does not support image editing"
+            raise NotImplementedError(msg)
         inputs = ImageInput(prompt=prompt, image=image)
         return self._client._stream(
             inputs,
             stream_class=self._client._stream_class(),
+            endpoint=self._client._edit_endpoint,
             extra_body=extra_body,
             extra_headers=extra_headers,
             **parameters,
@@ -153,7 +158,11 @@ class ImagesSyncNamespace:
         """
         inputs = ImageInput(prompt=prompt)
         return async_to_sync(self._client._predict)(
-            inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
+            inputs,
+            endpoint=self._client._generate_endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
         )
 
     def edit(
@@ -171,9 +180,16 @@ class ImagesSyncNamespace:
             result = client.sync.edit(image, "Add a rainbow")
             result.content.show()
         """
+        if self._client._edit_endpoint is None:
+            msg = f"Model {self._client.model.id} does not support image editing"
+            raise NotImplementedError(msg)
         inputs = ImageInput(prompt=prompt, image=image)
         return async_to_sync(self._client._predict)(
-            inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
+            inputs,
+            endpoint=self._client._edit_endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
         )
 
     def upscale(
@@ -190,9 +206,16 @@ class ImagesSyncNamespace:
             result = client.sync.upscale(image)
             result.content.show()
         """
+        if self._client._upscale_endpoint is None:
+            msg = f"Model {self._client.model.id} does not support image upscaling"
+            raise NotImplementedError(msg)
         inputs = ImageInput(image=image)
         return async_to_sync(self._client._predict)(
-            inputs, extra_body=extra_body, extra_headers=extra_headers, **parameters
+            inputs,
+            endpoint=self._client._upscale_endpoint,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            **parameters,
         )
 
     @property

--- a/tests/unit_tests/test_images_operation_routing.py
+++ b/tests/unit_tests/test_images_operation_routing.py
@@ -1,0 +1,57 @@
+import pytest
+
+from celeste.artifacts import ImageArtifact
+from celeste.modalities.images.client import ImagesStreamNamespace, ImagesSyncNamespace
+from celeste.models import Model
+
+
+class _Client:
+    model = Model(id="image-model", display_name="Image model", streaming=True)
+    _generate_endpoint = "/generate"
+    _edit_endpoint = "/edit"
+    _upscale_endpoint = "/upscale"
+
+    def __init__(self) -> None:
+        self.endpoints: list[str | None] = []
+
+    async def _predict(
+        self, inputs: object, *, endpoint: str | None = None, **_: object
+    ) -> str:
+        self.endpoints.append(endpoint)
+        return "output"
+
+    def _stream(
+        self, inputs: object, *, endpoint: str | None = None, **_: object
+    ) -> str:
+        self.endpoints.append(endpoint)
+        return "stream"
+
+    def _stream_class(self) -> type:
+        return object
+
+
+def test_image_namespaces_route_each_operation_to_its_endpoint() -> None:
+    client = _Client()
+    image = ImageArtifact(url="https://example.com/image.png")
+
+    sync = ImagesSyncNamespace(client)  # type: ignore[arg-type]
+    sync.generate("new")
+    sync.edit(image, "change")
+    sync.upscale(image)
+
+    stream = ImagesStreamNamespace(client)  # type: ignore[arg-type]
+    stream.generate("new")
+    stream.edit(image, "change")
+
+    assert client.endpoints == ["/generate", "/edit", "/upscale", "/generate", "/edit"]
+
+
+def test_image_namespaces_reject_unsupported_edit() -> None:
+    client = _Client()
+    client._edit_endpoint = None
+    image = ImageArtifact(url="https://example.com/image.png")
+
+    with pytest.raises(NotImplementedError, match="does not support image editing"):
+        ImagesSyncNamespace(client).edit(image, "change")  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="does not support image editing"):
+        ImagesStreamNamespace(client).edit(image, "change")  # type: ignore[arg-type]


### PR DESCRIPTION
The synchronous Images namespaces omit the selected operation endpoint, so xAI `sync.edit()` falls back to `/v1/images/generations`. Route generation, editing, and upscaling through the same endpoint fields used by the async methods, and make streaming namespaces preserve their selected generation/editing endpoint too. Unsupported edit/upscale calls now use the existing async guards. Change family: **API contract**.

xAI's [editing guide](https://docs.x.ai/developers/model-capabilities/images/editing) and [Images endpoint reference](https://docs.x.ai/developers/rest-api-reference/inference/images), reopened August 31, 2026, explicitly distinguish JSON `/v1/images/edits` from `/v1/images/generations`. The existing base and Quality image models are affected; this is also groundwork for image 2.0. This corrects an existing Celeste routing defect, not a new provider release or inferred effective date.

The fix belongs at the shared Images namespace that all callers use. Provider implementations keep their own encoding, model-specific endpoint handling, and streaming declarations. In particular, this does not enable xAI Images streaming. Sync-stream methods already delegate to the streaming namespace, so no second implementation is needed.

Validation:

- Both focused namespace tests passed: all five operation/namespace routes and unsupported editing.
- Full `make ci` passed: Ruff, formatting, mypy source/tests, Bandit, and all 587 unit tests with coverage (Python 3.13).
- Commit hooks passed. Independent review traced all seven registered image providers and sync-stream callers without finding a blocking regression.
- No provider-live requests were made. All 11 available GitHub checks passed, including the Python 3.12/3.13 OS matrix, static checks, CodeQL, and repository review workflow.

This is an independent shared groundwork draft, kept separate from the image 2.0 catalog/parameter change per repository policy. Merge it and [response preservation #374](https://github.com/withceleste/celeste-python/pull/374) before [image 2.0 support #377](https://github.com/withceleste/celeste-python/pull/377). The combined three-patch worktree passed full `make ci` with 597 unit tests; no Chat source change is required.
