### PR TITLE
fix(anthropic): raise Opus 4.6 and Sonnet 4.6 max output to the documented 128K

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -224,7 +224,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=64000),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
@@ -259,7 +259,7 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
-            Parameter.MAX_TOKENS: Range(min=1, max=64000),
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
             TextParameter.THINKING_LEVEL: Choice(
                 options=["low", "medium", "high", "max"]
             ),


### PR DESCRIPTION
What: raise MAX_TOKENS for claude-opus-4-6 and claude-sonnet-4-6 from 64000 to 128000
Why: Anthropic documents a 128K synchronous Messages API max output for both models (effective date unknown)
Evidence: https://platform.claude.com/docs/en/models/opus-4-6/overview (https://platform.claude.com/docs/en/models/sonnet-4-6/overview)
Files: src/celeste/modalities/text/providers/anthropic/models.py
Validation: make ci pass
Depends on: none