### PR TITLE
fix(openai): correct speech voices and output formats

### DIFF
--- a/src/celeste/modalities/audio/providers/openai/client.py
+++ b/src/celeste/modalities/audio/providers/openai/client.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from celeste.artifacts import AudioArtifact
+from celeste.mime_types import AudioMimeType
 from celeste.parameters import ParameterMapper
 from celeste.providers.openai.audio import config
 from celeste.providers.openai.audio.client import OpenAIAudioClient as OpenAIAudioMixin
@@ -50,7 +51,23 @@ class OpenAIAudioClient(OpenAIAudioMixin, AudioClient):
             if not audio_bytes:
                 msg = "No audio data in response"
                 raise ValueError(msg)
-            return AudioArtifact(data=audio_bytes)
+            content_type = (
+                response_data.get("headers", {})
+                .get("content-type", "")
+                .split(";", 1)[0]
+                .strip()
+                .lower()
+            )
+            try:
+                mime_type = AudioMimeType(content_type)
+            except ValueError:
+                response_format = response_data.get("response_format")
+                mime_type = (
+                    self._map_response_format_to_mime_type(response_format)
+                    if response_format
+                    else None
+                )
+            return AudioArtifact(data=audio_bytes, mime_type=mime_type)
         return super()._parse_content(response_data)
 
     def _parse_finish_reason(self, response_data: dict[str, Any]) -> AudioFinishReason:

--- a/src/celeste/modalities/audio/providers/openai/models.py
+++ b/src/celeste/modalities/audio/providers/openai/models.py
@@ -15,6 +15,7 @@ _RESPONSE_FORMAT_OPTIONS = [
     AudioMimeType.OGG,  # Maps to "opus" in OpenAI API
     AudioMimeType.AAC,
     AudioMimeType.FLAC,
+    AudioMimeType.WAV,
 ]
 
 _OPENAI_TRANSCRIBE_MIME_TYPES = [

--- a/src/celeste/modalities/audio/providers/openai/voices.py
+++ b/src/celeste/modalities/audio/providers/openai/voices.py
@@ -30,8 +30,14 @@ OPENAI_VOICES = [
     )
 ]
 
-TTS1_VOICES = OPENAI_VOICES
-TTS1_HD_VOICES = OPENAI_VOICES
+# https://developers.openai.com/api/docs/guides/text-to-speech#voice-options
+TTS1_VOICES = [
+    voice
+    for voice in OPENAI_VOICES
+    if voice.id
+    in {"alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"}
+]
+TTS1_HD_VOICES = TTS1_VOICES
 GPT4O_MINI_TTS_VOICES = OPENAI_VOICES
 
 __all__ = [

--- a/src/celeste/providers/openai/audio/client.py
+++ b/src/celeste/providers/openai/audio/client.py
@@ -11,6 +11,7 @@ from celeste.mime_types import AudioMimeType
 from celeste.utils import detect_mime_type
 
 from . import config
+from .parameters import ResponseFormatMapper
 
 _MIME_TO_EXT: dict[str, str] = {
     AudioMimeType.FLAC: "flac",
@@ -102,6 +103,7 @@ class OpenAIAudioClient(APIMixin):
         return {
             "audio_bytes": response.content,
             "headers": dict(response.headers),
+            "response_format": request_body.get("response_format") or "mp3",
         }
 
     async def _make_transcription_request(
@@ -195,15 +197,9 @@ class OpenAIAudioClient(APIMixin):
         self, response_format: str | None
     ) -> AudioMimeType:
         """Map OpenAI response_format to AudioMimeType."""
-        format_map: dict[str, AudioMimeType] = {
-            "mp3": AudioMimeType.MP3,
-            "opus": AudioMimeType.OGG,
-            "aac": AudioMimeType.AAC,
-            "flac": AudioMimeType.FLAC,
-            "wav": AudioMimeType.WAV,
-            "pcm": AudioMimeType.WAV,
-        }
-        return format_map.get(response_format or "", AudioMimeType.MP3)
+        return ResponseFormatMapper._mime_map.get(
+            response_format or "", AudioMimeType.MP3
+        )
 
 
 __all__ = ["OpenAIAudioClient"]

--- a/src/celeste/providers/openai/audio/parameters.py
+++ b/src/celeste/providers/openai/audio/parameters.py
@@ -29,6 +29,8 @@ class ResponseFormatMapper(ParameterMapper[AudioContent]):
         "opus": AudioMimeType.OGG,
         "aac": AudioMimeType.AAC,
         "flac": AudioMimeType.FLAC,
+        "wav": AudioMimeType.WAV,
+        "pcm": AudioMimeType.PCM,
     }
 
     def map(
@@ -38,26 +40,15 @@ class ResponseFormatMapper(ParameterMapper[AudioContent]):
         model: Model,
     ) -> dict[str, Any]:
         """Transform response_format into provider request."""
-        # Convert string values to AudioMimeType enum before validation
-        if isinstance(value, str) and not isinstance(value, AudioMimeType):
-            string_to_mime_type: dict[str, AudioMimeType] = {
-                "mp3": AudioMimeType.MP3,
-                "opus": AudioMimeType.OGG,  # OpenAI uses "opus" for OGG format
-                "aac": AudioMimeType.AAC,
-                "flac": AudioMimeType.FLAC,
-            }
-            value = string_to_mime_type.get(value.lower(), value)
+        if isinstance(value, str):
+            value = self._mime_map.get(value.lower(), value)
 
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
 
-        # Convert AudioMimeType enum to OpenAI string format
-        mime_type_to_openai_format: dict[AudioMimeType, str] = {
-            AudioMimeType.MP3: "mp3",
-            AudioMimeType.OGG: "opus",  # OpenAI uses "opus" for OGG format
-            AudioMimeType.AAC: "aac",
-            AudioMimeType.FLAC: "flac",
+        mime_type_to_openai_format = {
+            mime: output_format for output_format, mime in self._mime_map.items()
         }
 
         response_format = mime_type_to_openai_format.get(validated_value, "mp3")
@@ -66,10 +57,18 @@ class ResponseFormatMapper(ParameterMapper[AudioContent]):
 
     def parse_output(self, content: AudioContent, value: object | None) -> AudioContent:
         """Apply response_format → MIME type mapping to parsed content."""
-        if not isinstance(content, AudioArtifact):
+        if not isinstance(content, AudioArtifact) or content.mime_type is not None:
             return content
-        mime_type = self._mime_map.get(str(value) if value else "", AudioMimeType.MP3)
-        return AudioArtifact(data=content.data, mime_type=mime_type)
+        output_format = str(value).lower() if value is not None else ""
+        mime_type = next(
+            (
+                mime
+                for wire, mime in self._mime_map.items()
+                if output_format in (wire, mime)
+            ),
+            AudioMimeType.MP3,
+        )
+        return content.model_copy(update={"mime_type": mime_type})
 
 
 class InstructionsMapper(FieldMapper[AudioContent]):

--- a/tests/unit_tests/test_audio_voices.py
+++ b/tests/unit_tests/test_audio_voices.py
@@ -9,6 +9,9 @@ from celeste.modalities.audio.providers.google.models import (
 )
 from celeste.modalities.audio.providers.google.voices import GOOGLE_VOICES
 from celeste.modalities.audio.providers.gradium.voices import GRADIUM_VOICES
+from celeste.modalities.audio.providers.openai.models import (
+    MODELS as OPENAI_AUDIO_MODELS,
+)
 from celeste.modalities.audio.providers.openai.voices import OPENAI_VOICES
 from celeste.modalities.audio.voices import Voice
 
@@ -71,3 +74,31 @@ def test_voice_constraint_still_accepts_name_and_id() -> None:
 
     assert constraint(voice.name) == voice.id
     assert constraint(voice.id) == voice.id
+
+
+@pytest.mark.parametrize(
+    ("model_id", "additional_voices"),
+    [
+        ("tts-1", set()),
+        ("tts-1-hd", set()),
+        ("gpt-4o-mini-tts", {"ballad", "verse", "marin", "cedar"}),
+        ("gpt-4o-mini-tts-2025-12-15", {"ballad", "verse", "marin", "cedar"}),
+    ],
+)
+def test_openai_voice_availability_is_model_specific(
+    model_id: str, additional_voices: set[str]
+) -> None:
+    model = next(model for model in OPENAI_AUDIO_MODELS if model.id == model_id)
+    constraint = model.parameter_constraints[AudioParameter.VOICE]
+    assert isinstance(constraint, VoiceConstraint)
+    assert {voice.id for voice in constraint.voices} == {
+        "alloy",
+        "ash",
+        "coral",
+        "echo",
+        "fable",
+        "onyx",
+        "nova",
+        "sage",
+        "shimmer",
+    } | additional_voices

--- a/tests/unit_tests/test_openai_audio_speak.py
+++ b/tests/unit_tests/test_openai_audio_speak.py
@@ -1,0 +1,100 @@
+"""OpenAI speech formats preserve their wire encoding and artifact MIME type."""
+
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from celeste.artifacts import AudioArtifact
+from celeste.auth import AuthHeader
+from celeste.constraints import ConstraintViolationError
+from celeste.mime_types import AudioMimeType
+from celeste.modalities.audio.io import AudioInput
+from celeste.modalities.audio.providers.openai.client import OpenAIAudioClient
+from celeste.modalities.audio.providers.openai.models import MODELS
+
+
+def _client(model_id: str = "tts-1") -> OpenAIAudioClient:
+    return OpenAIAudioClient(
+        model=next(model for model in MODELS if model.id == model_id),
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    ["tts-1", "tts-1-hd", "gpt-4o-mini-tts", "gpt-4o-mini-tts-2025-12-15"],
+)
+@pytest.mark.parametrize(
+    ("wire", "mime_type"),
+    [
+        ("mp3", AudioMimeType.MP3),
+        ("opus", AudioMimeType.OGG),
+        ("aac", AudioMimeType.AAC),
+        ("flac", AudioMimeType.FLAC),
+        ("wav", AudioMimeType.WAV),
+    ],
+)
+def test_speech_format_round_trips(
+    model_id: str, wire: str, mime_type: AudioMimeType
+) -> None:
+    client = _client(model_id)
+    content = AudioArtifact(data=b"speech", metadata={"marker": "preserved"})
+    for value in (wire, wire.upper(), mime_type, mime_type.value):
+        request = client._build_request(
+            AudioInput(text="Hello"), voice="alloy", output_format=value
+        )
+        output = client._transform_output(content, output_format=value)
+        assert request["response_format"] == wire
+        assert isinstance(output, AudioArtifact)
+        assert output.mime_type == mime_type
+        assert output.data == content.data
+        assert output.metadata == content.metadata
+
+
+@pytest.mark.parametrize(
+    ("response_data", "mime_type"),
+    [
+        (
+            {
+                "headers": {"content-type": "audio/ogg; codecs=opus"},
+                "response_format": "wav",
+            },
+            AudioMimeType.OGG,
+        ),
+        (
+            {
+                "headers": {"content-type": "application/octet-stream"},
+                "response_format": "wav",
+            },
+            AudioMimeType.WAV,
+        ),
+        ({"response_format": "pcm"}, AudioMimeType.PCM),
+        ({"response_format": "mp3"}, AudioMimeType.MP3),
+    ],
+)
+def test_speech_response_preserves_applied_format(
+    response_data: dict[str, Any], mime_type: AudioMimeType
+) -> None:
+    client = _client()
+    response_data = {"audio_bytes": b"speech", **response_data}
+    content = client._parse_content(response_data)
+    output = client._transform_output(content, output_format="audio/aac")
+    assert isinstance(output, AudioArtifact)
+    assert output.data == b"speech"
+    assert output.mime_type == mime_type
+    assert "audio_bytes" not in client._build_metadata(response_data)["raw_response"]
+
+
+def test_speech_format_override_uses_existing_request_escape_hatch() -> None:
+    client = _client()
+    request = client._build_request(
+        AudioInput(text="Hello"),
+        voice="alloy",
+        output_format="aac",
+        extra_body={"response_format": "wav"},
+    )
+    assert request["response_format"] == "wav"
+
+    with pytest.raises(ConstraintViolationError):
+        client._build_request(AudioInput(text="Hello"), output_format="pcm")


### PR DESCRIPTION
## Summary

TTS-1 and TTS-1 HD currently advertise four voices outside their documented model-specific set. Speech requested using Celeste MIME strings or enums can also be labelled MP3 even when the returned bytes use another format, leaving incorrect metadata on persisted audio.

- Limit TTS-1 and TTS-1 HD to their nine supported voices; retain all thirteen for the mini TTS models.
- Add WAV to the existing output-format choices and reuse one format mapping for request construction and response parsing.
- Preserve the provider's recognized audio Content-Type, or fall back to the format actually sent after request overrides. Do not overwrite that MIME with the original parameter.
- Preserve artifact fields and metadata while continuing to exclude large audio bytes from response metadata.

## Official evidence and scope

The [model-specific voice documentation](https://developers.openai.com/api/docs/guides/text-to-speech#voice-options) lists the nine TTS-1/HD voices. The [speech endpoint reference](https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create) and [output-format documentation](https://developers.openai.com/api/docs/guides/text-to-speech#supported-output-formats) establish the wire formats and distinguish WAV from headerless PCM. The effective date of the voice restriction is not stated; this corrects current documented behavior, not an inferred rollout date.

This patch covers Celeste Audio `SPEAK` for `tts-1`, `tts-1-hd`, `gpt-4o-mini-tts`, and `gpt-4o-mini-tts-2025-12-15`: JSON requests to `POST /v1/audio/speech`, unary binary responses. Streaming declarations and the multipart transcription path remain unchanged; no Text, Chat Completions, Responses, or Realtime transport is modified.

PCM remains outside model-derived selectable formats because Chat's native players cannot consume headerless PCM directly. Existing explicit provider overrides are labelled honestly as PCM; this patch does not add a decoder or claim PCM playback support.

## Downstream impact

Chat derives speech controls and voice discovery from Celeste metadata and preserves artifact MIME in private storage. Its current dependency pins are unchanged; these fixes reach Chat after an upstream merge and dependency refresh. A credential-free compatibility check exercised its existing schema builder, WAV persistence/hydration, and retained usage envelope against the patched SDK. No Chat-specific implementation or TTS price change is required.

This draft is independent of the existing GPT Transcribe work in [#366](https://github.com/withceleste/celeste-python/pull/366) and [celeste-pricing#24](https://github.com/withceleste/celeste-pricing/pull/24).

## Validation

- `UV_NO_CACHE=1 UV_OFFLINE=1 UV_NO_SYNC=1 make ci`: passed, including Ruff, source/test mypy, Bandit, and **614 tests**; coverage **69.58%**.
- Focused speech, voice, and transcription sibling checks: **43 passed**.
- Credential-free Chat compatibility check: passed for nine/thirteen voices, WAV choices, PCM exclusion, stored MIME, WAV hydration, and duration-envelope preservation.
- No paid provider calls, production writes, releases, or deployments.
- Fresh independent source/diff review: passed, including 37 speech/voice checks and four simulated complete request/response paths for applied overrides and header precedence.
- Hosted checks at `940c4cb`: **all 11 passed**, including the Python/OS matrix, lint, formatting, typing, security, CodeQL, and review workflow. [CI run](https://github.com/withceleste/celeste-python/actions/runs/33367670100). No actionable review comments were present on inspection.
