### PR TITLE
feat(google): add the Lyria 3.5 music models to the audio catalog

### DIFF
--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -106,4 +106,22 @@ MODELS: list[Model] = [
             AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),
+    Model(
+        id="lyria-3.5-clip-preview",
+        provider=Provider.GOOGLE,
+        display_name="Google Lyria 3.5 Clip (Preview)",
+        operations={Modality.AUDIO: {Operation.GENERATE}},
+        parameter_constraints={
+            AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
+        },
+    ),
+    Model(
+        id="lyria-3.5-pro-preview",
+        provider=Provider.GOOGLE,
+        display_name="Google Lyria 3.5 Pro (Preview)",
+        operations={Modality.AUDIO: {Operation.GENERATE}},
+        parameter_constraints={
+            AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
+        },
+    ),
 ]


### PR DESCRIPTION
## What

Adds `lyria-3.5-clip-preview` and `lyria-3.5-pro-preview` to the Google audio catalog as `Operation.GENERATE` models with `ImagesConstraint(max_count=10)` on `reference_images`.

## Why

Google released the Lyria 3.5 music models in public preview on September 3, 2026; the catalog only held the Lyria 3 pair.

## Evidence

- `lyria-3.5-clip-preview`, `lyria-3.5-pro-preview`, released September 3, 2026, no shutdown date: [Gemini API deprecations](https://ai.google.dev/gemini-api/docs/deprecations)
- Lyria 3.5 public preview, September 3, 2026: [Gemini API release notes](https://ai.google.dev/gemini-api/docs/changelog)
- Model IDs `lyria-3.5-clip-preview` / `lyria-3.5-pro-preview`, display names Lyria 3.5 Clip / Lyria 3.5 Pro, music generation via `interactions.create`: [Generate music with Lyria 3.5](https://ai.google.dev/gemini-api/docs/music-generation)
- `max_count=10`: "Lyria 3.5 supports multimodal inputs — you can provide up to 10 images": [Generate music with Lyria 3.5](https://ai.google.dev/gemini-api/docs/music-generation)

The Lyria 3 entries stay: both are still listed with no shutdown date announced, and removal needs a live authenticated rejection.

## Files

- `src/celeste/modalities/audio/providers/google/models.py`

## Validation

`make ci`: **pass**
Live call: **none**

## Depends on

none