### PR TITLE
feat(google): add lyria-3.5 to the audio catalog

### DIFF
--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -124,4 +124,13 @@ MODELS: list[Model] = [
             AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
         },
     ),
+    Model(
+        id="lyria-3.5",
+        provider=Provider.GOOGLE,
+        display_name="Google Lyria 3.5 (Preview)",
+        operations={Modality.AUDIO: {Operation.GENERATE}},
+        parameter_constraints={
+            AudioParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=10),
+        },
+    ),
 ]


### PR DESCRIPTION
## What

Adds `lyria-3.5` to the Google audio catalog as an `Operation.GENERATE` model with `ImagesConstraint(max_count=10)` on `reference_images`.

## Why

Google released `lyria-3.5` in public preview on September 3, 2026; the catalog holds no entry for that id.

## Evidence

- `lyria-3.5` is the model code, inputs Text and Image, output Audio (MP3), versions "Preview: `lyria-3.5`": [Lyria 3.5](https://ai.google.dev/gemini-api/docs/models/lyria-3.5)
- `lyria-3.5` endpoint, "Our flagship music generation model, optimized for full-length songs with complex structural coherence": [Gemini API models](https://ai.google.dev/gemini-api/docs/models)
- "Lyria 3.5 in public preview", released September 3, 2026: [Gemini API release notes](https://ai.google.dev/gemini-api/docs/changelog)
- `max_count=10`: "Lyria 3.5 supports multimodal inputs — you can provide up to 10 images alongside your text prompt": [Generate music with Lyria 3.5](https://ai.google.dev/gemini-api/docs/music-generation)
- No `MAX_TOKENS`: the model page documents an input token limit of 131,072 and no completion cap: [Lyria 3.5](https://ai.google.dev/gemini-api/docs/models/lyria-3.5)

## Files

- `src/celeste/modalities/audio/providers/google/models.py`

## Validation

`make ci`: **pass**
Live call: **none**

## Depends on

none