### PR TITLE
feat(anthropic): add Claude Fable 5.1 and Mythos 5.1 text models

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -17,6 +17,46 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="claude-fable-5-1",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Fable 5.1",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
+        id="claude-mythos-5-1",
+        provider=Provider.ANTHROPIC,
+        display_name="Claude Mythos 5.1",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_LEVEL: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: Choice(
+                options=[ToolChoice.AUTO, ToolChoice.NONE]
+            ),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="claude-fable-5",
         provider=Provider.ANTHROPIC,
         display_name="Claude Fable 5",
@@ -235,6 +275,8 @@ MODELS: list[Model] = [
 # Models that support web_search dynamic filtering (web_search_20260209); others use basic.
 DYNAMIC_FILTERING_MODELS = frozenset(
     {
+        "claude-fable-5-1",
+        "claude-mythos-5-1",
         "claude-fable-5",
         "claude-mythos-5",
         "claude-opus-5",


### PR DESCRIPTION
What: add claude-fable-5-1 and claude-mythos-5-1 to the Anthropic text catalog (128k max output, effort low..max, tool_choice auto/none only, web_search_20260209)
Why: Claude Fable 5.1 and Claude Mythos 5.1 released on the Claude API and Google Cloud, 2026-09-01
Evidence: https://platform.claude.com/docs/en/release-notes/overview (https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1)
Files: src/celeste/modalities/text/providers/anthropic/models.py
Validation: make ci pass
Depends on: none