### PR TITLE
fix(anthropic): floor thinking_budget at 1024 on extended-only models

### DIFF
--- a/src/celeste/modalities/text/providers/anthropic/models.py
+++ b/src/celeste/modalities/text/providers/anthropic/models.py
@@ -155,7 +155,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=64000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=64000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -189,7 +189,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=32000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
@@ -206,7 +206,7 @@ MODELS: list[Model] = [
         parameter_constraints={
             Parameter.TEMPERATURE: Range(min=0.0, max=1.0, step=0.01),
             Parameter.MAX_TOKENS: Range(min=1, max=64000),
-            TextParameter.THINKING_BUDGET: Range(min=-1, max=32000),
+            TextParameter.THINKING_BUDGET: Range(min=1024, max=32000),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),


### PR DESCRIPTION
## What

Raise the `thinking_budget` lower bound from `-1` to `1024` on `claude-sonnet-4-5`, `claude-opus-4-5`, and `claude-opus-4-1`, whose only thinking mode is extended thinking with a fixed `budget_tokens`.

## Why

These models reject `thinking.type: "adaptive"` with a 400 and `budget_tokens` has a documented minimum of `1024`, so celeste's dynamic `-1` sentinel has no valid wire form on them (date unknown).

## Evidence

- `1024` (`budget_tokens` minimum) and `thinking.type` limited to `enabled`, `disabled`, `adaptive`: [Messages API reference](https://platform.claude.com/docs/en/api/messages/create)
- `claude-sonnet-4-5` and `claude-opus-4-5` are extended-only and reject `"adaptive"` with a 400: [Troubleshooting thinking](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting)
- `claude-opus-4-1` supports extended thinking only: [Troubleshooting thinking](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting)

## Files

- `src/celeste/modalities/text/providers/anthropic/models.py`

## Validation

`make ci`: **pass**
Live call: **none**

## Depends on

none
