### PR TITLE
feat(xai): support Responses compaction and native image outputs

### DIFF
--- a/src/celeste/modalities/text/providers/xai/__init__.py
+++ b/src/celeste/modalities/text/providers/xai/__init__.py
@@ -1,6 +1,7 @@
 """xAI provider for text modality."""
 
 from .client import XAITextClient
+from .io import XAITextOutput, XAITextUsage
 from .models import MODELS
 
-__all__ = ["MODELS", "XAITextClient"]
+__all__ = ["MODELS", "XAITextClient", "XAITextOutput", "XAITextUsage"]

--- a/src/celeste/modalities/text/providers/xai/client.py
+++ b/src/celeste/modalities/text/providers/xai/client.py
@@ -1,33 +1,112 @@
 """xAI text client (modality)."""
 
+import base64
 from typing import Any
 
+from asgiref.sync import async_to_sync
+from pydantic import BaseModel
+
+from celeste.artifacts import ImageArtifact
+from celeste.messages import request_messages
+from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
 from celeste.providers.xai.responses.client import (
     XAIResponsesClient as XAIResponsesMixin,
 )
+from celeste.providers.xai.responses.config import XAIResponsesEndpoint
 from celeste.providers.xai.responses.streaming import (
     XAIResponsesStream as _XAIResponsesStream,
 )
-from celeste.types import TextContent
+from celeste.tools import ToolResult
+from celeste.types import ImagePart, Message, Role, TextContent, TextPart
+from celeste.utils import detect_mime_type
 
-from ...io import TextInput
+from ...client import TextSyncNamespace
+from ...io import TextChunk, TextInput
 from ...protocols.openresponses.client import (
     OpenResponsesTextClient,
+    _serialize_messages,
 )
 from ...protocols.openresponses.client import (
     OpenResponsesTextStream as _OpenResponsesTextStream,
 )
 from ...streaming import TextStream
+from .io import XAITextOutput, XAITextUsage
 from .parameters import XAI_PARAMETER_MAPPERS
+
+
+def _has_image_generation_call(output: list[dict[str, Any]]) -> bool:
+    """Return whether output contains a native image-generation call."""
+    return any(item.get("type") == "image_generation_call" for item in output)
+
+
+def _parse_image_content(output: list[dict[str, Any]]) -> list[BaseModel]:
+    """Parse xAI text and image results in their original output order."""
+    parts: list[BaseModel] = []
+    for item in output:
+        if item.get("type") == "message":
+            parts.extend(
+                TextPart(text=part.get("text") or "")
+                for part in item.get("content", [])
+                if part.get("type") == "output_text"
+            )
+        elif item.get("type") == "image_generation_call":
+            result = item.get("result")
+            if not isinstance(result, str) or not result:
+                msg = "image_generation_call result must be a base64 string"
+                raise ValueError(msg)
+            try:
+                data = base64.b64decode(result, validate=True)
+            except ValueError as error:
+                msg = "image_generation_call result is not valid base64"
+                raise ValueError(msg) from error
+            mime = detect_mime_type(data)
+            parts.append(
+                ImagePart(
+                    image=ImageArtifact(
+                        data=data,
+                        mime_type=mime if isinstance(mime, ImageMimeType) else None,
+                        metadata={k: v for k, v in item.items() if k != "result"},
+                    )
+                )
+            )
+    return parts
 
 
 class XAITextStream(_XAIResponsesStream, _OpenResponsesTextStream):
     """xAI streaming for text modality."""
 
+    _usage_class = XAITextUsage
+    _output_class = XAITextOutput
+
+    def _aggregate_content(self, chunks: list[TextChunk]) -> TextContent:
+        """Include final native image results in the aggregated text output."""
+        if self._response_data is not None:
+            output = self._response_data.get("output", [])
+            if _has_image_generation_call(output):
+                return _parse_image_content(output)
+        return super()._aggregate_content(chunks)
+
+    def _aggregate_signature(
+        self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Keep the complete native image response for ordered replay."""
+        if self._response_data is not None:
+            output = self._response_data.get("output", [])
+            if _has_image_generation_call(output):
+                return list(output)
+        return super()._aggregate_signature(chunks, raw_events)
+
 
 class XAITextClient(XAIResponsesMixin, OpenResponsesTextClient):
     """xAI text client."""
+
+    _usage_class = XAITextUsage
+
+    @classmethod
+    def _output_class(cls) -> type[XAITextOutput]:
+        """Return the xAI text output class."""
+        return XAITextOutput
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:
@@ -41,11 +120,93 @@ class XAITextClient(XAIResponsesMixin, OpenResponsesTextClient):
         )
         if inputs.messages is None and not has_media:
             return {"input": inputs.prompt or ""}
-        return super()._init_request(inputs)
+        items: list[dict[str, Any]] = []
+        for message in request_messages(
+            prompt=inputs.prompt,
+            messages=inputs.messages,
+            image=inputs.image,
+            video=inputs.video,
+            audio=inputs.audio,
+            document=inputs.document,
+        ):
+            if (
+                isinstance(message, Message)
+                and message.role == Role.ASSISTANT
+                and message.signature
+                and _has_image_generation_call(message.signature)
+            ):
+                items.extend(message.signature)
+            else:
+                items.extend(_serialize_messages([message]))
+        return {"input": items}
+
+    def _parse_content(self, response_data: dict[str, Any]) -> TextContent:
+        """Parse native image output alongside text when present."""
+        output = response_data.get("output", [])
+        if _has_image_generation_call(output):
+            return _parse_image_content(output)
+        return super()._parse_content(response_data)
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Preserve native image or compaction output for verbatim replay."""
+        reasoning, signature = super()._parse_reasoning(response_data)
+        output = response_data.get("output", [])
+        if _has_image_generation_call(output) or any(
+            item.get("type") == "compaction" for item in output
+        ):
+            signature = list(output)
+        return reasoning, signature
+
+    async def compact(
+        self,
+        prompt: str | None = None,
+        *,
+        messages: list[Message | ToolResult] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> XAITextOutput:
+        """Compact conversation context into an opaque replayable item."""
+        self._check_media_support(messages=messages)
+        return await self._predict(
+            TextInput(prompt=prompt, messages=messages),
+            endpoint=XAIResponsesEndpoint.COMPACT_RESPONSE,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+        )
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""
         return XAITextStream
 
+    @property
+    def sync(self) -> "XAITextSyncNamespace":
+        """Synchronous xAI text operations."""
+        return XAITextSyncNamespace(self)
 
-__all__ = ["XAITextClient", "XAITextStream"]
+
+class XAITextSyncNamespace(TextSyncNamespace):
+    """Synchronous xAI text operations."""
+
+    def __init__(self, client: XAITextClient) -> None:
+        self._client = client
+
+    def compact(
+        self,
+        prompt: str | None = None,
+        *,
+        messages: list[Message | ToolResult] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> XAITextOutput:
+        """Blocking context compaction."""
+        return async_to_sync(self._client.compact)(
+            prompt,
+            messages=messages,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+        )
+
+
+__all__ = ["XAITextClient", "XAITextStream", "XAITextSyncNamespace"]

--- a/src/celeste/modalities/text/providers/xai/io.py
+++ b/src/celeste/modalities/text/providers/xai/io.py
@@ -1,0 +1,72 @@
+"""xAI-specific text IO types."""
+
+from typing import cast
+
+from pydantic import Field, SerializeAsAny, model_validator
+
+from celeste.messages import content_to_text
+from celeste.types import (
+    ImagePart,
+    Message,
+    MessageContent,
+    Role,
+    TextContent,
+    TextPart,
+)
+
+from ...io import TextOutput, TextUsage
+
+
+class XAITextUsage(TextUsage):
+    """xAI text usage, including context-compaction telemetry."""
+
+    dropped_message_count: int | None = None
+
+
+class XAITextOutput(TextOutput):
+    """xAI text output, including native generated images."""
+
+    content: SerializeAsAny[TextContent]
+    usage: XAITextUsage = Field(default_factory=XAITextUsage)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _restore_image_content(cls, data: object) -> object:
+        """Restore serialized image output without interpreting structured JSON."""
+        if not isinstance(data, dict):
+            return data
+        content = data.get("content")
+        signature = data.get("signature")
+        if (
+            isinstance(content, list)
+            and isinstance(signature, list)
+            and any(
+                isinstance(item, dict) and item.get("type") == "image_generation_call"
+                for item in signature
+            )
+        ):
+            data = dict(data)
+            data["content"] = Message(role=Role.ASSISTANT, content=content).content
+        return data
+
+    @property
+    def message(self) -> Message:
+        """Preserve generated image parts in the assistant message."""
+        content = (
+            cast(MessageContent, self.content)
+            if isinstance(self.content, list)
+            and self.content
+            and all(isinstance(part, (TextPart, ImagePart)) for part in self.content)
+            else content_to_text(self.content)
+        )
+        return Message(
+            role=Role.ASSISTANT,
+            content=content,
+            tool_calls=self.tool_calls if self.tool_calls else None,
+            reasoning=self.reasoning,
+            signature=self.signature,
+            container=self.container,
+        )
+
+
+__all__ = ["XAITextOutput", "XAITextUsage"]

--- a/src/celeste/modalities/text/streaming.py
+++ b/src/celeste/modalities/text/streaming.py
@@ -1,6 +1,7 @@
 """Text streaming primitives."""
 
 from celeste.streaming import Stream
+from celeste.types import TextContent
 
 from .io import TextChunk, TextFinishReason, TextOutput, TextUsage
 from .parameters import TextParameters
@@ -15,7 +16,7 @@ class TextStream(Stream[TextOutput, TextParameters, TextChunk]):
     _output_class = TextOutput
     _empty_content = ""
 
-    def _aggregate_content(self, chunks: list[TextChunk]) -> str:
+    def _aggregate_content(self, chunks: list[TextChunk]) -> TextContent:
         """Aggregate content from chunks into raw text."""
         return "".join(chunk.content for chunk in chunks)
 

--- a/src/celeste/providers/xai/responses/client.py
+++ b/src/celeste/providers/xai/responses/client.py
@@ -1,7 +1,8 @@
 """xAI Responses API client."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
+from celeste.io import FinishReason
 from celeste.protocols.openresponses.client import OpenResponsesClient
 
 from . import config
@@ -11,6 +12,19 @@ class XAIResponsesClient(OpenResponsesClient):
     """XAI Responses API client."""
 
     _default_base_url: ClassVar[str] = config.BASE_URL
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
+        """Recognize completed responses even when they contain only tool output."""
+        if response_data.get("status") == "completed":
+            return FinishReason(reason="completed")
+        return super()._parse_finish_reason(response_data)
+
+    @staticmethod
+    def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
+        """Map xAI Responses usage, including context-compaction telemetry."""
+        usage = OpenResponsesClient.map_usage_fields(usage_data)
+        usage["dropped_message_count"] = usage_data.get("dropped_message_count")
+        return usage
 
 
 __all__ = ["XAIResponsesClient"]

--- a/src/celeste/providers/xai/responses/config.py
+++ b/src/celeste/providers/xai/responses/config.py
@@ -7,6 +7,7 @@ class XAIResponsesEndpoint(StrEnum):
     """Endpoints for XAI Responses API."""
 
     CREATE_RESPONSE = "/v1/responses"
+    COMPACT_RESPONSE = "/v1/responses/compact"
     LIST_MODELS = "/v1/models"
     GET_MODEL = "/v1/models/{model_id}"
 

--- a/src/celeste/providers/xai/responses/streaming.py
+++ b/src/celeste/providers/xai/responses/streaming.py
@@ -1,10 +1,28 @@
 """XAI Responses SSE parsing for streaming."""
 
+from typing import Any
+
 from celeste.protocols.openresponses.streaming import OpenResponsesStream
+from celeste.types import ToolActivity, ToolActivityStatus
 
 
 class XAIResponsesStream(OpenResponsesStream):
     """XAI Responses SSE parsing."""
+
+    def _parse_chunk_tool_activity(
+        self, event_data: dict[str, Any]
+    ) -> ToolActivity | None:
+        """Extract xAI native image-generation activity."""
+        event_type = event_data.get("type")
+        if event_type == "response.image_generation_call.in_progress":
+            return ToolActivity(
+                tool_name="generate_image", status=ToolActivityStatus.STARTED
+            )
+        if event_type == "response.image_generation_call.completed":
+            return ToolActivity(
+                tool_name="generate_image", status=ToolActivityStatus.COMPLETED
+            )
+        return super()._parse_chunk_tool_activity(event_data)
 
 
 __all__ = ["XAIResponsesStream"]

--- a/tests/unit_tests/test_xai_context_compaction.py
+++ b/tests/unit_tests/test_xai_context_compaction.py
@@ -1,0 +1,169 @@
+"""xAI Responses context-compaction contracts."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from pydantic import SecretStr
+
+from celeste import Message, Model, Role
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.modalities.text.io import TextInput
+from celeste.modalities.text.protocols.openresponses.client import (
+    OpenResponsesTextClient,
+)
+from celeste.modalities.text.providers.xai.client import XAITextClient, XAITextStream
+from celeste.modalities.text.providers.xai.io import XAITextOutput, XAITextUsage
+from celeste.providers.xai.responses.config import XAIResponsesEndpoint
+
+COMPACTION_ITEM = {
+    "type": "compaction",
+    "id": "cmp_123",
+    "encrypted_content": "opaque-content",
+}
+
+COMPACTION_RESPONSE: dict[str, Any] = {
+    "id": "cmp_123",
+    "object": "response.compaction",
+    "created_at": 1_788_000_000,
+    "model": "grok-4.6",
+    "output": [COMPACTION_ITEM],
+    "usage": {
+        "input_tokens": 12_000,
+        "input_tokens_details": {"cached_tokens": 300},
+        "output_tokens": 800,
+        "output_tokens_details": {"reasoning_tokens": 240},
+        "total_tokens": 12_800,
+        "dropped_message_count": 45,
+    },
+}
+
+
+def _model(provider: Provider = Provider.XAI) -> Model:
+    return Model(
+        id="grok-4.6",
+        provider=provider,
+        display_name="Grok 4.6",
+        operations={Modality.TEXT: {Operation.GENERATE}},
+    )
+
+
+def _client() -> XAITextClient:
+    return XAITextClient(
+        model=_model(),
+        provider=Provider.XAI,
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+
+
+async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+async def test_compact_uses_xai_endpoint_and_preserves_usage_and_item() -> None:
+    client = _client()
+    make_request = AsyncMock(return_value=COMPACTION_RESPONSE)
+
+    with patch.object(XAITextClient, "_make_request", new=make_request):
+        output = await client.compact(
+            messages=[Message(role=Role.USER, content="Long conversation")]
+        )
+
+    assert make_request.await_args is not None
+    request = make_request.await_args.args[0]
+    assert request == {
+        "input": [{"role": "user", "content": "Long conversation"}],
+        "model": "grok-4.6",
+    }
+    assert (
+        make_request.await_args.kwargs["endpoint"]
+        == XAIResponsesEndpoint.COMPACT_RESPONSE
+    )
+    assert isinstance(output, XAITextOutput)
+    assert output.content == ""
+    assert output.signature == COMPACTION_RESPONSE["output"]
+    assert output.usage.dropped_message_count == 45
+    assert output.model_dump()["usage"]["dropped_message_count"] == 45
+    assert "output" not in output.metadata["raw_response"]
+    assert output.metadata["raw_response"]["usage"]["dropped_message_count"] == 45
+
+
+async def test_full_compaction_output_replays_at_head_and_can_recompact() -> None:
+    client = _client()
+    make_request = AsyncMock(return_value=COMPACTION_RESPONSE)
+
+    with patch.object(XAITextClient, "_make_request", new=make_request):
+        compacted = await client.compact("Long conversation")
+
+        followup = client._init_request(
+            TextInput(
+                messages=[
+                    compacted.message,
+                    Message(role=Role.USER, content="What gives particles mass?"),
+                ]
+            )
+        )
+        assert followup["input"] == [
+            *COMPACTION_RESPONSE["output"],
+            {"role": "user", "content": "What gives particles mass?"},
+        ]
+
+        await client.compact(messages=[compacted.message])
+
+    recompact_request = make_request.await_args_list[1].args[0]
+    assert recompact_request["input"] == COMPACTION_RESPONSE["output"]
+
+
+def test_compact_is_available_synchronously() -> None:
+    client = _client()
+    make_request = AsyncMock(return_value=COMPACTION_RESPONSE)
+
+    with patch.object(XAITextClient, "_make_request", new=make_request):
+        output = client.sync.compact("Long conversation")
+
+    assert output.signature == COMPACTION_RESPONSE["output"]
+
+
+async def test_xai_unary_and_stream_outputs_use_provider_usage_types() -> None:
+    client = _client()
+    unary_response = {
+        **COMPACTION_RESPONSE,
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "done"}],
+            }
+        ],
+    }
+    make_request = AsyncMock(return_value=unary_response)
+
+    with patch.object(XAITextClient, "_make_request", new=make_request):
+        unary = await client.generate("hello")
+
+    events = [
+        {"type": "response.output_text.delta", "delta": "done"},
+        {"type": "response.completed", "response": unary_response},
+    ]
+    stream = XAITextStream(_async_iter(events))
+    async for _ in stream:
+        pass
+
+    assert isinstance(unary, XAITextOutput)
+    assert isinstance(unary.usage, XAITextUsage)
+    assert isinstance(stream.output, XAITextOutput)
+    assert isinstance(stream.output.usage, XAITextUsage)
+
+
+def test_shared_openresponses_does_not_capture_xai_compaction_item() -> None:
+    client = OpenResponsesTextClient(
+        model=_model(Provider.OPENAI),
+        provider=Provider.OPENAI,
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+
+    assert client._parse_reasoning(COMPACTION_RESPONSE) == (None, [])

--- a/tests/unit_tests/test_xai_image_generation.py
+++ b/tests/unit_tests/test_xai_image_generation.py
@@ -1,0 +1,238 @@
+"""xAI Responses native image output, streaming, and continuation."""
+
+import base64
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from celeste.auth import AuthHeader
+from celeste.core import Modality, Operation, Provider
+from celeste.mime_types import ImageMimeType
+from celeste.modalities.text.io import TextInput
+from celeste.modalities.text.protocols.openresponses.client import (
+    OpenResponsesTextClient,
+    OpenResponsesTextStream,
+)
+from celeste.modalities.text.providers.ollama.client import OllamaTextClient
+from celeste.modalities.text.providers.openai.client import OpenAITextClient
+from celeste.modalities.text.providers.openrouter.client import OpenRouterTextClient
+from celeste.modalities.text.providers.xai.client import XAITextClient, XAITextStream
+from celeste.modalities.text.providers.xai.io import XAITextOutput
+from celeste.models import Model
+from celeste.tools import ToolResult
+from celeste.types import (
+    ImagePart,
+    Message,
+    Role,
+    TextPart,
+    ToolActivity,
+    ToolActivityStatus,
+)
+
+IMAGE_DATA = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\0" * 20
+IMAGE_RESULT = base64.b64encode(IMAGE_DATA).decode()
+IMAGE_ITEM = {
+    "type": "image_generation_call",
+    "id": "ig_first",
+    "status": "completed",
+    "prompt": "first",
+    "result": IMAGE_RESULT,
+}
+REASONING_ITEM = {
+    "type": "reasoning",
+    "id": "r_01",
+    "summary": [{"type": "summary_text", "text": "Plan."}],
+}
+OUTPUT_ITEMS = [
+    REASONING_ITEM,
+    IMAGE_ITEM,
+    {
+        "type": "message",
+        "id": "msg_01",
+        "status": "completed",
+        "role": "assistant",
+        "content": [
+            {"type": "output_text", "text": "Between "},
+            {"type": "output_text", "text": "images."},
+        ],
+    },
+    {
+        "type": "web_search_call",
+        "id": "ws_01",
+        "status": "completed",
+        "action": {"type": "search", "query": "reference"},
+    },
+    {
+        "type": "function_call",
+        "id": "fc_01",
+        "call_id": "call_01",
+        "name": "save",
+        "arguments": "{}",
+    },
+    {**IMAGE_ITEM, "id": "ie_second", "prompt": "second"},
+]
+
+
+def _client(
+    client_class: type[OpenResponsesTextClient] = XAITextClient,
+) -> OpenResponsesTextClient:
+    return client_class(
+        model=Model(
+            id="grok-4.6",
+            provider=Provider.XAI,
+            display_name="Grok 4.6",
+            operations={Modality.TEXT: {Operation.GENERATE}},
+            streaming=True,
+        ),
+        provider=Provider.XAI,
+        auth=AuthHeader(secret=SecretStr("test")),
+    )
+
+
+async def _async_iter(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+@pytest.mark.parametrize("image_only", [False, True])
+async def test_image_output_unary_stream_and_replay_parity(image_only: bool) -> None:
+    output_items = [IMAGE_ITEM] if image_only else OUTPUT_ITEMS
+    response = {
+        "id": "resp_01",
+        "status": "completed",
+        "output": output_items,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "cost_in_usd_ticks": 12345,
+        },
+    }
+    client = _client()
+    with patch.object(XAITextClient, "_make_request", AsyncMock(return_value=response)):
+        unary = await client.generate("Make an image")
+
+    events: list[dict[str, Any]] = []
+    if not image_only:
+        events.extend(
+            [
+                {"type": "response.reasoning_summary_text.delta", "delta": "Plan."},
+                {"type": "response.output_text.delta", "delta": "Between images."},
+            ]
+        )
+    events.extend(
+        [
+            {"type": "response.image_generation_call.in_progress"},
+            {"type": "response.image_generation_call.generating"},
+            {"type": "response.image_generation_call.completed"},
+            {"type": "response.output_item.done", "item": IMAGE_ITEM},
+            {"type": "response.completed", "response": response},
+        ]
+    )
+    stream = XAITextStream(_async_iter(events))
+    chunks = [chunk async for chunk in stream]
+
+    assert isinstance(unary, XAITextOutput)
+    assert isinstance(stream.output, XAITextOutput)
+    assert unary.content == stream.output.content
+    assert unary.signature == stream.output.signature == output_items
+    assert unary.reasoning == stream.output.reasoning
+    assert unary.tool_calls == stream.output.tool_calls
+    assert unary.finish_reason == stream.output.finish_reason
+    assert unary.finish_reason is not None
+    assert unary.finish_reason.reason == "completed"
+    assert unary.usage == stream.output.usage
+    assert (
+        unary.metadata["raw_response"]["usage"]
+        == (stream.output.metadata["raw_response"]["usage"])
+    )
+    assert [chunk.tool_activity for chunk in chunks if chunk.tool_activity] == [
+        ToolActivity(tool_name="generate_image", status=ToolActivityStatus.STARTED),
+        ToolActivity(tool_name="generate_image", status=ToolActivityStatus.COMPLETED),
+    ]
+
+    assert isinstance(unary.content, list)
+    assert [type(part) for part in unary.content] == (
+        [ImagePart] if image_only else [ImagePart, TextPart, TextPart, ImagePart]
+    )
+    image = unary.content[0]
+    assert isinstance(image, ImagePart)
+    assert image.image.data == IMAGE_DATA
+    assert image.image.mime_type == ImageMimeType.JPEG
+    assert image.image.metadata == {
+        k: v for k, v in IMAGE_ITEM.items() if k != "result"
+    }
+    assert unary.message.content == unary.content
+    restored = XAITextOutput.model_validate_json(unary.model_dump_json())
+    assert restored.content == unary.content
+    assert restored.message == unary.message
+
+    followup = client._init_request(
+        TextInput(
+            messages=[
+                restored.message,
+                ToolResult(content="saved", tool_call_id="call_01"),
+                Message(role=Role.USER, content="Edit the image"),
+            ]
+        )
+    )
+    assert followup["input"] == [
+        *output_items,
+        {"type": "function_call_output", "call_id": "call_01", "output": "saved"},
+        {"role": "user", "content": "Edit the image"},
+    ]
+
+
+@pytest.mark.parametrize("result", [None, "", "not base64!", "é"])
+def test_missing_or_invalid_image_result_is_rejected(result: object) -> None:
+    with pytest.raises(ValueError, match="image_generation_call result"):
+        _client()._parse_content({"output": [{**IMAGE_ITEM, "result": result}]})
+
+
+def test_unknown_image_format_keeps_mime_unset() -> None:
+    content = _client()._parse_content(
+        {"output": [{**IMAGE_ITEM, "result": base64.b64encode(b"unknown").decode()}]}
+    )
+    assert isinstance(content, list)
+    image = content[0]
+    assert isinstance(image, ImagePart)
+    assert image.image.mime_type is None
+
+
+@pytest.mark.parametrize(
+    "client_class",
+    [OpenResponsesTextClient, OpenAITextClient, OpenRouterTextClient, OllamaTextClient],
+)
+def test_other_responses_clients_keep_existing_parsing(
+    client_class: type[OpenResponsesTextClient],
+) -> None:
+    client = _client(client_class)
+    response = {"output": OUTPUT_ITEMS}
+    assert client._parse_content(response) == "Between "
+    assert client._parse_reasoning(response) == ("Plan.", [REASONING_ITEM])
+    stream = object.__new__(OpenResponsesTextStream)
+    assert (
+        stream._parse_chunk_tool_activity(
+            {"type": "response.image_generation_call.in_progress"}
+        )
+        is None
+    )
+
+
+def test_structured_json_is_not_interpreted_as_message_parts() -> None:
+    content = [{"type": "text", "text": "structured JSON"}]
+    output = XAITextOutput(content=content)
+    restored = XAITextOutput.model_validate_json(output.model_dump_json())
+    assert restored.content == content
+    assert restored.message.content == json.dumps(content)
+
+
+def test_native_image_tool_remains_an_explicit_raw_tool() -> None:
+    tool = {"type": "image_generation"}
+    request = _client()._build_request(TextInput(prompt="Make an image"), tools=[tool])
+    assert request["input"] == "Make an image"
+    assert request["tools"] == [tool]


### PR DESCRIPTION
xAI Responses can return opaque compaction state and native image-tool results, but Celeste could not call the compaction endpoint and discarded image content and ordered native items needed for continuation. This draft completes that support at the xAI provider seam.

Change families: **API contract; Capabilities and limits**.

- Add `compact(...)` and `sync.compact(...)` on explicit `XAITextClient` instances, reusing the existing request, authentication, usage, and error pipeline for `POST /v1/responses/compact`.
- Preserve the complete opaque compaction output verbatim for continuation and re-compaction, including `usage.dropped_message_count`.
- Decode native `image_generation_call.result` into existing `ImageArtifact` / `ImagePart` content while preserving mixed output order, multiple images, metadata, image-only responses, JSON restoration, and the complete native output for stateless editing.
- Reconstruct unary and streaming results consistently, map the documented image STARTED / COMPLETED activity, and preserve completed finish state when a response contains only tool output.
- Keep xAI-specific behavior at the provider seam. OpenAI, Ollama, OpenRouter, and shared Responses parsers/types remain unchanged; the only shared edit widens `TextStream._aggregate_content` to its existing `TextContent` contract.

Official evidence reopened on September 1, 2026:

- [Context compaction](https://docs.x.ai/developers/advanced-api-usage/context-compaction), [REST contract](https://docs.x.ai/developers/rest-api-reference/inference/chat#compact-a-conversation), and [release notes](https://docs.x.ai/developers/release-notes): `POST /v1/responses/compact` accepts a model and input, returns a `response.compaction` object, and requires the complete opaque output to be passed unchanged into later Responses calls. Availability is dated May 29, 2026. Compaction uses tokens and cannot rescue an already over-limit request.
- [Image generation tool](https://docs.x.ai/developers/tools/image-generation): conversational `grok-4.6` requests to `/v1/responses` return bare-base64 `image_generation_call` items, require prior native output verbatim for stateless editing, preserve interleaved output order, and emit `in_progress`, `generating`, and `completed` events before the final item carries the image. No partial image previews are documented.
- [Cost tracking](https://docs.x.ai/developers/cost-tracking): exact request cost remains in raw usage metadata for downstream pricing. Related pricing draft: https://github.com/withceleste/celeste-pricing/pull/28.

Scope is the registered xAI REST Responses text client using the existing Bearer / `XAI_API_KEY` route. No xAI SDK/gRPC, Chat Completions, WebSocket, dedicated media API, model catalog, first-class image-tool parameter, automatic Chat compaction policy, or guessed tool fee is added.

Validation on current `main` `be841f6258530c22dbdb927e600b112f85df9227`, Python 3.13.3:

- 18 focused compaction, image, continuation, serialization, and unary/streaming tests passed.
- `make ci` passed: **606 unit tests, 70.68% coverage**, Ruff lint/format, mypy for 389 source and 84 test files, and Bandit with zero issues.
- `git diff --check` passed. The nine feature files are byte-identical to the previously reviewed head; the refresh merge adds only the unrelated Google Vertex fix from current `main`.
- Fresh independent review found no actionable issues across unary/streaming typed output, finish state, native replay, compaction/re-compaction, tool-result continuation, shared consumers, and merge impact.
- No live provider call was made.

All 11 GitHub checks passed on refreshed head `c24f703`, including the Python 3.12 Ubuntu/macOS/Windows and 3.13 Ubuntu matrices, lint, format, types, security, CodeQL, repository review, and Actions analysis. [CI run](https://github.com/withceleste/celeste-python/actions/runs/33532536027).

Chat now locks Celeste to `ee277f147fa279b5786ecdfaa655c27c370ecbe6` and pricing to `0.2.13`, so it consumes neither this draft nor pricing #28 yet. Adoption still requires upstream publication, dependency updates, product/card seeding, and cache refresh. Chat model roles/defaults remain unchanged.

Draft only. No merge, release, package publication, or deployment.
