### PR TITLE
fix(anthropic): allow forced tool use on claude-fable-5

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -69,9 +69,7 @@ MODELS: list[Model] = [
             ),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: Choice(
-                options=[ToolChoice.AUTO, ToolChoice.NONE]
-            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.IMAGE: ImagesConstraint(),
             TextParameter.DOCUMENT: DocumentsConstraint(),
         },


### PR DESCRIPTION
## What

`claude-fable-5` accepts every `tool_choice` type again: its `TOOL_CHOICE` constraint changes from `Choice([ToolChoice.AUTO, ToolChoice.NONE])` to `ToolChoiceSupport()`, the shape used by `claude-mythos-5` and the other adaptive-thinking entries.

## Why

Anthropic documents that Claude Fable 5 accepts `tool_choice` `auto`, `none`, `any`, and `tool`; only `claude-fable-5-1` and `claude-mythos-5-1` reject `any` and `tool` with a 400, a breaking change introduced with those models on September 1, 2026.

## Evidence

- https://platform.claude.com/docs/en/models/fable-5-1/migration-guide
- https://platform.claude.com/docs/en/build-with-claude/thinking

## Files

- `src/celeste/modalities/text/providers/anthropic/models.py`

## Validation

`make ci`: **pass**

## Depends on

none
