### PR TITLE
feat(anthropic): add Claude Fable 5.1

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -17,6 +17,26 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="claude-fable-5-1",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Fable 5.1",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="claude-fable-5",
         provider=Provider.ANTHROPIC,
         display_name="Claude Fable 5",
@@ -235,6 +255,7 @@ MODELS: list[Model] = [
 # Models that support web_search dynamic filtering (web_search_20260209); others use basic.
 DYNAMIC_FILTERING_MODELS = frozenset(
     {
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-mythos-5",
         "claude-opus-5",


### PR DESCRIPTION
What: Add Claude Fable 5.1 (`claude-fable-5-1`) to the Anthropic text catalog.
Why: Anthropic released Claude Fable 5.1 GA, effective September 1, 2026.
Evidence: https://platform.claude.com/docs/en/models/fable-5-1/overview (https://platform.claude.com/docs/en/about-claude/model-deprecations)
Files: src/celeste/modalities/text/providers/anthropic/models.py
Validation: make ci pass
Depends on: none

Constraint surface copied verbatim from the existing `claude-fable-5` entry: 128K max output, adaptive-only thinking (`THINKING_LEVEL` low/medium/high/xhigh/max; `budget_tokens` and disabled thinking are both rejected on this model per the model page), no forced `tool_choice`, and the same web_search dynamic-filtering (`web_search_20260209`) eligibility as Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3fXfMySdHnBGmKvcCERV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3fXfMySdHnBGmKvcCERV1)_