### PR TITLE
fix(bfl): map image parameters by model family

### DIFF
--- a/src/celeste/constraints.py
+++ b/src/celeste/constraints.py
@@ -132,6 +132,8 @@ class Dimensions(Constraint):
     max_aspect_ratio: float
     presets: dict[str, str] | None = None
     multiple_of: int | None = Field(default=None, gt=0)
+    min_dimension: int | None = Field(default=None, gt=0)
+    max_dimension: int | None = Field(default=None, gt=0)
 
     def __call__(self, value: str) -> str:
         """Validate dimension string against pixel and aspect ratio bounds."""
@@ -169,6 +171,13 @@ class Dimensions(Constraint):
 
         if self.multiple_of and (width % self.multiple_of or height % self.multiple_of):
             msg = f"Width and height must be multiples of {self.multiple_of}"
+            raise ConstraintViolationError(msg)
+
+        if self.min_dimension is not None and min(width, height) < self.min_dimension:
+            msg = f"Width and height must each be at least {self.min_dimension}"
+            raise ConstraintViolationError(msg)
+        if self.max_dimension is not None and max(width, height) > self.max_dimension:
+            msg = f"Width and height must each be at most {self.max_dimension}"
             raise ConstraintViolationError(msg)
 
         # Validate total pixels

--- a/src/celeste/modalities/images/providers/bfl/models.py
+++ b/src/celeste/modalities/images/providers/bfl/models.py
@@ -1,10 +1,56 @@
 """BFL (Black Forest Labs) models for images modality."""
 
-from celeste.constraints import Choice, Dimensions, ImagesConstraint, Int, Range
+from celeste.constraints import (
+    Bool,
+    Choice,
+    Constraint,
+    Dimensions,
+    ImagesConstraint,
+    Int,
+    Range,
+    Str,
+)
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
 from ...parameters import ImageParameter
+
+_FLUX_2_DIMENSIONS = Dimensions(
+    min_pixels=64 * 64,
+    max_pixels=2048 * 2048,
+    # Ratios follow only from the per-axis minimum and total pixel maximum.
+    min_aspect_ratio=1 / 1024,
+    max_aspect_ratio=1024,
+    min_dimension=64,
+    multiple_of=16,
+    presets={
+        "Square 1K": "1024x1024",
+        "Square 2K": "2048x2048",
+        "HD 16:9": "1920x1088",
+        "Portrait HD": "1088x1920",
+        "4:3": "1280x960",
+        "3:4": "960x1280",
+        "Ultra-wide 21:9": "1920x832",
+        "Portrait 9:21": "832x1920",
+    },
+)
+_LEGACY_DIMENSIONS = Dimensions(
+    min_pixels=256 * 256,
+    max_pixels=1440 * 1440,
+    min_aspect_ratio=256 / 1440,
+    max_aspect_ratio=1440 / 256,
+    min_dimension=256,
+    max_dimension=1440,
+    multiple_of=32,
+    presets={"Square": "1024x1024", "Landscape": "1024x768", "Portrait": "768x1024"},
+)
+_LEGACY_CONSTRAINTS: dict[str, Constraint] = {
+    ImageParameter.PROMPT_UPSAMPLING: Bool(),
+    ImageParameter.SEED: Int(),
+    ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6, step=1),
+    ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+}
+_ASPECT_RATIO = Str(description="Aspect ratio from 3:7 to 7:3, for example 16:9.")
 
 MODELS: list[Model] = [
     Model(
@@ -13,27 +59,11 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [max]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,  # 4,096
-                max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
-            # Note: flux-2-max always upsamples prompts (no prompt_upsampling parameter)
-            # Includes grounding search for real-time information integration
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -43,25 +73,11 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [pro]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,  # 4,096
-                max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -71,25 +87,11 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [pro] Preview",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,
-                max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -99,25 +101,10 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [klein] 4B",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,
-                max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -127,25 +114,10 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [klein] 9B",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,
-                max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -155,25 +127,10 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [klein] 9B Preview",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,
-                max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=3),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
         },
     ),
@@ -183,27 +140,13 @@ MODELS: list[Model] = [
         display_name="FLUX.2 [flex]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
         parameter_constraints={
-            ImageParameter.ASPECT_RATIO: Dimensions(
-                min_pixels=64 * 64,  # 4,096
-                max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
-                presets={
-                    "Square 1K": "1024x1024",
-                    "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
-                    "4:3": "1280x960",
-                    "3:4": "960x1280",
-                    "Ultra-wide 21:9": "1920x832",
-                    "Portrait 9:21": "832x1920",
-                },
-            ),
+            ImageParameter.ASPECT_RATIO: _FLUX_2_DIMENSIONS,
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=7),
             ImageParameter.SEED: Int(),
-            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5, step=1),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
-            ImageParameter.STEPS: Range(min=1, max=50),
+            ImageParameter.STEPS: Range(min=1, max=50, step=1),
             ImageParameter.GUIDANCE: Range(min=1.5, max=10.0),
         },
     ),
@@ -212,30 +155,58 @@ MODELS: list[Model] = [
         provider=Provider.BFL,
         display_name="FLUX.1 Kontext [max]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            **_LEGACY_CONSTRAINTS,
+            ImageParameter.ASPECT_RATIO: _ASPECT_RATIO,
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(
+                max_count=3, description="Experimental additional reference images."
+            ),
+        },
     ),
     Model(
         id="flux-kontext-pro",
         provider=Provider.BFL,
         display_name="FLUX.1 Kontext [pro]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            **_LEGACY_CONSTRAINTS,
+            ImageParameter.ASPECT_RATIO: _ASPECT_RATIO,
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(
+                max_count=3, description="Experimental additional reference images."
+            ),
+        },
     ),
     Model(
         id="flux-pro-1.1-ultra",
         provider=Provider.BFL,
         display_name="FLUX1.1 [pro] Ultra",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            **_LEGACY_CONSTRAINTS,
+            ImageParameter.ASPECT_RATIO: _ASPECT_RATIO,
+        },
     ),
     Model(
         id="flux-pro-1.1",
         provider=Provider.BFL,
         display_name="FLUX1.1 [pro]",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            **_LEGACY_CONSTRAINTS,
+            ImageParameter.ASPECT_RATIO: _LEGACY_DIMENSIONS,
+        },
     ),
     Model(
         id="flux-dev",
         provider=Provider.BFL,
         display_name="FLUX.1 [dev]",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            **_LEGACY_CONSTRAINTS,
+            ImageParameter.ASPECT_RATIO: _LEGACY_DIMENSIONS,
+            ImageParameter.STEPS: Range(min=1, max=50, step=1),
+            ImageParameter.GUIDANCE: Range(min=1.5, max=5.0),
+        },
     ),
 ]
 

--- a/src/celeste/modalities/images/providers/bfl/parameters.py
+++ b/src/celeste/modalities/images/providers/bfl/parameters.py
@@ -5,10 +5,10 @@ from typing import Any
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.bfl.images.parameters import (
-    GuidanceMapper as _GuidanceMapper,
+    AspectRatioMapper as _AspectRatioMapper,
 )
 from celeste.providers.bfl.images.parameters import (
-    HeightMapper as _HeightMapper,
+    GuidanceMapper as _GuidanceMapper,
 )
 from celeste.providers.bfl.images.parameters import (
     OutputFormatMapper as _OutputFormatMapper,
@@ -25,47 +25,14 @@ from celeste.providers.bfl.images.parameters import (
 from celeste.providers.bfl.images.parameters import (
     StepsMapper as _StepsMapper,
 )
-from celeste.providers.bfl.images.parameters import (
-    WidthMapper as _WidthMapper,
-)
 from celeste.providers.bfl.images.utils import add_reference_images
 from celeste.types import ImageContent
 
 from ...parameters import ImageParameter
 
 
-class AspectRatioMapper(ParameterMapper[ImageContent]):
-    """Map aspect_ratio to BFL width/height parameters.
-
-    Converts 'WxH' string to width/height, rounded to nearest multiple of 16.
-    Delegates to provider's WidthMapper and HeightMapper for the actual mapping.
-    """
-
+class AspectRatioMapper(_AspectRatioMapper):
     name = ImageParameter.ASPECT_RATIO
-
-    def map(
-        self,
-        request: dict[str, Any],
-        value: object,
-        model: Model,
-    ) -> dict[str, Any]:
-        """Transform aspect_ratio into provider request."""
-        validated_value = self._validate_value(value, model)
-        if validated_value is None:
-            return request
-
-        parts = validated_value.split("x")
-        width = int(parts[0])
-        height = int(parts[1])
-
-        # Round to nearest multiple of 16 as required by BFL API
-        width = ((width + 8) // 16) * 16
-        height = ((height + 8) // 16) * 16
-
-        # Delegate to provider mappers
-        request = _WidthMapper().map(request, width, model)
-        request = _HeightMapper().map(request, height, model)
-        return request
 
 
 class PromptUpsamplingMapper(_PromptUpsamplingMapper):

--- a/src/celeste/providers/bfl/images/parameters.py
+++ b/src/celeste/providers/bfl/images/parameters.py
@@ -42,10 +42,53 @@ class HeightMapper(ParameterMapper[ImageContent]):
         return request
 
 
+class AspectRatioMapper(ParameterMapper[ImageContent]):
+    """Map ratios or exact pixel dimensions to the model's BFL fields."""
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform aspect_ratio into provider request."""
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+
+        if model.id in {"flux-kontext-pro", "flux-kontext-max", "flux-pro-1.1-ultra"}:
+            request["aspect_ratio"] = validated_value
+            return request
+
+        width, height = validated_value.split("x")
+        request = WidthMapper().map(request, width, model)
+        return HeightMapper().map(request, height, model)
+
+
 class PromptUpsamplingMapper(FieldMapper[ImageContent]):
-    """Map prompt_upsampling to BFL prompt_upsampling field."""
+    """Map prompt rewriting to the model's native control and polarity."""
 
     field = "prompt_upsampling"
+
+    def map(
+        self,
+        request: dict[str, Any],
+        value: object,
+        model: Model,
+    ) -> dict[str, Any]:
+        """Transform prompt_upsampling into provider request."""
+        if model.id in {"flux-2-max", "flux-2-pro", "flux-2-pro-preview"}:
+            validated_value = self._validate_value(value, model)
+            if validated_value is not None:
+                request["disable_pup"] = not validated_value
+            return request
+        if model.id in {
+            "flux-2-klein-4b",
+            "flux-2-klein-9b",
+            "flux-2-klein-9b-preview",
+        }:
+            return request
+        return super().map(request, value, model)
 
 
 class SeedMapper(FieldMapper[ImageContent]):
@@ -79,6 +122,7 @@ class GuidanceMapper(FieldMapper[ImageContent]):
 
 
 __all__ = [
+    "AspectRatioMapper",
     "GuidanceMapper",
     "HeightMapper",
     "OutputFormatMapper",

--- a/tests/unit_tests/test_bfl_image_parameters.py
+++ b/tests/unit_tests/test_bfl_image_parameters.py
@@ -1,0 +1,232 @@
+from typing import Any
+
+import pytest
+
+from celeste.artifacts import ImageArtifact
+from celeste.constraints import Dimensions
+from celeste.core import Modality, Operation, Provider
+from celeste.exceptions import ConstraintViolationError
+from celeste.mime_types import ImageMimeType
+from celeste.modalities.images.io import ImageInput
+from celeste.modalities.images.parameters import ImageParameter as IP
+from celeste.modalities.images.providers.bfl.client import BFLImagesClient
+from celeste.models import get_model
+
+FLUX_2 = [
+    "flux-2-max",
+    "flux-2-pro",
+    "flux-2-pro-preview",
+    "flux-2-flex",
+    "flux-2-klein-4b",
+    "flux-2-klein-9b",
+    "flux-2-klein-9b-preview",
+]
+LEGACY_DIMENSIONS = ["flux-pro-1.1", "flux-dev"]
+PRIMARY = ImageArtifact(data=b"primary", mime_type=ImageMimeType.PNG)
+REFERENCE = ImageArtifact(url="https://example.com/reference.png")
+
+
+@pytest.mark.parametrize(
+    ("model_id", "size", "size_fields", "upsampling_field", "editable"),
+    [
+        ("flux-2-max", "4096x512", {"width": 4096, "height": 512}, "disable_pup", True),
+        ("flux-2-pro", "4096x512", {"width": 4096, "height": 512}, "disable_pup", True),
+        (
+            "flux-2-pro-preview",
+            "4096x512",
+            {"width": 4096, "height": 512},
+            "disable_pup",
+            True,
+        ),
+        (
+            "flux-2-flex",
+            "4096x512",
+            {"width": 4096, "height": 512},
+            "prompt_upsampling",
+            True,
+        ),
+        ("flux-2-klein-4b", "4096x512", {"width": 4096, "height": 512}, None, True),
+        ("flux-2-klein-9b", "4096x512", {"width": 4096, "height": 512}, None, True),
+        (
+            "flux-2-klein-9b-preview",
+            "4096x512",
+            {"width": 4096, "height": 512},
+            None,
+            True,
+        ),
+        (
+            "flux-kontext-pro",
+            "16:9",
+            {"aspect_ratio": "16:9"},
+            "prompt_upsampling",
+            True,
+        ),
+        (
+            "flux-kontext-max",
+            "16:9",
+            {"aspect_ratio": "16:9"},
+            "prompt_upsampling",
+            True,
+        ),
+        (
+            "flux-pro-1.1-ultra",
+            "16:9",
+            {"aspect_ratio": "16:9"},
+            "prompt_upsampling",
+            False,
+        ),
+        (
+            "flux-pro-1.1",
+            "1440x256",
+            {"width": 1440, "height": 256},
+            "prompt_upsampling",
+            False,
+        ),
+        (
+            "flux-dev",
+            "1440x256",
+            {"width": 1440, "height": 256},
+            "prompt_upsampling",
+            False,
+        ),
+    ],
+)
+@pytest.mark.parametrize("upsampling", [False, True, None])
+def test_bfl_family_requests(
+    model_id: str,
+    size: str,
+    size_fields: dict[str, Any],
+    upsampling_field: str | None,
+    editable: bool,
+    upsampling: bool | None,
+) -> None:
+    model = get_model(model_id, Provider.BFL)
+    assert model is not None
+    operations = (
+        {Operation.GENERATE, Operation.EDIT} if editable else {Operation.GENERATE}
+    )
+    assert model.operations == {Modality.IMAGES: operations}
+    assert not model.streaming
+    assert (IP.PROMPT_UPSAMPLING in model.supported_parameters) == (
+        upsampling_field is not None
+    )
+    assert {
+        IP.ASPECT_RATIO,
+        IP.SEED,
+        IP.SAFETY_TOLERANCE,
+        IP.OUTPUT_FORMAT,
+    } <= model.supported_parameters
+    assert (IP.REFERENCE_IMAGES in model.supported_parameters) == editable
+    client = BFLImagesClient.model_construct(model=model, provider=Provider.BFL)
+
+    for image in [None, PRIMARY] if editable else [None]:
+        parameters: dict[str, Any] = {
+            "aspect_ratio": size,
+            "prompt_upsampling": upsampling,
+            "seed": 0,
+            "safety_tolerance": 0,
+            "output_format": "webp",
+        }
+        expected = {
+            "prompt": "A red apple",
+            "seed": 0,
+            "safety_tolerance": 0,
+            "output_format": "webp",
+            **size_fields,
+        }
+        if upsampling_field is not None and upsampling is not None:
+            expected[upsampling_field] = (
+                not upsampling if upsampling_field == "disable_pup" else upsampling
+            )
+        if image is not None:
+            expected["input_image"] = "cHJpbWFyeQ=="
+        if editable:
+            parameters["reference_images"] = [REFERENCE]
+            expected["input_image_2" if image else "input_image"] = REFERENCE.url
+        assert (
+            client._build_request(
+                ImageInput(prompt="A red apple", image=image), **parameters
+            )
+            == expected
+        )
+
+
+@pytest.mark.parametrize("model_id", FLUX_2 + LEGACY_DIMENSIONS)
+def test_bfl_pixel_dimensions_are_exact(model_id: str) -> None:
+    model = get_model(model_id, Provider.BFL)
+    assert model is not None
+    constraint = model.parameter_constraints[IP.ASPECT_RATIO]
+    assert isinstance(constraint, Dimensions)
+    client = BFLImagesClient.model_construct(model=model, provider=Provider.BFL)
+    if model_id in FLUX_2:
+        valid = ["64x64", "64x4096", "4096x64", "2048x2048"]
+        invalid = ["48x128", "128x48", "1920x1080", "1080x1920", "2064x2048"]
+    else:
+        valid = ["256x256", "256x1440", "1440x256", "1440x1440"]
+        invalid = ["224x512", "512x224", "1472x1024", "1024x1472", "272x512", "512x272"]
+    for value in valid:
+        width, height = map(int, value.split("x"))
+        assert client._build_request(
+            ImageInput(prompt="A red apple"), aspect_ratio=value
+        ) == {"prompt": "A red apple", "width": width, "height": height}
+    for value in invalid:
+        with pytest.raises(ConstraintViolationError):
+            client._build_request(ImageInput(prompt="A red apple"), aspect_ratio=value)
+    for name, dimensions in (constraint.presets or {}).items():
+        width, height = map(int, dimensions.split("x"))
+        assert client._build_request(
+            ImageInput(prompt="A red apple"), aspect_ratio=name
+        ) == {"prompt": "A red apple", "width": width, "height": height}
+
+
+@pytest.mark.parametrize("model_id", ["flux-kontext-pro", "flux-kontext-max"])
+def test_kontext_preserves_order_with_three_additional_images(model_id: str) -> None:
+    model = get_model(model_id, Provider.BFL)
+    assert model is not None
+    client = BFLImagesClient.model_construct(model=model, provider=Provider.BFL)
+    references = [ImageArtifact(url=f"https://example.com/{i}.png") for i in range(3)]
+    request = client._build_request(
+        ImageInput(prompt="Compose these", image=PRIMARY), reference_images=references
+    )
+    assert request == {
+        "prompt": "Compose these",
+        "input_image": "cHJpbWFyeQ==",
+        "input_image_2": references[0].url,
+        "input_image_3": references[1].url,
+        "input_image_4": references[2].url,
+    }
+    with pytest.raises(ConstraintViolationError):
+        client._build_request(
+            ImageInput(prompt="Compose these", image=PRIMARY),
+            reference_images=[*references, REFERENCE],
+        )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        *FLUX_2,
+        "flux-kontext-pro",
+        "flux-kontext-max",
+        "flux-pro-1.1-ultra",
+        *LEGACY_DIMENSIONS,
+    ],
+)
+def test_bfl_integer_controls_and_family_limits(model_id: str) -> None:
+    model = get_model(model_id, Provider.BFL)
+    assert model is not None
+    constraint = model.parameter_constraints[IP.SAFETY_TOLERANCE]
+    maximum = 5 if model_id in FLUX_2 else 6
+    assert constraint(maximum) == maximum
+    for invalid in [-1, 0.5, maximum + 1]:
+        with pytest.raises(ConstraintViolationError):
+            constraint(invalid)
+    if model_id in {"flux-dev", "flux-2-flex"}:
+        assert model.parameter_constraints[IP.STEPS](50) == 50
+        for invalid in [0, 1.5, 51]:
+            with pytest.raises(ConstraintViolationError):
+                model.parameter_constraints[IP.STEPS](invalid)
+        guidance_max = 5 if model_id == "flux-dev" else 10
+        assert model.parameter_constraints[IP.GUIDANCE](guidance_max) == guidance_max
+        with pytest.raises(ConstraintViolationError):
+            model.parameter_constraints[IP.GUIDANCE](guidance_max + 0.1)


### PR DESCRIPTION
Celeste currently converts every BFL `aspect_ratio` into rounded pixel dimensions and sends `prompt_upsampling` with one wire shape. That breaks the documented controls for several hosted image families and leaves the five legacy models without discoverable parameter metadata.

This corrects the current hosted `https://api.bfl.ai/v1/{model_id}` contract, without changing endpoints, model operations, defaults, streaming, asynchronous transport, pricing, or product roles. The effective date of these provider corrections is unknown; they are present in the official API reference and schema checked on 2026-08-31.

- `flux-2-max`, `flux-2-pro`, and `flux-2-pro-preview`: map the existing unified `prompt_upsampling` boolean to inverse `disable_pup`, preserving omitted controls and false values.
- `flux-2-flex`: advertise and retain native `prompt_upsampling`; `flux-2-klein-4b`, `flux-2-klein-9b`, and `flux-2-klein-9b-preview` advertise no such control and emit neither field.
- All seven FLUX.2 endpoints: require exact 16-pixel dimensions, at least 64 per axis, up to 2048×2048 total pixels, and remove the unrelated 9:21–21:9 restriction. Existing HD presets now use 1088 pixels and no mapper silently changes requested dimensions.
- `flux-kontext-pro`, `flux-kontext-max`, and `flux-pro-1.1-ultra`: send native ratio strings through `aspect_ratio`. Advertise the five legacy models' mapped seed, prompt, safety, and format controls; Kontext's three additional references retain their documented experimental status and preserve primary-image ordering.
- `flux-pro-1.1` and `flux-dev`: represent exact 256–1440 bounds per axis and 32-pixel multiples; retain Dev's separate steps/guidance limits. Optional axis bounds extend the existing `Dimensions` constraint without changing other models' defaults.

The current API reference and OpenAPI both enumerate `jpeg`, `png`, and `webp` for these endpoints. The older Kontext how-to table omits WebP and names a different output default; this patch does not inject a default or narrow previously accepted WebP behavior. Legacy `image_prompt` remains unadvertised because its singular base64 contract does not match the numbered URL/base64 reference mapper.

Evidence:

- [BFL OpenAPI](https://api.bfl.ai/openapi.json), including each exact endpoint's request schema.
- [FLUX.2 Max prompt control](https://docs.bfl.ai/api-reference/models/generate-or-edit-an-image-with-flux2-%5Bmax%5D) and [Flex control](https://docs.bfl.ai/api-reference/models/generate-or-edit-an-image-with-flux2-%5Bflex%5D).
- [BFL output dimensions](https://help.bfl.ai/articles/8916739058-what-aspect-ratios-and-output-dimensions-are-supported) and [Klein controls](https://help.bfl.ai/articles/7592221790-how-do-i-generate-quickly-with-flux-2-klein).
- [Kontext reference](https://docs.bfl.ai/api-reference/models/edit-or-create-an-image-with-flux1-kontext-%5Bpro%5D), [Ultra reference](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux11-%5Bpro%5D-ultra-mode), [Pro 1.1 reference](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux11-%5Bpro%5D), and [Dev reference](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux1-%5Bdev%5D).

Validation: `make ci` passes on macOS/Python 3.13.3: Ruff lint/format, mypy, Bandit, 644 unit tests, 69.59% coverage. The focused BFL/wire/constraint selection passes 217 tests. Request tests cover all 12 registered BFL models and each supported generation/editing operation, true/false/omitted prompt controls, exact dimension boundaries/presets, and reference ordering. A separate local check built and validated all 21 generation/editing tool schemas using Chat's installed `celeste-tools==0.3.13`; its preset enum/constraint-description path consumes the updated metadata without a downstream source edit. No paid live BFL generation was run.

GitHub checks at `01a1c72497281415e2338846f8256f6fbebebd19` all passed: formatting, lint, types, Bandit, all four Python/OS test jobs, CodeQL/Actions analysis, and the automated review job.

Combined with async draft #372 in a separate scratch worktree: `make ci` passes 687 tests with 70.21% coverage; 280 focused HTTP/parameter/wire/constraint tests and all 21 Chat tool schemas pass. The two drafts apply cleanly together without an extra fix; neither published branch was changed by this check.

Independent review reopened the exact endpoint references and current dimension guidance, traced the shared mapping and validation path, and ran all 59 new parameter tests. No actionable findings remained. A separate review of the wider `Dimensions` consumers and Chat's resolved tool-schema adapter found no required downstream source change.

This parameter correction is independent of the asynchronous contract correction in #372 and the [settled-cost pricing draft](https://github.com/withceleste/celeste-pricing/pull/26). Chat can consume the corrected metadata after its existing Celeste dependency is refreshed from merged main; no draft branch dependency is introduced. No release, merge, or Chat lockfile change is included.

Fixes #369.
