### PR TITLE
fix(google): add referenceImages support to Veo 3.1 Fast

### DIFF
--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -46,6 +46,10 @@ GOOGLE_VEO_MODELS: list[Model] = [
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p", "4k"]),
             VideoParameter.DURATION: Choice(options=[4, 6, 8]),
+            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
+                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
+                max_count=3,
+            ),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
             ),


### PR DESCRIPTION
What: add the referenceImages constraint (up to 3 JPEG/PNG/WebP) to veo-3.1-fast-generate-preview, matching veo-3.1-generate-preview
Why: the Gemini API Veo parameter table lists referenceImages for "Veo 3.1 & Veo 3.1 Fast"; shipped with the Veo 3.1 / 3.1 Fast launch on October 15, 2025
Evidence: https://ai.google.dev/gemini-api/docs/veo#veo-model-parameters (https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate)
Files: src/celeste/modalities/videos/providers/google/models.py
Validation: make ci pass
Depends on: none