### PR TITLE
fix(google): add medium thinking level to Gemini 2.5 Pro and 2.5 Flash-Lite

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -57,7 +57,7 @@ MODELS: list[Model] = [
                 min=512, max=24576, special_values=[-1, 0]
             ),
             # Interactions path (API key): thinking_level; Vertex/ADC: thinking_budget
-            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(
                 tools=[WebSearch, CodeExecution, UrlContext]
             ),
@@ -84,7 +84,7 @@ MODELS: list[Model] = [
                 min=128, max=32768, special_values=[-1]
             ),
             # Interactions path (API key): thinking_level; Vertex/ADC: thinking_budget
-            TextParameter.THINKING_LEVEL: Choice(options=["low", "high"]),
+            TextParameter.THINKING_LEVEL: Choice(options=["low", "medium", "high"]),
             TextParameter.TOOLS: ToolSupport(
                 tools=[WebSearch, CodeExecution, UrlContext]
             ),


### PR DESCRIPTION
## What

Widen `TextParameter.THINKING_LEVEL` on `gemini-2.5-pro` and `gemini-2.5-flash-lite` from `low`/`high` to `low`/`medium`/`high`.

## Why

Google's thinking guide lists `low, medium, high` as the supported `thinking_level` values for `gemini-2.5-pro` and `gemini-2.5-flash-lite` on the Interactions API, matching `gemini-2.5-flash`; the catalog omitted `medium` for those two ids (date unknown, no release note announces it). The Vertex/GenerateContent path is unchanged: `thinkingLevel` errors on pre-Gemini-3 models there, so the 2.5 entries keep `THINKING_BUDGET` as the Vertex control.

## Evidence

- `medium` is a documented `generation_config.thinking_level` literal: [Interactions API reference](https://ai.google.dev/api/interactions-api)
- `gemini-2.5-pro` supports `low, medium, high`: [Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking)
- `gemini-2.5-flash-lite` supports `low, medium, high`: [Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking)
- `thinkingLevel` on GenerateContent errors for models earlier than Gemini 3: [GenerateContent API reference](https://ai.google.dev/api/generate-content)

## Files

- `src/celeste/modalities/text/providers/google/models.py`

## Validation

`make ci`: **pass**
Live call: **none**

## Depends on

none
