### PR TITLE
feat(xai): add grok-imagine-image-2.0 and 21:9, 5:2 aspect ratios

### DIFF
--- a/src/celeste/modalities/images/providers/xai/models.py
+++ b/src/celeste/modalities/images/providers/xai/models.py
@@ -8,6 +8,36 @@ from ...parameters import ImageParameter
 
 MODELS: list[Model] = [
     Model(
+        id="grok-imagine-image-2.0",
+        provider=Provider.XAI,
+        display_name="Grok Imagine Image 2.0",
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.ASPECT_RATIO: Choice(
+                options=[
+                    "1:1",
+                    "3:4",
+                    "4:3",
+                    "9:16",
+                    "16:9",
+                    "2:3",
+                    "3:2",
+                    "9:19.5",
+                    "19.5:9",
+                    "9:20",
+                    "20:9",
+                    "1:2",
+                    "2:1",
+                    "21:9",
+                    "5:2",
+                    "auto",
+                ]
+            ),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["url", "b64_json"]),
+        },
+    ),
+    Model(
         id="grok-imagine-image",
         provider=Provider.XAI,
         display_name="Grok Imagine Image",
@@ -29,6 +59,8 @@ MODELS: list[Model] = [
                     "20:9",
                     "1:2",
                     "2:1",
+                    "21:9",
+                    "5:2",
                     "auto",
                 ]
             ),
@@ -57,6 +89,8 @@ MODELS: list[Model] = [
                     "20:9",
                     "1:2",
                     "2:1",
+                    "21:9",
+                    "5:2",
                     "auto",
                 ]
             ),


### PR DESCRIPTION
What: register grok-imagine-image-2.0 and add the 21:9 and 5:2 aspect_ratio literals to the xAI images catalog
Why: xAI lists grok-imagine-image-2.0 as its current image model ($0.04/image) and the Images REST reference's aspect_ratio enum now includes 21:9 and 5:2 (release notes: August 2026, day unknown; 2.0 launch date unknown)
Evidence: https://docs.x.ai/developers/rest-api-reference/inference/images (https://docs.x.ai/developers/models/grok-imagine-image-2.0)
Files: src/celeste/modalities/images/providers/xai/models.py
Validation: make ci pass
Depends on: none