### PR TITLE
feat(openai): add the gpt-image-2-2026-04-21 snapshot to the images catalog

### DIFF
--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -99,4 +99,33 @@ MODELS: list[Model] = [
             ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
         },
     ),
+    Model(
+        id="gpt-image-2-2026-04-21",
+        provider=Provider.OPENAI,
+        display_name="GPT Image 2 (2026-04-21)",
+        operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        streaming=False,
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Choice(
+                options=[
+                    "1024x1024",
+                    "1536x1024",
+                    "1024x1536",
+                    "2048x2048",
+                    "2048x1152",
+                    "3840x2160",
+                    "2160x3840",
+                    "auto",
+                ]
+            ),
+            ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
+            ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
+            ImageParameter.BACKGROUND: Choice(
+                options=["transparent", "opaque", "auto"]
+            ),
+            ImageParameter.SAFETY_TOLERANCE: Choice(options=["auto", "low"]),
+            ImageParameter.OUTPUT_COMPRESSION: Range(min=0, max=100),
+        },
+    ),
 ]


### PR DESCRIPTION
## What

Add the dated snapshot `gpt-image-2-2026-04-21` to the OpenAI images catalog with the same operations (`GENERATE`, `EDIT`) and constraints as `gpt-image-2`. `streaming` stays `False` because no live call through the Celeste stream path was possible in this run, so the entry carries no `partial_images` constraint (same shape as `gpt-image-1.5`).

## Why

The Images API request reference accepts `gpt-image-2-2026-04-21` as a `model` value on both `/images/generations` and `/images/edits`, and the model page lists it as the only GPT Image 2 snapshot; the snapshot dates from the 2026-04-21 GPT Image 2 release, and the 2026-08-20 changelog names it alongside `gpt-image-2` for transparent backgrounds.

## Evidence

- https://developers.openai.com/api/reference/resources/images/methods/generate
- https://developers.openai.com/api/reference/resources/images/methods/edit

## Files

- `src/celeste/modalities/images/providers/openai/models.py`

## Validation

`make ci`: **pass**

## Depends on

none
