### PR TITLE
feat(google): register gemini-omni-1.1-flash in the videos catalog

### DIFF
--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -91,6 +91,19 @@ GOOGLE_OMNI_MODELS: list[Model] = [
             VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
         },
     ),
+    Model(
+        id="gemini-omni-1.1-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini Omni Flash",
+        operations={Modality.VIDEOS: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
+            VideoParameter.DURATION: Range(min=3, max=10),
+            VideoParameter.FIRST_FRAME: ImageConstraint(),
+            VideoParameter.LAST_FRAME: ImageConstraint(),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(),
+        },
+    ),
 ]
 
 MODELS: list[Model] = [


### PR DESCRIPTION
What: add gemini-omni-1.1-flash to the Google videos catalog (Interactions backend)
Why: Gemini Omni Flash reached GA as gemini-omni-1.1-flash on August 27, 2026; gemini-omni-flash-preview shuts down September 30, 2026
Evidence: https://ai.google.dev/gemini-api/docs/changelog (https://ai.google.dev/api/interactions-api)
Files: src/celeste/modalities/videos/providers/google/models.py
Validation: make ci pass
Depends on: none