### PR TITLE
feat(google): register Gemini 3.8 Flash text model

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -259,4 +259,26 @@ MODELS: list[Model] = [
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },
     ),
+    Model(
+        id="gemini-3.8-flash",
+        provider=Provider.GOOGLE,
+        display_name="Gemini 3.8 Flash",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            # 3.8 Flash rejects minimal with a validation error (Google model page).
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            # Media input support
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
 ]


### PR DESCRIPTION
## What

Adds `gemini-3.8-flash` (`Gemini 3.8 Flash`) to the Google text catalog next to `gemini-3.7-flash`, with the same shape: `MAX_TOKENS` `Range(min=1, max=65536)`, `THINKING_LEVEL` `Choice(["low", "medium", "high"])`, built-in `WebSearch`/`CodeExecution`/`UrlContext` tools, structured output, and image/video/audio/document inputs. `streaming=True` mirrors the 3.7 Flash entry on the same Interactions/GenerateContent wire paths; no live call was made in this run.

## Why

Google released `gemini-3.8-flash` as generally available on 2026-09-02 (Gemini API changelog); the model page documents a 65,536 output-token limit and thinking levels low/medium/high with `minimal` rejected, and the Vertex model-versions page lists the same id released September 2, 2026, so both the Interactions and `GenerateContent` backends serve it. The Interactions reference's `model` enum still ends at `gemini-3.7-flash` while its banner announces 3.8 availability, so a live API-key call is worth running before merge.

## Evidence

- https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
- https://ai.google.dev/gemini-api/docs/changelog

## Files

- `src/celeste/modalities/text/providers/google/models.py`

## Validation

`make ci`: **pass**

## Depends on

none
