### PR TITLE
fix(openai): narrow tts-1 and tts-1-hd voices to the documented set

### DIFF
--- a/src/celeste/modalities/audio/providers/openai/voices.py
+++ b/src/celeste/modalities/audio/providers/openai/voices.py
@@ -30,8 +30,15 @@ OPENAI_VOICES = [
     )
 ]
 
-TTS1_VOICES = OPENAI_VOICES
-TTS1_HD_VOICES = OPENAI_VOICES
+# tts-1 and tts-1-hd accept only a subset of the built-in voices.
+# Source: https://developers.openai.com/api/docs/guides/text-to-speech
+TTS1_VOICES = [
+    voice
+    for voice in OPENAI_VOICES
+    if voice.id
+    in ("alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer")
+]
+TTS1_HD_VOICES = TTS1_VOICES
 GPT4O_MINI_TTS_VOICES = OPENAI_VOICES
 
 __all__ = [


### PR DESCRIPTION
What: limit the tts-1 and tts-1-hd voice constraints to the nine voices OpenAI documents for them
Why: OpenAI's text-to-speech guide states tts-1 and tts-1-hd support only alloy, ash, coral, echo, fable, onyx, nova, sage, and shimmer; effective date unknown
Evidence: https://developers.openai.com/api/docs/guides/text-to-speech (https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create)
Files: src/celeste/modalities/audio/providers/openai/voices.py
Validation: make ci pass
Depends on: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ5YqvsZx3XVuQtDXWRqgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ5YqvsZx3XVuQtDXWRqgG)_