### PR TITLE
fix: close SDK transports and preserve provider response metadata

### DIFF
--- a/src/celeste/auth.py
+++ b/src/celeste/auth.py
@@ -13,6 +13,10 @@ class Authentication(ABC, BaseModel):
         """Return authentication headers for HTTP requests."""
         ...
 
+    async def aget_headers(self) -> dict[str, str]:
+        """Return headers asynchronously; blocking credential sources override this."""
+        return self.get_headers()
+
 
 class AuthHeader(Authentication):
     """Authentication via HTTP header with configurable header name and prefix.

--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -44,7 +44,7 @@ class APIMixin(ABC):
         class OpenAIResponsesMixin(APIMixin):
             async def _make_request(self, request_body, **parameters):
                 request_body["model"] = self.model.id  # Type-safe!
-                headers = {**self.auth.get_headers(), ...}
+                headers = {**(await self.auth.aget_headers()), ...}
                 return await self.http_client.post(...)
 
         class OpenAITextClient(OpenAIResponsesMixin, TextClient):
@@ -64,11 +64,14 @@ class APIMixin(ABC):
         """HTTP client with connection pooling for this provider."""
         ...
 
-    def _json_headers(
+    async def _json_headers(
         self, extra_headers: dict[str, str] | None = None
     ) -> dict[str, str]:
         """Build standard JSON request headers with auth."""
-        headers = {**self.auth.get_headers(), "Content-Type": ApplicationMimeType.JSON}
+        headers = {
+            **(await self.auth.aget_headers()),
+            "Content-Type": ApplicationMimeType.JSON,
+        }
         if extra_headers:
             headers.update(extra_headers)
         return headers

--- a/src/celeste/client.py
+++ b/src/celeste/client.py
@@ -2,7 +2,8 @@
 
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
+from functools import partial
 from json import JSONDecodeError
 from typing import Any, ClassVar, Unpack
 
@@ -344,13 +345,16 @@ class ModalityClient[
             attributes={**request_attrs, "gen_ai.request.stream": True},
         )
         telemetry.add_input_event(span, inputs)
-        sse_iterator = self._make_stream_request(
-            request_body,
-            endpoint=endpoint,
-            extra_headers=extra_headers,
-            **parameters,
+        sse_iterator = enrich_stream_errors(
+            partial(
+                self._make_stream_request,
+                request_body,
+                endpoint=endpoint,
+                extra_headers=extra_headers,
+                **parameters,
+            ),
+            self._handle_error_response,
         )
-        sse_iterator = enrich_stream_errors(sse_iterator, self._handle_error_response)
         sse_iterator = telemetry.bind_first_pull_to_span(sse_iterator, span)
         stream = stream_class(
             sse_iterator,
@@ -421,15 +425,15 @@ class ModalityClient[
         """Make HTTP request(s) and return response data."""
         ...
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Unpack[Params],  # type: ignore[misc]
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Make HTTP streaming request and return async iterator of events."""
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Return an unstarted transport generator; the shared stream owns its lifetime."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 
     def _stream_class(self) -> type[Stream[Out, Params, Chunk]]:

--- a/src/celeste/http.py
+++ b/src/celeste/http.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -38,7 +38,11 @@ async def _retry_request(
 
 
 class HTTPClient:
-    """Async HTTP client with persistent connection pooling."""
+    """Pool connections per loop and close them during async-generator shutdown.
+
+    asyncio.run/Runner perform this shutdown automatically. Manually managed loops
+    must await aclose() or loop.shutdown_asyncgens() before loop.close().
+    """
 
     def __init__(
         self,
@@ -51,8 +55,10 @@ class HTTPClient:
             max_connections: Maximum total connections in pool.
             max_keepalive_connections: Maximum idle keepalive connections.
         """
-        self._client: httpx.AsyncClient | None = None
-        self._client_loop: int | None = None
+        self._clients: dict[
+            asyncio.AbstractEventLoop,
+            tuple[httpx.AsyncClient, AsyncGenerator[httpx.AsyncClient, None]],
+        ] = {}
         self._max_connections = max_connections
         self._max_keepalive_connections = max_keepalive_connections
 
@@ -60,19 +66,25 @@ class HTTPClient:
         """Get or create httpx.AsyncClient with connection pooling."""
         current_loop = asyncio.get_running_loop()
 
-        # Recreate client if event loop changed (prevents "Event loop is closed" errors)
-        if self._client is not None and self._client_loop != id(current_loop):
-            self._client = None
+        if current_loop not in self._clients:
+            lifetime = self._client_lifetime()
+            self._clients[current_loop] = (await anext(lifetime), lifetime)
 
-        if self._client is None:
-            limits = httpx.Limits(
-                max_connections=self._max_connections,
-                max_keepalive_connections=self._max_keepalive_connections,
-            )
-            self._client = httpx.AsyncClient(limits=limits)  # nosec B113
-            self._client_loop = id(current_loop)
+        return self._clients[current_loop][0]
 
-        return self._client
+    async def _client_lifetime(self) -> AsyncGenerator[httpx.AsyncClient, None]:
+        """Register cleanup on the owning loop before handing out its client."""
+        loop = asyncio.get_running_loop()
+        limits = httpx.Limits(
+            max_connections=self._max_connections,
+            max_keepalive_connections=self._max_keepalive_connections,
+        )
+        client = httpx.AsyncClient(limits=limits)  # nosec B113
+        try:
+            yield client
+        finally:
+            self._clients.pop(loop, None)
+            await client.aclose()
 
     async def post(
         self,
@@ -190,7 +202,7 @@ class HTTPClient:
         headers: dict[str, str],
         json_body: dict[str, Any],
         timeout: float = DEFAULT_TIMEOUT,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Stream POST request using Server-Sent Events.
 
         Args:
@@ -227,7 +239,7 @@ class HTTPClient:
         headers: dict[str, str],
         json_body: dict[str, Any],
         timeout: float = DEFAULT_TIMEOUT,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Stream POST request using NDJSON (newline-delimited JSON).
 
         Unlike SSE (stream_post), NDJSON returns one JSON object per line.
@@ -258,10 +270,10 @@ class HTTPClient:
                     yield json.loads(line)
 
     async def aclose(self) -> None:
-        """Close HTTP client and cleanup all connections."""
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
+        """Close connections owned by the current event loop."""
+        entry = self._clients.pop(asyncio.get_running_loop(), None)
+        if entry is not None:
+            await entry[1].aclose()
 
     async def __aenter__(self) -> "HTTPClient":
         """Enter async context manager."""
@@ -272,7 +284,7 @@ class HTTPClient:
         await self.aclose()
 
 
-# Module-level registry of shared HTTPClient instances
+# Shared wrappers stay registered while other threads may be creating their pools.
 _http_clients: dict[tuple[Provider | Protocol, Modality], HTTPClient] = {}
 
 
@@ -288,19 +300,17 @@ def get_http_client(provider: Provider | Protocol, modality: Modality) -> HTTPCl
     """
     key = (provider, modality)
     if key not in _http_clients:
-        _http_clients[key] = HTTPClient()
+        return _http_clients.setdefault(key, HTTPClient())
     return _http_clients[key]
 
 
 async def close_all_http_clients() -> None:
-    """Close all HTTP clients gracefully and clear registry."""
+    """Close this event loop's HTTP clients, leaving other loops' pools intact."""
     for key, client in list(_http_clients.items()):
         try:
             await client.aclose()
         except Exception as e:
             logger.warning(f"Failed to close HTTP client for {key}: {e}")
-
-    _http_clients.clear()
 
 
 def clear_http_clients() -> None:

--- a/src/celeste/modalities/audio/providers/elevenlabs/client.py
+++ b/src/celeste/modalities/audio/providers/elevenlabs/client.py
@@ -1,5 +1,6 @@
 """ElevenLabs audio client (dispatches TTS and STT wire backends)."""
 
+from collections.abc import AsyncGenerator
 from typing import Any, Unpack
 
 from celeste.parameters import ParameterMapper
@@ -109,15 +110,15 @@ class ElevenLabsAudioClient(AudioClient):
     def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
         return self._strategy._build_metadata(response_data)  # type: ignore[union-attr]
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Unpack[AudioParameters],
-    ) -> Any:
-        return self._strategy._make_stream_request(  # type: ignore[union-attr]
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        return await self._strategy._make_stream_request(  # type: ignore[union-attr]
             request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
         )
 

--- a/src/celeste/modalities/embeddings/io.py
+++ b/src/celeste/modalities/embeddings/io.py
@@ -16,22 +16,19 @@ class EmbeddingsInput(Input):
 
     @model_validator(mode="after")
     def _validate_inputs(self) -> "EmbeddingsInput":
-        if (
-            self.text is None
-            and self.images is None
-            and self.videos is None
-            and self.audio is None
-        ):
+        inputs = {
+            "text": self.text,
+            "images": self.images,
+            "videos": self.videos,
+            "audio": self.audio,
+        }
+        provided = {name: value for name, value in inputs.items() if value is not None}
+        if not provided:
             msg = "At least one of text, images, videos, or audio must be provided"
             raise ValueError(msg)
-        if isinstance(self.text, list) and (
-            self.images is not None or self.videos is not None or self.audio is not None
-        ):
-            msg = (
-                "Batch text (list[str]) cannot be combined with images, videos,"
-                " or audio"
-            )
-            raise ValueError(msg)
+        for name, value in provided.items():
+            if isinstance(value, list) and len(provided) > 1:
+                raise ValueError(f"Batch {name} cannot be combined with other inputs")
         return self
 
 

--- a/src/celeste/modalities/text/protocols/openresponses/client.py
+++ b/src/celeste/modalities/text/protocols/openresponses/client.py
@@ -123,9 +123,9 @@ class OpenResponsesTextStream(_OpenResponsesStream, TextStream):
         self._response_data: dict[str, Any] | None = None
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> TextChunk | None:
-        """Parse one SSE event into a typed chunk (captures response.completed)."""
+        """Parse one SSE event into a typed chunk, retaining the terminal response."""
         event_type = event_data.get("type")
-        if event_type == "response.completed":
+        if event_type in self._terminal_events:
             response = event_data.get("response")
             if isinstance(response, dict):
                 self._response_data = response

--- a/src/celeste/modalities/text/providers/google/client.py
+++ b/src/celeste/modalities/text/providers/google/client.py
@@ -1,6 +1,6 @@
 """Google text client (Interactions API; GoogleADC auth uses Vertex GenerateContent)."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, Unpack
 
 from celeste.grounding import Grounding
@@ -110,15 +110,15 @@ class GoogleTextClient(TextClient):
             **parameters,
         )
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Unpack[TextParameters],
-    ) -> AsyncIterator[dict[str, Any]]:
-        return self._strategy._make_stream_request(  # type: ignore[union-attr]
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        return await self._strategy._make_stream_request(  # type: ignore[union-attr]
             request_body,
             endpoint=endpoint,
             extra_headers=extra_headers,

--- a/src/celeste/modalities/text/providers/google/grounding.py
+++ b/src/celeste/modalities/text/providers/google/grounding.py
@@ -15,8 +15,18 @@ def _byte_offset_to_char_offset(text: str, offset: int) -> int | None:
         return None
 
 
-def map_grounding_vertex(grounding_metadata: dict[str, Any], text: str) -> Grounding:
+def map_grounding_vertex(
+    grounding_metadata: dict[str, Any], parts: list[dict[str, Any]]
+) -> Grounding:
     """Map generateContent groundingMetadata to text grounding."""
+    text_parts: list[tuple[str | None, int]] = []
+    offset = 0
+    for part in parts:
+        text = part.get("text") if not part.get("thought") else None
+        text_parts.append((text, offset))
+        if isinstance(text, str):
+            offset += len(text)
+
     sources: list[GroundingSource] = []
     source_indices: dict[int, int] = {}
     for index, chunk in enumerate(grounding_metadata.get("groundingChunks", [])):
@@ -40,13 +50,22 @@ def map_grounding_vertex(grounding_metadata: dict[str, Any], text: str) -> Groun
         segment = support.get("segment", {})
         if not isinstance(segment, dict):
             continue
-        start = segment.get("startIndex")
+        part_index = segment.get("partIndex", 0)
+        if not isinstance(part_index, int) or not 0 <= part_index < len(text_parts):
+            continue
+        text, offset = text_parts[part_index]
+        if not isinstance(text, str):
+            continue
+        start = segment.get("startIndex", 0)
         end = segment.get("endIndex")
         if not isinstance(start, int) or not isinstance(end, int):
             continue
         start = _byte_offset_to_char_offset(text, start)
         end = _byte_offset_to_char_offset(text, end)
-        if start is None or end is None:
+        if start is None or end is None or start > end:
+            continue
+        cited_text = segment.get("text")
+        if isinstance(cited_text, str) and text[start:end] != cited_text:
             continue
         raw_indices = support.get("groundingChunkIndices", [])
         indices = [
@@ -56,10 +75,10 @@ def map_grounding_vertex(grounding_metadata: dict[str, Any], text: str) -> Groun
         ]
         citations.append(
             Citation(
-                start=start,
-                end=end,
+                start=offset + start,
+                end=offset + end,
                 source_indices=indices,
-                cited_text=segment.get("text"),
+                cited_text=cited_text,
             )
         )
 

--- a/src/celeste/modalities/text/providers/google/vertex.py
+++ b/src/celeste/modalities/text/providers/google/vertex.py
@@ -53,9 +53,18 @@ class GoogleVertexTextStream(_GoogleGenerateContentStream, TextStream):
         metadata = getattr(self, "_grounding_metadata", None)
         if not metadata:
             return None
+        parts = []
+        for fragments in self._grounding_part_fragments:
+            part = fragments[0]
+            if isinstance(part.get("text"), str):
+                part = {
+                    **part,
+                    "text": "".join(fragment["text"] for fragment in fragments),
+                }
+            parts.append(part)
         return map_grounding_vertex(
             merge_grounding_metadata(metadata),
-            self._aggregate_content(chunks),
+            parts,
         )
 
     def _aggregate_tool_calls(
@@ -198,7 +207,8 @@ class GoogleVertexTextClient(GoogleGenerateContentMixin, TextClient):
         meta = parse_grounding_metadata(response_data)
         if meta is None:
             return None
-        return map_grounding_vertex(meta, self._parse_content(response_data))
+        parts = response_data["candidates"][0].get("content", {}).get("parts", [])
+        return map_grounding_vertex(meta, parts)
 
     def _parse_tool_calls(self, response_data: dict[str, Any]) -> list[ToolCall]:
         """Parse tool calls from Google response."""

--- a/src/celeste/modalities/videos/providers/google/interactions.py
+++ b/src/celeste/modalities/videos/providers/google/interactions.py
@@ -9,7 +9,7 @@ from celeste.providers.google.interactions import config
 from celeste.providers.google.interactions.client import (
     GoogleInteractionsClient as GoogleInteractionsMixin,
 )
-from celeste.providers.google.utils import build_content_part
+from celeste.providers.google.utils import build_content_part, download_video
 from celeste.types import VideoContent
 
 from ...client import VideosClient
@@ -69,10 +69,7 @@ class GoogleInteractionsVideosClient(GoogleInteractionsMixin, VideosClient):
             msg = "Artifact has no URL or data to download"
             raise ValueError(msg)
 
-        headers = self.auth.get_headers()
-        response = await self.http_client.get(
-            artifact.url, headers=headers, follow_redirects=True
-        )
+        response = await download_video(self.http_client, self.auth, artifact.url)
         self._handle_error_response(response)
         return VideoArtifact(data=response.content, mime_type=artifact.mime_type)
 

--- a/src/celeste/protocols/chatcompletions/client.py
+++ b/src/celeste/protocols/chatcompletions/client.py
@@ -1,6 +1,7 @@
 """Chat Completions protocol client."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -80,7 +81,7 @@ class ChatCompletionsClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -91,7 +92,7 @@ class ChatCompletionsClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -103,13 +104,17 @@ class ChatCompletionsClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            self._build_url(endpoint, streaming=True),
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                self._build_url(endpoint, streaming=True),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/protocols/chatcompletions/client.py
+++ b/src/celeste/protocols/chatcompletions/client.py
@@ -1,7 +1,6 @@
 """Chat Completions protocol client."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -99,22 +98,18 @@ class ChatCompletionsClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to Chat Completions API endpoint."""
         if endpoint is None:
             endpoint = self._default_endpoint
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                self._build_url(endpoint, streaming=True),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            self._build_url(endpoint, streaming=True),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/protocols/openresponses/client.py
+++ b/src/celeste/protocols/openresponses/client.py
@@ -1,7 +1,6 @@
 """OpenResponses protocol client."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -99,22 +98,18 @@ class OpenResponsesClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to Responses API endpoint."""
         if endpoint is None:
             endpoint = self._default_endpoint
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                self._build_url(endpoint, streaming=True),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            self._build_url(endpoint, streaming=True),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/protocols/openresponses/client.py
+++ b/src/celeste/protocols/openresponses/client.py
@@ -1,6 +1,7 @@
 """OpenResponses protocol client."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -80,7 +81,7 @@ class OpenResponsesClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -91,7 +92,7 @@ class OpenResponsesClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -103,13 +104,17 @@ class OpenResponsesClient(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            self._build_url(endpoint, streaming=True),
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                self._build_url(endpoint, streaming=True),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:
@@ -142,6 +147,9 @@ class OpenResponsesClient(APIMixin):
     def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
         """Extract finish reason from Responses API response."""
         status = response_data.get("status")
+        if status == "incomplete":
+            details = response_data.get("incomplete_details") or {}
+            return FinishReason(reason=details.get("reason") or "incomplete")
         if status == "completed":
             output_items = response_data.get("output", [])
             for item in output_items:

--- a/src/celeste/protocols/openresponses/streaming.py
+++ b/src/celeste/protocols/openresponses/streaming.py
@@ -24,11 +24,18 @@ class OpenResponsesStream:
     """
 
     _error_type_fields: ClassVar[tuple[str, ...]] = ("code",)
+    _terminal_events: ClassVar[tuple[str, ...]] = (
+        "response.completed",
+        "response.incomplete",
+    )
 
     def _parse_stream_error(self, event_data: dict[str, Any]) -> dict[str, Any] | None:
-        """Detect Responses API error events (flat shape: code/message at root level)."""
+        """Normalize error events and failed terminal responses."""
         if event_data.get("type") == "error":
             return self._build_error_from_value(event_data)  # type: ignore[attr-defined, no-any-return]
+        if event_data.get("type") == "response.failed":
+            error = event_data.get("response", {}).get("error")
+            return self._build_error_from_value(error)  # type: ignore[attr-defined, no-any-return]
         return None
 
     def _parse_chunk_content(self, event_data: dict[str, Any]) -> str | None:
@@ -68,7 +75,7 @@ class OpenResponsesStream:
     ) -> dict[str, int | float | None] | None:
         """Extract and normalize usage from SSE event."""
         event_type = event_data.get("type")
-        if event_type == "response.completed":
+        if event_type in self._terminal_events:
             response_data = event_data.get("response", {})
             usage_data = response_data.get("usage")
             if usage_data:
@@ -78,9 +85,9 @@ class OpenResponsesStream:
     def _aggregate_raw_response(
         self, chunks: list[Any], raw_events: list[dict[str, Any]]
     ) -> dict[str, Any] | None:
-        """Unwrap the final Response object from the response.completed event."""
+        """Unwrap the final Response object from a terminal event."""
         for event in reversed(raw_events):
-            if event.get("type") == "response.completed":
+            if event.get("type") in self._terminal_events:
                 response = event.get("response")
                 return response if isinstance(response, dict) else None
         return None
@@ -90,9 +97,12 @@ class OpenResponsesStream:
     ) -> FinishReason | None:
         """Extract finish reason from SSE event."""
         event_type = event_data.get("type")
-        if event_type == "response.completed":
+        if event_type in self._terminal_events:
             response_data = event_data.get("response", {})
             status = response_data.get("status")
+            if status == "incomplete":
+                details = response_data.get("incomplete_details") or {}
+                return FinishReason(reason=details.get("reason") or "incomplete")
             if status == "completed":
                 return FinishReason(reason="completed")
         return None
@@ -105,7 +115,7 @@ class OpenResponsesStream:
             e
             for e in raw_events
             if "delta" not in e.get("type", "")
-            and e.get("type") != "response.completed"
+            and e.get("type") not in self._terminal_events
         ]
         return super()._build_stream_metadata(filtered)  # type: ignore[misc, no-any-return]
 

--- a/src/celeste/protocols/openresponses/tools.py
+++ b/src/celeste/protocols/openresponses/tools.py
@@ -65,10 +65,13 @@ TOOL_MAPPERS: list[ToolMapper] = [
 
 
 def parse_tool_calls(response_data: dict[str, Any]) -> list[ToolCall]:
-    """Parse tool calls from Responses API output."""
+    """Parse executable tool calls, leaving unfinished items in the raw response."""
     tool_calls: list[ToolCall] = []
     for item in response_data.get("output", []):
-        if item.get("type") != "function_call":
+        if item.get("type") != "function_call" or item.get("status") in (
+            "incomplete",
+            "in_progress",
+        ):
             continue
         raw_args = item.get("arguments")
         if isinstance(raw_args, str):

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -1,6 +1,7 @@
 """Anthropic Messages API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -72,14 +73,14 @@ class AnthropicMessagesClient(APIMixin):
             )
         return f"{config.BASE_URL}{endpoint}"
 
-    def _build_headers(
+    async def _build_headers(
         self,
         beta_features: list[str] | None = None,
         extra_headers: dict[str, str] | None = None,
     ) -> dict[str, str]:
         """Build Anthropic request headers."""
         headers: dict[str, str] = {
-            **self._json_headers(),
+            **(await self._json_headers()),
             config.HEADER_ANTHROPIC_VERSION: config.ANTHROPIC_VERSION,
         }
         if beta_features:
@@ -129,7 +130,7 @@ class AnthropicMessagesClient(APIMixin):
             request_body["max_tokens"] = self._resolve_max_tokens()
 
         beta_features: list[str] = request_body.pop("_beta_features", [])
-        headers = self._build_headers(
+        headers = await self._build_headers(
             beta_features=beta_features, extra_headers=extra_headers
         )
 
@@ -145,7 +146,7 @@ class AnthropicMessagesClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -159,18 +160,22 @@ class AnthropicMessagesClient(APIMixin):
             request_body["max_tokens"] = self._resolve_max_tokens()
 
         beta_features: list[str] = request_body.pop("_beta_features", [])
-        headers = self._build_headers(
+        headers = await self._build_headers(
             beta_features=beta_features, extra_headers=extra_headers
         )
 
         if endpoint is None:
             endpoint = config.AnthropicMessagesEndpoint.CREATE_MESSAGE
 
-        return self.http_client.stream_post(
-            url=self._build_url(endpoint, streaming=True),
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                url=self._build_url(endpoint, streaming=True),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/anthropic/messages/client.py
+++ b/src/celeste/providers/anthropic/messages/client.py
@@ -1,7 +1,6 @@
 """Anthropic Messages API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -153,7 +152,7 @@ class AnthropicMessagesClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to Anthropic Messages API endpoint."""
         # Apply max_tokens default if not set (Anthropic requires it)
         if "max_tokens" not in request_body:
@@ -167,15 +166,11 @@ class AnthropicMessagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.AnthropicMessagesEndpoint.CREATE_MESSAGE
 
-        async with aclosing(
-            self.http_client.stream_post(
-                url=self._build_url(endpoint, streaming=True),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            url=self._build_url(endpoint, streaming=True),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -51,7 +51,7 @@ class BFLImagesClient(APIMixin):
         3. Return response with _submit_metadata for usage parsing
         """
         headers = {
-            **self._json_headers(extra_headers),
+            **(await self._json_headers(extra_headers)),
             "Accept": ApplicationMimeType.JSON,
         }
 
@@ -77,7 +77,7 @@ class BFLImagesClient(APIMixin):
         # Phase 2: Poll for completion
         start_time = time.monotonic()
         poll_headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            {**(await self.auth.aget_headers()), "Accept": ApplicationMimeType.JSON},
             extra_headers,
         )
 

--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -109,14 +109,14 @@ class BFLImagesClient(APIMixin):
 
             await asyncio.sleep(config.POLLING_INTERVAL)
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """BFL Images API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/byteplus/images/client.py
+++ b/src/celeste/providers/byteplus/images/client.py
@@ -1,7 +1,6 @@
 """BytePlus Images API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -76,22 +75,18 @@ class BytePlusImagesClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to BytePlus Images API endpoint."""
         if endpoint is None:
             endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                f"{config.BASE_URL}{endpoint}",
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            f"{config.BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/byteplus/images/client.py
+++ b/src/celeste/providers/byteplus/images/client.py
@@ -1,6 +1,7 @@
 """BytePlus Images API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -57,7 +58,7 @@ class BytePlusImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -68,7 +69,7 @@ class BytePlusImagesClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -80,13 +81,17 @@ class BytePlusImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.BytePlusImagesEndpoint.CREATE_IMAGE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                f"{config.BASE_URL}{endpoint}",
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/byteplus/videos/client.py
+++ b/src/celeste/providers/byteplus/videos/client.py
@@ -67,7 +67,7 @@ class BytePlusVideosClient(APIMixin):
         2. Poll CONTENT_STATUS endpoint until succeeded/failed/canceled
         3. Return response with final status data
         """
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         if endpoint is None:
             endpoint = config.BytePlusVideosEndpoint.CREATE_VIDEO

--- a/src/celeste/providers/byteplus/videos/client.py
+++ b/src/celeste/providers/byteplus/videos/client.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -126,14 +126,14 @@ class BytePlusVideosClient(APIMixin):
 
             await asyncio.sleep(config.POLLING_INTERVAL)
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """BytePlus Videos API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/cohere/chat/client.py
+++ b/src/celeste/providers/cohere/chat/client.py
@@ -1,7 +1,6 @@
 """Cohere Chat API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -78,22 +77,18 @@ class CohereChatClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to Cohere Chat API endpoint."""
         if endpoint is None:
             endpoint = config.CohereChatEndpoint.CREATE_CHAT
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                f"{config.BASE_URL}{endpoint}",
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            f"{config.BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/cohere/chat/client.py
+++ b/src/celeste/providers/cohere/chat/client.py
@@ -1,6 +1,7 @@
 """Cohere Chat API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -59,7 +60,7 @@ class CohereChatClient(APIMixin):
         if endpoint is None:
             endpoint = config.CohereChatEndpoint.CREATE_CHAT
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -70,7 +71,7 @@ class CohereChatClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -82,13 +83,17 @@ class CohereChatClient(APIMixin):
         if endpoint is None:
             endpoint = config.CohereChatEndpoint.CREATE_CHAT
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                f"{config.BASE_URL}{endpoint}",
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/elevenlabs/speech_to_text/client.py
+++ b/src/celeste/providers/elevenlabs/speech_to_text/client.py
@@ -71,7 +71,7 @@ class ElevenLabsSpeechToTextClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )

--- a/src/celeste/providers/elevenlabs/text_to_speech/client.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/client.py
@@ -1,7 +1,6 @@
 """ElevenLabs TextToSpeech API client mixin."""
 
-from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import httpx
@@ -84,7 +83,7 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make HTTP streaming request returning binary audio chunks.
 
         ElevenLabs streams binary audio data, not JSON SSE events.
@@ -112,15 +111,11 @@ class ElevenLabsTextToSpeechClient(APIMixin):
         if output_format:
             url = f"{url}?output_format={output_format}"
 
-        async with aclosing(
-            self._stream_binary_audio(
-                url,
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self._stream_binary_audio(
+            url,
+            headers=headers,
+            json_body=request_body,
+        )
 
     async def _stream_binary_audio(
         self,

--- a/src/celeste/providers/elevenlabs/text_to_speech/client.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/client.py
@@ -1,6 +1,7 @@
 """ElevenLabs TextToSpeech API client mixin."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import aclosing
 from typing import Any
 
 import httpx
@@ -59,7 +60,7 @@ class ElevenLabsTextToSpeechClient(APIMixin):
             endpoint = config.ElevenLabsTextToSpeechEndpoint.CREATE_SPEECH
         endpoint = endpoint.format(voice_id=voice_id)
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         url = f"{config.BASE_URL}{endpoint}"
         if output_format:
@@ -76,7 +77,7 @@ class ElevenLabsTextToSpeechClient(APIMixin):
             "headers": dict(response.headers),
         }
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -105,24 +106,28 @@ class ElevenLabsTextToSpeechClient(APIMixin):
             endpoint = config.ElevenLabsTextToSpeechEndpoint.STREAM_SPEECH
         endpoint = endpoint.format(voice_id=voice_id)
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         url = f"{config.BASE_URL}{endpoint}"
         if output_format:
             url = f"{url}?output_format={output_format}"
 
-        return self._stream_binary_audio(
-            url,
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self._stream_binary_audio(
+                url,
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     async def _stream_binary_audio(
         self,
         url: str,
         headers: dict[str, str],
         json_body: dict[str, Any],
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Stream binary audio data and yield as dict events.
 
         Wraps httpx streaming to yield dicts compatible with Stream interface.

--- a/src/celeste/providers/elevenlabs/text_to_speech/streaming.py
+++ b/src/celeste/providers/elevenlabs/text_to_speech/streaming.py
@@ -47,11 +47,8 @@ class ElevenLabsTextToSpeechStream:
     def _build_stream_metadata(
         self, raw_events: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        """Filter to keep only metadata events.
-
-        ElevenLabs binary stream has no metadata events.
-        """
-        return super()._build_stream_metadata(raw_events)  # type: ignore[misc]
+        """Exclude audio chunks; the binary stream has no metadata events."""
+        return super()._build_stream_metadata([])  # type: ignore[misc]
 
 
 __all__ = ["ElevenLabsTextToSpeechStream"]

--- a/src/celeste/providers/fal/queue/client.py
+++ b/src/celeste/providers/fal/queue/client.py
@@ -39,7 +39,7 @@ class FalQueueClient(APIMixin):
     ) -> dict[str, Any]:
         """Submit to fal queue, poll until COMPLETED, return result payload."""
         headers = {
-            **self._json_headers(extra_headers),
+            **(await self._json_headers(extra_headers)),
             "Accept": ApplicationMimeType.JSON,
         }
 
@@ -62,7 +62,7 @@ class FalQueueClient(APIMixin):
             raise ValueError(msg)
 
         poll_headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            {**(await self.auth.aget_headers()), "Accept": ApplicationMimeType.JSON},
             extra_headers,
         )
         start_time = time.monotonic()

--- a/src/celeste/providers/fal/queue/client.py
+++ b/src/celeste/providers/fal/queue/client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from celeste.client import APIMixin
@@ -99,14 +99,14 @@ class FalQueueClient(APIMixin):
 
             await asyncio.sleep(config.POLLING_INTERVAL)
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """fal queue does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/google/auth.py
+++ b/src/celeste/providers/google/auth.py
@@ -1,8 +1,10 @@
 """Google Cloud authentication using ADC."""
 
+import asyncio
+from threading import Lock
 from typing import Any, ClassVar
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, PrivateAttr
 
 from celeste.auth import Authentication
 from celeste.exceptions import MissingDependencyError
@@ -29,6 +31,11 @@ class GoogleADC(Authentication):
     _credentials: Any = None
     _auth_request: Any = None
     _project: str | None = None
+    _refresh_lock: Lock = PrivateAttr(default_factory=Lock)
+
+    async def aget_headers(self) -> dict[str, str]:
+        """Discover and refresh credentials without blocking the event loop."""
+        return await asyncio.to_thread(self.get_headers)
 
     def get_headers(self) -> dict[str, str]:
         """Return OAuth Bearer token header with quota project."""
@@ -46,14 +53,17 @@ class GoogleADC(Authentication):
         except ImportError as e:
             raise MissingDependencyError(library="google-auth", extra="gcp") from e
 
-        if self._credentials is None:
-            self._credentials, self._project = google.auth.default(scopes=self.scopes)
-            self._auth_request = google.auth.transport.requests.Request()
+        with self._refresh_lock:
+            if self._credentials is None:
+                self._credentials, self._project = google.auth.default(
+                    scopes=self.scopes
+                )
+                self._auth_request = google.auth.transport.requests.Request()
 
-        if not self._credentials.valid:
-            self._credentials.refresh(self._auth_request)
+            if not self._credentials.valid:
+                self._credentials.refresh(self._auth_request)
 
-        return self._credentials.token, self.project_id or self._project
+            return self._credentials.token, self.project_id or self._project
 
     @property
     def resolved_project_id(self) -> str | None:

--- a/src/celeste/providers/google/embeddings/client.py
+++ b/src/celeste/providers/google/embeddings/client.py
@@ -108,8 +108,8 @@ class GoogleEmbeddingsClient(APIMixin):
         if endpoint is None:
             endpoint = endpoint_template
 
+        headers = await self._json_headers(extra_headers)
         url = self._build_url(endpoint)
-        headers = self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             url,

--- a/src/celeste/providers/google/embeddings/client.py
+++ b/src/celeste/providers/google/embeddings/client.py
@@ -1,7 +1,7 @@
 """Google Embeddings API client mixin."""
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -31,14 +31,14 @@ class GoogleEmbeddingsClient(APIMixin):
 
     _content_fields: ClassVar[set[str]] = {"embedding", "embeddings"}
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Embeddings API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/google/generate_content/client.py
+++ b/src/celeste/providers/google/generate_content/client.py
@@ -1,6 +1,7 @@
 """Google GenerateContent API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -70,7 +71,7 @@ class GoogleGenerateContentClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleGenerateContentEndpoint.GENERATE_CONTENT
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
         response = await self.http_client.post(
             url=self._build_url(endpoint),
             headers=headers,
@@ -80,7 +81,7 @@ class GoogleGenerateContentClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -92,12 +93,16 @@ class GoogleGenerateContentClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleGenerateContentEndpoint.STREAM_GENERATE_CONTENT
 
-        headers = self._json_headers(extra_headers)
-        return self.http_client.stream_post(
-            url=self._build_url(endpoint),
-            headers=headers,
-            json_body=request_body,
-        )
+        headers = await self._json_headers(extra_headers)
+        async with aclosing(
+            self.http_client.stream_post(
+                url=self._build_url(endpoint),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/google/generate_content/client.py
+++ b/src/celeste/providers/google/generate_content/client.py
@@ -1,7 +1,6 @@
 """Google GenerateContent API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -88,21 +87,17 @@ class GoogleGenerateContentClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to streamGenerateContent endpoint."""
         if endpoint is None:
             endpoint = config.GoogleGenerateContentEndpoint.STREAM_GENERATE_CONTENT
 
         headers = await self._json_headers(extra_headers)
-        async with aclosing(
-            self.http_client.stream_post(
-                url=self._build_url(endpoint),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            url=self._build_url(endpoint),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/google/generate_content/streaming.py
+++ b/src/celeste/providers/google/generate_content/streaming.py
@@ -20,21 +20,34 @@ class GoogleGenerateContentStream:
 
     _error_type_fields: ClassVar[tuple[str, ...]] = ("status", "code")
     _content_parts: list[dict[str, Any]]
+    _grounding_part_fragments: list[list[dict[str, Any]]]
     _grounding_metadata: list[dict[str, Any]]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         super().__init__(*args, **kwargs)
         self._content_parts = []
+        self._grounding_part_fragments = []
         self._grounding_metadata = []
 
     def _parse_chunk(self, event_data: dict[str, Any]) -> Any | None:  # noqa: ANN401
         """Capture native Parts and grounding before normal chunk filtering."""
         candidates = event_data.get("candidates", [])
         if candidates:
-            self._content_parts.extend(
-                candidates[0].get("content", {}).get("parts", [])
-            )
-        for candidate in candidates:
+            candidate = candidates[0]
+            parts = candidate.get("content", {}).get("parts", [])
+            self._content_parts.extend(parts)
+            # Treat adjacent SSE text as a continuation; keep in-event Parts distinct.
+            if (
+                self._grounding_part_fragments
+                and parts
+                and isinstance(self._grounding_part_fragments[-1][-1].get("text"), str)
+                and isinstance(parts[0].get("text"), str)
+                and bool(self._grounding_part_fragments[-1][-1].get("thought"))
+                == bool(parts[0].get("thought"))
+            ):
+                self._grounding_part_fragments[-1].append(parts[0])
+                parts = parts[1:]
+            self._grounding_part_fragments.extend([part] for part in parts)
             meta = candidate.get("groundingMetadata")
             if isinstance(meta, dict):
                 self._grounding_metadata.append(meta)
@@ -64,11 +77,10 @@ class GoogleGenerateContentStream:
             return None
 
         parts = candidates[0].get("content", {}).get("parts", [])
-        for p in parts:
-            if p.get("thought") and "text" in p:
-                return p["text"]
-
-        return None
+        return (
+            "".join(p["text"] for p in parts if p.get("thought") and p.get("text"))
+            or None
+        )
 
     def _parse_chunk_usage(
         self, event_data: dict[str, Any]

--- a/src/celeste/providers/google/imagen/client.py
+++ b/src/celeste/providers/google/imagen/client.py
@@ -67,7 +67,7 @@ class GoogleImagenClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleImagenEndpoint.CREATE_IMAGE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
         response = await self.http_client.post(
             self._build_url(endpoint),
             headers=headers,

--- a/src/celeste/providers/google/imagen/client.py
+++ b/src/celeste/providers/google/imagen/client.py
@@ -1,6 +1,6 @@
 """Google Imagen API client mixin."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -77,14 +77,14 @@ class GoogleImagenClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Imagen API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -1,6 +1,7 @@
 """Google Interactions API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -66,7 +67,7 @@ class GoogleInteractionsClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
@@ -76,7 +77,7 @@ class GoogleInteractionsClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -88,12 +89,16 @@ class GoogleInteractionsClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
-        headers = self._json_headers(extra_headers)
-        return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
+        headers = await self._json_headers(extra_headers)
+        async with aclosing(
+            self.http_client.stream_post(
+                f"{config.BASE_URL}{endpoint}",
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/google/interactions/client.py
+++ b/src/celeste/providers/google/interactions/client.py
@@ -1,7 +1,6 @@
 """Google Interactions API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -84,21 +83,17 @@ class GoogleInteractionsClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to interactions endpoint."""
         if endpoint is None:
             endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
         headers = await self._json_headers(extra_headers)
-        async with aclosing(
-            self.http_client.stream_post(
-                f"{config.BASE_URL}{endpoint}",
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            f"{config.BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/google/utils.py
+++ b/src/celeste/providers/google/utils.py
@@ -3,8 +3,47 @@
 import base64
 from typing import Any
 
+import httpx
+
 from celeste.artifacts import Artifact
+from celeste.auth import Authentication
+from celeste.http import DEFAULT_TIMEOUT, HTTPClient
 from celeste.utils import detect_mime_type
+
+from .auth import GoogleADC
+
+
+async def download_video(
+    http_client: HTTPClient,
+    auth: Authentication,
+    url: str,
+    extra_headers: dict[str, str] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> httpx.Response:
+    """Download video, authenticating only the matching Google origin on each hop."""
+    target = httpx.URL(
+        url.replace("gs://", "https://storage.googleapis.com/", 1)
+        if url.startswith("gs://")
+        else url
+    )
+    auth_host = (
+        "storage.googleapis.com"
+        if isinstance(auth, GoogleADC)
+        else "generativelanguage.googleapis.com"
+    )
+    for _ in range(21):
+        headers = {}
+        if (target.scheme, target.host, target.port) == ("https", auth_host, None):
+            headers = {**await auth.aget_headers(), **(extra_headers or {})}
+        response = await http_client.get(
+            str(target), headers=headers, timeout=timeout, follow_redirects=False
+        )
+        if response.next_request is None:
+            return response
+        target = response.next_request.url
+    raise httpx.TooManyRedirects(
+        "Exceeded maximum allowed redirects.", request=response.request
+    )
 
 
 def build_media_part(artifact: Artifact) -> dict[str, Any]:

--- a/src/celeste/providers/google/veo/client.py
+++ b/src/celeste/providers/google/veo/client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -95,14 +95,14 @@ class GoogleVeoClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Veo API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/google/veo/client.py
+++ b/src/celeste/providers/google/veo/client.py
@@ -10,6 +10,7 @@ from celeste.exceptions import StreamingNotSupportedError
 from celeste.io import FinishReason
 
 from ..auth import GoogleADC
+from ..utils import download_video
 from . import config
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class GoogleVeoClient(APIMixin):
         Vertex AI uses POST to fetchPredictOperation with operationName in body.
         AI Studio uses GET to /v1beta/{operation_name}.
         """
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
         poll_url = self._build_poll_url(operation_name)
 
         if isinstance(self.auth, GoogleADC):
@@ -117,7 +118,7 @@ class GoogleVeoClient(APIMixin):
         if endpoint is None:
             endpoint = config.GoogleVeoEndpoint.CREATE_VIDEO
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         logger.info(f"Initiating video generation with model {self.model.id}")
         response = await self.http_client.post(
@@ -167,9 +168,8 @@ class GoogleVeoClient(APIMixin):
                 msg = "No videos in response"
                 raise ValueError(msg)
             video = videos[0]
-            # Normalize Vertex key "videoGcsUri" to "uri" for consistency
-            if "videoGcsUri" in video:
-                video["uri"] = video.pop("videoGcsUri")
+            if "gcsUri" in video:
+                return {**video, "uri": video["gcsUri"]}
             return video
 
         generated_samples = response.get("generateVideoResponse", {}).get(
@@ -213,19 +213,12 @@ class GoogleVeoClient(APIMixin):
         Returns:
             Raw video bytes.
         """
-        download_url = url
-        if download_url.startswith("gs://"):
-            download_url = download_url.replace("gs://", config.STORAGE_BASE_URL, 1)
-
-        logger.info(f"Downloading video from: {download_url}")
-
-        headers = self._merge_headers(self.auth.get_headers(), extra_headers)
-
-        response = await self.http_client.get(
-            download_url,
-            headers=headers,
+        response = await download_video(
+            self.http_client,
+            self.auth,
+            url,
+            extra_headers,
             timeout=config.DEFAULT_TIMEOUT,
-            follow_redirects=True,
         )
 
         self._handle_error_response(response)

--- a/src/celeste/providers/google/veo/config.py
+++ b/src/celeste/providers/google/veo/config.py
@@ -22,6 +22,3 @@ BASE_URL = "https://generativelanguage.googleapis.com"
 # Polling Configuration
 POLL_INTERVAL = 10  # seconds
 DEFAULT_TIMEOUT = 300.0  # 5 minutes for long-running operations
-
-# Storage Configuration
-STORAGE_BASE_URL = "https://storage.googleapis.com/"

--- a/src/celeste/providers/gradium/text_to_speech/client.py
+++ b/src/celeste/providers/gradium/text_to_speech/client.py
@@ -2,7 +2,8 @@
 
 import base64
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from typing import Any
 
 from websockets.asyncio.client import connect as ws_connect
@@ -18,7 +19,7 @@ class GradiumTextToSpeechClient(APIMixin):
     """Mixin for Gradium Text-to-Speech API.
 
     Provides shared implementation for speech generation via WebSocket:
-    - _make_stream_request() - WebSocket streaming (yields events)
+    - _make_stream_request() - Returns WebSocket streaming events
     - _parse_usage() - Returns empty dict (TTS doesn't return usage)
     - _map_output_format_to_mime_type() - Map format string to AudioMimeType
 
@@ -38,33 +39,24 @@ class GradiumTextToSpeechClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Execute WebSocket TTS flow as async generator.
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Return the WebSocket audio generator."""
+        if endpoint is None:
+            endpoint = config.GradiumTextToSpeechEndpoint.CREATE_SPEECH
+        headers = self._merge_headers(await self.auth.aget_headers(), extra_headers)
+        return self._stream_audio(f"{config.BASE_URL}{endpoint}", headers, request_body)
 
-        Yields events in streaming format:
-        - {"data": bytes} for audio chunks
-        - {"finish_reason": "stop"} at end
-
-        Args:
-            request_body: Request with text, voice_id, output_format, json_config.
-            endpoint: WebSocket endpoint path (defaults to config).
-            **parameters: Additional parameters (unused).
-
-        Yields:
-            Event dicts with audio data or finish_reason.
-
-        Raises:
-            ValueError: If connection fails or error received.
-        """
+    async def _stream_audio(
+        self,
+        url: str,
+        headers: dict[str, str],
+        request_body: dict[str, Any],
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Yield audio and finish events from the WebSocket TTS flow."""
         voice_id = request_body.get("voice_id", config.DEFAULT_VOICE_ID)
         output_format = request_body.get("output_format", "wav")
         text = request_body.get("text", "")
         json_config = request_body.get("json_config")
-
-        if endpoint is None:
-            endpoint = config.GradiumTextToSpeechEndpoint.CREATE_SPEECH
-        url = f"{config.BASE_URL}{endpoint}"
-        headers = self._merge_headers(await self.auth.aget_headers(), extra_headers)
 
         async with ws_connect(url, additional_headers=headers) as ws:
             # 1. Send setup message
@@ -154,11 +146,17 @@ class GradiumTextToSpeechClient(APIMixin):
         audio_chunks: list[bytes] = []
         output_format = request_body.get("output_format", "wav")
 
-        async for event in self._make_stream_request(
-            request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
-        ):
-            if "data" in event:
-                audio_chunks.append(event["data"])
+        async with aclosing(
+            await self._make_stream_request(
+                request_body,
+                endpoint=endpoint,
+                extra_headers=extra_headers,
+                **parameters,
+            )
+        ) as events:
+            async for event in events:
+                if "data" in event:
+                    audio_chunks.append(event["data"])
 
         return {
             "audio_bytes": b"".join(audio_chunks),

--- a/src/celeste/providers/gradium/text_to_speech/client.py
+++ b/src/celeste/providers/gradium/text_to_speech/client.py
@@ -64,7 +64,7 @@ class GradiumTextToSpeechClient(APIMixin):
         if endpoint is None:
             endpoint = config.GradiumTextToSpeechEndpoint.CREATE_SPEECH
         url = f"{config.BASE_URL}{endpoint}"
-        headers = self._merge_headers(self.auth.get_headers(), extra_headers)
+        headers = self._merge_headers(await self.auth.aget_headers(), extra_headers)
 
         async with ws_connect(url, additional_headers=headers) as ws:
             # 1. Send setup message

--- a/src/celeste/providers/gradium/text_to_speech/streaming.py
+++ b/src/celeste/providers/gradium/text_to_speech/streaming.py
@@ -49,11 +49,10 @@ class GradiumTextToSpeechStream:
     def _build_stream_metadata(
         self, raw_events: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        """Filter to keep only metadata events.
-
-        Gradium WebSocket stream has no metadata events.
-        """
-        return super()._build_stream_metadata(raw_events)  # type: ignore[misc]
+        """Retain finish events without duplicating binary audio content."""
+        return super()._build_stream_metadata(  # type: ignore[misc]
+            [e for e in raw_events if "data" not in e]
+        )
 
 
 __all__ = ["GradiumTextToSpeechStream"]

--- a/src/celeste/providers/groq/audio/client.py
+++ b/src/celeste/providers/groq/audio/client.py
@@ -72,7 +72,7 @@ class GroqAudioClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )

--- a/src/celeste/providers/mistral/audio/client.py
+++ b/src/celeste/providers/mistral/audio/client.py
@@ -71,7 +71,7 @@ class MistralAudioClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )

--- a/src/celeste/providers/ollama/generate/client.py
+++ b/src/celeste/providers/ollama/generate/client.py
@@ -1,8 +1,7 @@
 """Ollama Generate API client mixin."""
 
 import json
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -78,22 +77,18 @@ class OllamaGenerateClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make NDJSON streaming request to Ollama Generate API."""
         if endpoint is None:
             endpoint = config.OllamaGenerateEndpoint.GENERATE
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post_ndjson(
-                self._build_url(endpoint),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post_ndjson(
+            self._build_url(endpoint),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/ollama/generate/client.py
+++ b/src/celeste/providers/ollama/generate/client.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -59,7 +60,7 @@ class OllamaGenerateClient(APIMixin):
         if endpoint is None:
             endpoint = config.OllamaGenerateEndpoint.GENERATE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -70,7 +71,7 @@ class OllamaGenerateClient(APIMixin):
         # NDJSON: Ollama returns progress lines, final line has done=true + image
         return json.loads(response.text.strip().splitlines()[-1])
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -82,13 +83,17 @@ class OllamaGenerateClient(APIMixin):
         if endpoint is None:
             endpoint = config.OllamaGenerateEndpoint.GENERATE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post_ndjson(
-            self._build_url(endpoint),
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post_ndjson(
+                self._build_url(endpoint),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/openai/audio/client.py
+++ b/src/celeste/providers/openai/audio/client.py
@@ -92,7 +92,7 @@ class OpenAIAudioClient(APIMixin):
                 request_body, endpoint=endpoint, extra_headers=extra_headers
             )
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
@@ -130,7 +130,7 @@ class OpenAIAudioClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )

--- a/src/celeste/providers/openai/audio/client.py
+++ b/src/celeste/providers/openai/audio/client.py
@@ -1,6 +1,6 @@
 """OpenAI Audio API client mixin."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.artifacts import AudioArtifact
@@ -63,14 +63,14 @@ class OpenAIAudioClient(APIMixin):
             request_body["stream"] = True
         return request_body
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """OpenAI Audio speech endpoint does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -6,6 +6,7 @@ Provides shared implementation for capabilities using the OpenAI Images API:
 """
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -77,7 +78,7 @@ class OpenAIImagesClient(APIMixin):
         extra_headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Make JSON request for generate operations."""
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -117,7 +118,7 @@ class OpenAIImagesClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )
@@ -125,7 +126,7 @@ class OpenAIImagesClient(APIMixin):
         response_data: dict[str, Any] = response.json()
         return response_data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -150,13 +151,17 @@ class OpenAIImagesClient(APIMixin):
             request_body["images"] = [{"image_url": build_data_url(artifact)}]
             endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                f"{config.BASE_URL}{endpoint}",
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -5,8 +5,7 @@ Provides shared implementation for capabilities using the OpenAI Images API:
 - image-edit (edits endpoint)
 """
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -133,7 +132,7 @@ class OpenAIImagesClient(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to OpenAI Images API.
 
         Streaming is only supported for gpt-image-1.
@@ -153,15 +152,11 @@ class OpenAIImagesClient(APIMixin):
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                f"{config.BASE_URL}{endpoint}",
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            f"{config.BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/src/celeste/providers/openai/videos/client.py
+++ b/src/celeste/providers/openai/videos/client.py
@@ -93,7 +93,9 @@ class OpenAIVideosClient(APIMixin):
             logger.info("Sending multipart request to OpenAI with input_reference")
             response = await self.http_client.post_multipart(
                 f"{config.BASE_URL}{endpoint}",
-                headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+                headers=self._merge_headers(
+                    await self.auth.aget_headers(), extra_headers
+                ),
                 files=files,
                 data=data,
             )
@@ -101,7 +103,7 @@ class OpenAIVideosClient(APIMixin):
             logger.info(f"Sending request to OpenAI: {request_body}")
             response = await self.http_client.post(
                 f"{config.BASE_URL}{endpoint}",
-                headers=self._json_headers(extra_headers),
+                headers=await self._json_headers(extra_headers),
                 json_body=request_body,
             )
 
@@ -112,7 +114,7 @@ class OpenAIVideosClient(APIMixin):
         logger.info(f"Created video job: {video_id}")
 
         # Poll for completion
-        poll_headers = self._json_headers(extra_headers)
+        poll_headers = await self._json_headers(extra_headers)
         for _ in range(config.MAX_POLLS):
             status_response = await self.http_client.get(
                 f"{config.BASE_URL}{endpoint}/{video_id}",

--- a/src/celeste/providers/openai/videos/client.py
+++ b/src/celeste/providers/openai/videos/client.py
@@ -7,7 +7,7 @@ Provides shared implementation for capabilities using the OpenAI Videos API:
 import asyncio
 import base64
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -58,14 +58,14 @@ class OpenAIVideosClient(APIMixin):
             request_body["stream"] = True
         return request_body
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """OpenAI Videos API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/topazlabs/image/client.py
+++ b/src/celeste/providers/topazlabs/image/client.py
@@ -99,7 +99,7 @@ class TopazLabsImageClient(APIMixin):
 
         response = await self.http_client.post_multipart(
             f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(self.auth.get_headers(), extra_headers),
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
             files=files,
             data=data,
         )
@@ -115,7 +115,7 @@ class TopazLabsImageClient(APIMixin):
     ) -> dict[str, Any]:
         """Poll status until Completed or terminal failure."""
         headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            {**(await self.auth.aget_headers()), "Accept": ApplicationMimeType.JSON},
             extra_headers,
         )
         status_url = (
@@ -155,7 +155,7 @@ class TopazLabsImageClient(APIMixin):
     ) -> dict[str, Any]:
         """Fetch presigned download URL for a completed process."""
         headers = self._merge_headers(
-            {**self.auth.get_headers(), "Accept": ApplicationMimeType.JSON},
+            {**(await self.auth.aget_headers()), "Accept": ApplicationMimeType.JSON},
             extra_headers,
         )
         download_url = (

--- a/src/celeste/providers/topazlabs/image/client.py
+++ b/src/celeste/providers/topazlabs/image/client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -167,14 +167,14 @@ class TopazLabsImageClient(APIMixin):
         download_data: dict[str, Any] = response.json()
         return download_data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Topaz Labs Image API does not support SSE streaming in this client."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/xai/images/client.py
+++ b/src/celeste/providers/xai/images/client.py
@@ -1,6 +1,6 @@
 """xAI Images API client mixin."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -65,14 +65,14 @@ class XAIImagesClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """xAI Images does not support SSE streaming."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/xai/images/client.py
+++ b/src/celeste/providers/xai/images/client.py
@@ -54,7 +54,7 @@ class XAIImagesClient(APIMixin):
         if endpoint is None:
             endpoint = config.XAIImagesEndpoint.CREATE_IMAGE
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",

--- a/src/celeste/providers/xai/videos/client.py
+++ b/src/celeste/providers/xai/videos/client.py
@@ -1,7 +1,7 @@
 """xAI Videos API client mixin."""
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -44,14 +44,14 @@ class XAIVideosClient(APIMixin):
         request_body["model"] = self.model.id
         return request_body
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """xAI Videos API does not support SSE streaming."""
         raise StreamingNotSupportedError(model_id=self.model.id)
 

--- a/src/celeste/providers/xai/videos/client.py
+++ b/src/celeste/providers/xai/videos/client.py
@@ -67,7 +67,7 @@ class XAIVideosClient(APIMixin):
         if endpoint is None:
             endpoint = config.XAIVideosEndpoint.CREATE_VIDEO
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         # Submit video generation request
         response = await self.http_client.post(

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -1,5 +1,6 @@
 """Streaming support for Celeste."""
 
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import suppress
@@ -29,6 +30,9 @@ async def enrich_stream_errors(
     except httpx.HTTPStatusError as e:
         error_handler(e.response)
         raise  # Unreachable — error_handler always raises for error responses
+    finally:
+        if hasattr(iterator, "aclose"):
+            await iterator.aclose()
 
 
 class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
@@ -60,6 +64,8 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         self._sse_iterator = sse_iterator
         self._chunks: list[Chunk] = []
         self._closed = False
+        self._pending: asyncio.Future[dict[str, Any]] | None = None
+        self._close_task: asyncio.Task[None] | None = None
         self._output: Out | None = None
         self._parameters = parameters
         self._transform_output = transform_output
@@ -338,9 +344,20 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
         """Yield next chunk from stream."""
         if self._closed:
             raise StopAsyncIteration
+        if self._pending is not None:
+            raise RuntimeError("Stream already has a pending next chunk")
 
         try:
-            async for event in self._sse_iterator:
+            while True:
+                self._pending = asyncio.ensure_future(anext(self._sse_iterator))
+                try:
+                    event = await self._pending
+                except StopAsyncIteration:
+                    break
+                finally:
+                    self._pending = None
+                if self._closed:
+                    raise StopAsyncIteration
                 chunk = self._parse_chunk(event)
                 if chunk is not None:
                     self._chunks.append(chunk)
@@ -349,11 +366,11 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
             # Stream exhausted naturally
             if self._chunks:
                 self._output = self._parse_output(self._chunks, **self._parameters)
-            self._closed = True
-        except Exception:
+        except BaseException:
             await self.aclose()
             raise
 
+        await self.aclose()
         raise StopAsyncIteration
 
     # Iterator protocol (sync)
@@ -416,20 +433,29 @@ class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):
 
     async def aclose(self) -> None:
         """Explicitly close stream and cleanup resources."""
-        if self._closed:
-            return
+        task = self._close_task
+        if task is None:
+            if self._closed:
+                return
+            self._closed = True
+            task = asyncio.create_task(self._close_iterator(self._pending))
+            if not task.done():
+                self._close_task = task
+        await asyncio.shield(task)
 
-        self._closed = True
-
-        # Fast path: skip if iterator is currently running
-        if getattr(self._sse_iterator, "ag_running", False):
-            return
-
-        # Close SSE iterator (httpx-sse connection)
-        # Use suppress to handle TOCTOU race between ag_running check and aclose
-        if hasattr(self._sse_iterator, "aclose"):
-            with suppress(RuntimeError):
+    async def _close_iterator(
+        self, pending: asyncio.Future[dict[str, Any]] | None
+    ) -> None:
+        """Stop a pending read before closing the iterator that owns the transport."""
+        try:
+            if pending is not None:
+                pending.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await pending
+            if hasattr(self._sse_iterator, "aclose"):
                 await self._sse_iterator.aclose()
+        finally:
+            self._close_task = None
 
 
 __all__ = ["Stream", "enrich_stream_errors"]

--- a/src/celeste/streaming.py
+++ b/src/celeste/streaming.py
@@ -2,8 +2,8 @@
 
 import asyncio
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Callable, Iterator
-from contextlib import suppress
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterator
+from contextlib import aclosing, suppress
 from types import TracebackType
 from typing import Any, ClassVar, Self, Unpack
 
@@ -20,19 +20,17 @@ from celeste.types import RawUsage, ToolActivity
 
 
 async def enrich_stream_errors(
-    iterator: AsyncIterator[dict[str, Any]],
+    factory: Callable[[], Awaitable[AsyncGenerator[dict[str, Any], None]]],
     error_handler: Callable[[httpx.Response], None],
 ) -> AsyncIterator[dict[str, Any]]:
-    """Wrap stream iterator to enrich HTTP errors with provider-specific messages."""
+    """Lazily create and close the transport iterator, enriching HTTP errors."""
     try:
-        async for event in iterator:
-            yield event
+        async with aclosing(await factory()) as iterator:
+            async for event in iterator:
+                yield event
     except httpx.HTTPStatusError as e:
         error_handler(e.response)
         raise  # Unreachable — error_handler always raises for error responses
-    finally:
-        if hasattr(iterator, "aclose"):
-            await iterator.aclose()
 
 
 class Stream[Out: Output, Params: Parameters, Chunk: ChunkBase](ABC):

--- a/src/celeste/telemetry.py
+++ b/src/celeste/telemetry.py
@@ -554,15 +554,16 @@ async def bind_first_pull_to_span(
 
     task = asyncio.create_task(_first(), context=ctx)
     try:
-        first = await task
-    except StopAsyncIteration:
-        return
-    except BaseException:
-        task.cancel()
-        raise
-    yield first
-    async for event in inner:
-        yield event
+        try:
+            first = await task
+        except StopAsyncIteration:
+            return
+        yield first
+        async for event in inner:
+            yield event
+    finally:
+        if hasattr(inner, "aclose"):
+            await inner.aclose()
 
 
 __all__ = [

--- a/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
+++ b/templates/modalities/{modality_slug}/providers/{provider_slug}/_dispatcher.py.template
@@ -120,8 +120,8 @@ class {Provider}{Modality}Client({Modality}Client):
         return self._strategy._build_metadata(response_data)  # type: ignore[union-attr]
 
     # Streaming path — delete if this provider does not stream this modality:
-    # def _make_stream_request(self, request_body, *, endpoint=None, extra_headers=None, **parameters):
-    #     return self._strategy._make_stream_request(
+    # async def _make_stream_request(self, request_body, *, endpoint=None, extra_headers=None, **parameters):
+    #     return await self._strategy._make_stream_request(
     #         request_body, endpoint=endpoint, extra_headers=extra_headers, **parameters
     #     )
     #

--- a/templates/protocols/{protocol_slug}/client.py.template
+++ b/templates/protocols/{protocol_slug}/client.py.template
@@ -1,6 +1,7 @@
 """{Protocol} protocol client."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -48,7 +49,8 @@ class {Protocol}Client(APIMixin):
                     return self.auth.build_url(self._get_vertex_endpoint(endpoint, streaming))
                 return super()._build_url(endpoint, streaming)
         """
-        return f"{self._default_base_url}{endpoint}"
+        base = self.base_url if self.base_url is not None else self._default_base_url
+        return f"{base}{endpoint}"
 
     def _build_request(
         self,
@@ -78,7 +80,7 @@ class {Protocol}Client(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             self._build_url(endpoint),
@@ -89,7 +91,7 @@ class {Protocol}Client(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -101,13 +103,17 @@ class {Protocol}Client(APIMixin):
         if endpoint is None:
             endpoint = self._default_endpoint
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            self._build_url(endpoint, streaming=True),
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                self._build_url(endpoint, streaming=True),
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/templates/protocols/{protocol_slug}/client.py.template
+++ b/templates/protocols/{protocol_slug}/client.py.template
@@ -1,7 +1,6 @@
 """{Protocol} protocol client."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -98,22 +97,18 @@ class {Protocol}Client(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to {Protocol} API endpoint."""
         if endpoint is None:
             endpoint = self._default_endpoint
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                self._build_url(endpoint, streaming=True),
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            self._build_url(endpoint, streaming=True),
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/templates/providers/{provider_slug}/{api_slug}/client.py.template
+++ b/templates/providers/{provider_slug}/{api_slug}/client.py.template
@@ -1,7 +1,6 @@
 """{Provider} {Api} API client mixin."""
 
-from collections.abc import AsyncIterator
-from contextlib import aclosing
+from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -100,18 +99,18 @@ class {Provider}{Api}Client(APIMixin):
         endpoint: str | None = None,
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Make streaming request to {Provider} {Api} API.
 
         If this API does not support streaming, replace this implementation with:
-            def _make_stream_request(
+            async def _make_stream_request(
                 self,
                 request_body: dict[str, Any],
                 *,
                 endpoint: str | None = None,
                 extra_headers: dict[str, str] | None = None,
                 **parameters: Any,
-            ) -> AsyncIterator[dict[str, Any]]:
+            ) -> AsyncGenerator[dict[str, Any], None]:
                 \"\"\"{Provider} {Api} does not support SSE streaming in this client.\"\"\"
                 raise StreamingNotSupportedError(model_id=self.model.id)
         """
@@ -120,15 +119,11 @@ class {Provider}{Api}Client(APIMixin):
 
         headers = await self._json_headers(extra_headers)
 
-        async with aclosing(
-            self.http_client.stream_post(
-                f"{config.BASE_URL}{endpoint}",
-                headers=headers,
-                json_body=request_body,
-            )
-        ) as events:
-            async for event in events:
-                yield event
+        return self.http_client.stream_post(
+            f"{config.BASE_URL}{endpoint}",
+            headers=headers,
+            json_body=request_body,
+        )
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/templates/providers/{provider_slug}/{api_slug}/client.py.template
+++ b/templates/providers/{provider_slug}/{api_slug}/client.py.template
@@ -1,6 +1,7 @@
 """{Provider} {Api} API client mixin."""
 
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, ClassVar
 
 from celeste.client import APIMixin
@@ -81,7 +82,7 @@ class {Provider}{Api}Client(APIMixin):
         if endpoint is None:
             endpoint = config.{Provider}{Api}Endpoint.CREATE_...
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
@@ -92,7 +93,7 @@ class {Provider}{Api}Client(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    def _make_stream_request(
+    async def _make_stream_request(
         self,
         request_body: dict[str, Any],
         *,
@@ -117,13 +118,17 @@ class {Provider}{Api}Client(APIMixin):
         if endpoint is None:
             endpoint = config.{Provider}{Api}Endpoint.CREATE_...
 
-        headers = self._json_headers(extra_headers)
+        headers = await self._json_headers(extra_headers)
 
-        return self.http_client.stream_post(
-            f"{config.BASE_URL}{endpoint}",
-            headers=headers,
-            json_body=request_body,
-        )
+        async with aclosing(
+            self.http_client.stream_post(
+                f"{config.BASE_URL}{endpoint}",
+                headers=headers,
+                json_body=request_body,
+            )
+        ) as events:
+            async for event in events:
+                yield event
 
     @staticmethod
     def map_usage_fields(usage_data: dict[str, Any]) -> dict[str, int | float | None]:

--- a/tests/unit_tests/_http_helpers.py
+++ b/tests/unit_tests/_http_helpers.py
@@ -1,0 +1,41 @@
+"""Small HTTPX helpers shared by transport regression tests."""
+
+import json
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from celeste import Modality, Protocol, create_client
+from celeste.auth import NoAuth
+from celeste.http import HTTPClient
+from celeste.modalities.text.client import TextClient
+
+
+def _text_client() -> TextClient:
+    return create_client(
+        modality=Modality.TEXT,
+        protocol=Protocol.OPENRESPONSES,
+        model="test",
+        base_url="https://example.test",
+        auth=NoAuth(),
+    )
+
+
+def _sse(*events: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        content="".join(f"data: {json.dumps(event)}\n\n" for event in events),
+    )
+
+
+@asynccontextmanager
+async def _mock_http(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> AsyncIterator[None]:
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        with patch.object(HTTPClient, "_get_client", AsyncMock(return_value=http)):
+            yield

--- a/tests/unit_tests/test_audio_stream_metadata.py
+++ b/tests/unit_tests/test_audio_stream_metadata.py
@@ -1,0 +1,36 @@
+"""Binary audio is serialized once while finish metadata remains available."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from celeste.modalities.audio.providers.elevenlabs.text_to_speech import (
+    ElevenLabsTextToSpeechAudioStream,
+)
+from celeste.modalities.audio.providers.gradium.client import GradiumAudioStream
+
+
+@pytest.mark.parametrize(
+    "stream_class", [ElevenLabsTextToSpeechAudioStream, GradiumAudioStream]
+)
+async def test_audio_metadata_excludes_binary_chunks(stream_class: type) -> None:
+    data = bytes([255, 254, 0, 1]) * 16384
+
+    async def events() -> AsyncIterator[dict[str, Any]]:
+        yield {"data": data}
+        yield {"finish_reason": "stop"}
+
+    stream = stream_class(events())
+    _ = [chunk async for chunk in stream]
+    output = stream.output
+    assert output.content.data == data
+    assert (
+        len(output.model_dump_json())
+        < len(output.model_dump_json(exclude={"metadata"})) + 1024
+    )
+    if stream_class is GradiumAudioStream:
+        assert output.metadata["raw_events"] == [{"finish_reason": "stop"}]
+        assert output.finish_reason.reason == "stop"
+    else:
+        assert output.metadata["raw_events"] == []

--- a/tests/unit_tests/test_embeddings_input.py
+++ b/tests/unit_tests/test_embeddings_input.py
@@ -1,6 +1,7 @@
 """Unit tests for EmbeddingsInput validation."""
 
 import pytest
+from pydantic import ValidationError
 
 from celeste.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
 from celeste.mime_types import AudioMimeType, ImageMimeType, VideoMimeType
@@ -59,18 +60,6 @@ def test_no_input_raises() -> None:
         EmbeddingsInput()
 
 
-def test_batch_text_with_image_raises() -> None:
-    img = ImageArtifact(data=_TEST_PNG_BYTES, mime_type=ImageMimeType.PNG)
-    with pytest.raises(Exception, match="Batch text"):
-        EmbeddingsInput(text=["a", "b"], images=img)
-
-
-def test_batch_text_with_video_raises() -> None:
-    vid = VideoArtifact(data=b"\x00" * 10, mime_type=VideoMimeType.MP4)
-    with pytest.raises(Exception, match="Batch text"):
-        EmbeddingsInput(text=["a", "b"], videos=vid)
-
-
 def test_audio_only() -> None:
     aud = AudioArtifact(data=b"\x00" * 10, mime_type=AudioMimeType.MP3)
     inp = EmbeddingsInput(audio=aud)
@@ -78,7 +67,20 @@ def test_audio_only() -> None:
     assert inp.text is None
 
 
-def test_batch_text_with_audio_raises() -> None:
-    aud = AudioArtifact(data=b"\x00" * 10, mime_type=AudioMimeType.MP3)
-    with pytest.raises(Exception, match="Batch text"):
-        EmbeddingsInput(text=["a", "b"], audio=aud)
+@pytest.mark.parametrize("batch_name", ["text", "images", "videos", "audio"])
+@pytest.mark.parametrize("other_name", ["text", "images", "videos", "audio"])
+def test_batches_cannot_silently_discard_other_inputs(
+    batch_name: str, other_name: str
+) -> None:
+    inputs = {
+        "text": "hello",
+        "images": ImageArtifact(data=_TEST_PNG_BYTES, mime_type=ImageMimeType.PNG),
+        "videos": VideoArtifact(data=b"video", mime_type=VideoMimeType.MP4),
+        "audio": AudioArtifact(data=b"audio", mime_type=AudioMimeType.MP3),
+    }
+    batch = {batch_name: [inputs[batch_name]]}
+    if batch_name == other_name:
+        assert getattr(EmbeddingsInput(**batch), batch_name) == batch[batch_name]
+    else:
+        with pytest.raises(ValidationError, match=f"Batch {batch_name}"):
+            EmbeddingsInput(**batch, **{other_name: inputs[other_name]})

--- a/tests/unit_tests/test_google_grounding.py
+++ b/tests/unit_tests/test_google_grounding.py
@@ -1,0 +1,104 @@
+"""Google grounding uses Part-relative UTF-8 offsets, not output offsets."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from celeste.modalities.text.providers.google.grounding import map_grounding_vertex
+from celeste.modalities.text.providers.google.vertex import (
+    GoogleVertexTextClient,
+    GoogleVertexTextStream,
+)
+
+PARTS = [
+    {"text": "secret", "thought": True},
+    {"text": "Café "},
+    {"executableCode": {"language": "PYTHON", "code": "1 + 1"}},
+    {"text": "🫖 éclair"},
+]
+SOURCE = {"web": {"uri": "https://example.test/source"}}
+SEGMENT = {"partIndex": 3, "startIndex": 5, "endIndex": 12, "text": "éclair"}
+
+
+async def _events(
+    groups: list[list[dict[str, Any]]], meta: dict
+) -> AsyncIterator[dict]:
+    for group in groups:
+        yield {"candidates": [{"content": {"parts": group}}]}
+    yield {
+        "candidates": [
+            {"finishReason": "STOP", "groundingMetadata": meta},
+            {"groundingMetadata": {"groundingChunks": [SOURCE]}},
+        ]
+    }
+
+
+@pytest.mark.parametrize("bundled", [True, False])
+async def test_grounding_preserves_part_boundaries_and_native_replay(
+    bundled: bool,
+) -> None:
+    meta = {
+        "groundingChunks": [SOURCE],
+        "groundingSupports": [
+            {"segment": SEGMENT, "groundingChunkIndices": [0]},
+            {"segment": {"partIndex": 1, "endIndex": 5, "text": "Café"}},
+        ],
+    }
+    response = {
+        "candidates": [{"content": {"parts": PARTS}, "groundingMetadata": meta}]
+    }
+    client = object.__new__(GoogleVertexTextClient)
+    grounding = client._parse_grounding(response)
+    assert grounding is not None
+    assert [(c.start, c.end) for c in grounding.citations] == [(7, 13), (0, 4)]
+    assert grounding.citations[0].source_indices == [0]
+    groups = (
+        [PARTS]
+        if bundled
+        else [[{"text": text, "thought": True}] for text in ("sec", "ret")]
+        + [[{"text": "Ca"}], [{"text": "fé "}], [PARTS[2]]]
+        + [[{"text": text}] for text in ("🫖 ", "écl", "air")]
+    )
+    stream = GoogleVertexTextStream(_events(groups, meta))
+    _ = [chunk async for chunk in stream]
+    assert stream.output.content == client._parse_content(response) == "Café 🫖 éclair"
+    assert stream.output.grounding == grounding
+    assert stream.output.signature == [part for group in groups for part in group]
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [{"partIndex": index} for index in (-1, 0, 2, 99, "bad")]
+    + [{"startIndex": 1}, {"endIndex": 99}, {"startIndex": 13}, {"text": "wrong"}],
+)
+def test_grounding_omits_invalid_spans_without_losing_sources(invalid: dict) -> None:
+    result = map_grounding_vertex(
+        {
+            "groundingChunks": [SOURCE],
+            "groundingSupports": [{"segment": SEGMENT | invalid}],
+        },
+        PARTS,
+    )
+    assert result.citations == []
+    assert result.sources[0].url == SOURCE["web"]["uri"]
+
+
+@pytest.mark.parametrize("bundled", [True, False])
+async def test_grounding_metadata_only_terminal_keeps_text_part_offsets(
+    bundled: bool,
+) -> None:
+    parts = [{"text": "Alpha "}, {"text": "Beta"}]
+    segment = (
+        {"partIndex": 1, "endIndex": 4, "text": "Beta"}
+        if bundled
+        else {"endIndex": 10, "text": "Alpha Beta"}
+    )
+    meta = {"groundingSupports": [{"segment": segment}]}
+    groups = [parts] if bundled else [[part] for part in parts]
+    stream = GoogleVertexTextStream(_events(groups, meta))
+    _ = [chunk async for chunk in stream]
+    assert stream.output.grounding is not None
+    citation = stream.output.grounding.citations[0]
+    assert stream.output.content == "Alpha Beta"
+    assert (citation.start, citation.end) == ((6, 10) if bundled else (0, 10))

--- a/tests/unit_tests/test_google_native_replay.py
+++ b/tests/unit_tests/test_google_native_replay.py
@@ -126,3 +126,11 @@ def test_google_vertex_non_text_parts_do_not_emit_text() -> None:
         assert object.__new__(GoogleVertexTextClient)._parse_content(response) == ""
         assert stream._parse_chunk_content(response) is None
     assert stream._parse_chunk_content({}) is None
+
+
+async def test_google_stream_joins_thought_parts() -> None:
+    parts = [{"text": text, "thought": True} for text in ("Thinking", " more")]
+    response = {"candidates": [{"content": {"parts": parts}}]}
+    stream = GoogleVertexTextStream(_async_iter([response]))
+    _ = [chunk async for chunk in stream]
+    assert stream.output.reasoning == "Thinking more"

--- a/tests/unit_tests/test_google_transport.py
+++ b/tests/unit_tests/test_google_transport.py
@@ -1,0 +1,135 @@
+"""Google download credential isolation and asynchronous ADC."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from celeste import Modality, Provider, create_client
+from celeste.artifacts import VideoArtifact
+from celeste.auth import AuthHeader
+from celeste.providers.google.auth import GoogleADC
+
+from ._http_helpers import _mock_http, _sse
+
+
+@pytest.mark.parametrize(
+    "model", ["veo-3.1-generate-preview", "gemini-omni-flash-preview"]
+)
+@pytest.mark.parametrize("adc", [False, True])
+async def test_google_download_auth_is_scoped_to_each_hops_origin(
+    model: str, adc: bool
+) -> None:
+    credentials = (
+        {"Authorization": "Bearer test", "x-goog-user-project": "test-project"}
+        if adc
+        else {"x-goog-api-key": "test"}
+    )
+    auth = (
+        GoogleADC(project_id="test-project")
+        if adc
+        else AuthHeader(secret="test", header="x-goog-api-key", prefix="")  # nosec B106
+    )
+    host = "storage.googleapis.com" if adc else "generativelanguage.googleapis.com"
+    seen: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path == "/start":
+            return httpx.Response(302, headers={"location": "/same-origin"})
+        if request.url.path == "/same-origin":
+            return httpx.Response(
+                302, headers={"location": "https://external.test/final"}
+            )
+        return httpx.Response(200, content=b"video")
+
+    client = create_client(
+        modality=Modality.VIDEOS, provider=Provider.GOOGLE, model=model, auth=auth
+    )
+    async with _mock_http(handle):
+        with patch.object(GoogleADC, "get_headers", return_value=credentials):
+            for url in (
+                f"http://{host}/file",
+                f"https://{host}:8443/file",
+                f"https://{host}.external.test/file",
+                "https://external.test/file",
+            ):
+                result = await client.download_content(VideoArtifact(url=url))
+                assert result.data == b"video"
+                assert all(key not in seen[-1].headers for key in credentials)
+            seen.clear()
+            url = "gs://start" if adc else f"https://{host}/start"
+            await client.download_content(VideoArtifact(url=url))
+            assert len(seen) == 3
+            for request in seen[:2]:
+                assert all(
+                    request.headers[key] == value for key, value in credentials.items()
+                )
+            assert all(key not in seen[-1].headers for key in credentials)
+
+
+async def test_adc_discovery_and_refresh_are_offloaded_and_shared() -> None:
+    google_auth = pytest.importorskip("google.auth")
+    auth = GoogleADC()
+    loop = asyncio.get_running_loop()
+    entered = asyncio.Event()
+    release = threading.Event()
+    threads: list[int] = []
+    credentials = SimpleNamespace(valid=False, token="test")  # nosec B106
+
+    def refresh(_: object) -> None:
+        threads.append(threading.get_ident())
+        loop.call_soon_threadsafe(entered.set)
+        assert release.wait(5)
+        credentials.valid = True
+
+    credentials.refresh = refresh
+
+    def discover(**_: object) -> tuple[Any, str]:
+        threads.append(threading.get_ident())
+        return credentials, "test-project"
+
+    text = create_client(
+        modality=Modality.TEXT,
+        provider=Provider.GOOGLE,
+        model="gemini-2.5-flash",
+        auth=auth,
+    )
+    embeddings = create_client(
+        modality=Modality.EMBEDDINGS, provider=Provider.GOOGLE, auth=auth
+    )
+    payload = {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert "/projects/test-project/" in request.url.path
+        if "streamGenerateContent" in request.url.path:
+            return _sse(payload)
+        if "embedContent" in request.url.path:
+            return httpx.Response(200, json={"embedding": {"values": [0.1]}})
+        return httpx.Response(200, json=payload)
+
+    async def consume() -> str:
+        stream = text.stream.generate("hello")
+        _ = [chunk async for chunk in stream]
+        return stream.output.content
+
+    async with _mock_http(handle):
+        with patch.object(google_auth, "default", discover):
+            tasks = [
+                asyncio.create_task(text.generate("hello")),
+                asyncio.create_task(consume()),
+                asyncio.create_task(embeddings.embed(text=["a", "b"])),
+            ]
+            try:
+                await asyncio.wait_for(entered.wait(), 2)
+                assert all(thread != threading.get_ident() for thread in threads)
+            finally:
+                release.set()
+            unary, streamed, vectors = await asyncio.gather(*tasks)
+    assert unary.content == streamed == "ok"
+    assert len(vectors.content) == 2
+    assert len(threads) == 2  # One discovery and one refresh across concurrent calls.

--- a/tests/unit_tests/test_google_videos_interactions.py
+++ b/tests/unit_tests/test_google_videos_interactions.py
@@ -14,6 +14,7 @@ from celeste.modalities.videos.providers.google.interactions import (
     GoogleInteractionsVideosClient,
 )
 from celeste.modalities.videos.providers.google.veo import GoogleVeoVideosClient
+from celeste.providers.google.auth import GoogleADC
 
 IMAGE = ImageArtifact(data=b"img", mime_type=ImageMimeType.PNG)
 
@@ -40,6 +41,23 @@ def test_veo_model_dispatches_to_veo_strategy() -> None:
     assert isinstance(client._strategy, GoogleVeoVideosClient)
     assert client._generate_endpoint == client._strategy._generate_endpoint
     assert client._edit_endpoint == client._strategy._edit_endpoint
+
+
+@pytest.mark.parametrize(
+    "video", [{"gcsUri": "gs://bucket/result.mp4"}, {"bytesBase64Encoded": "dmlk"}]
+)
+def test_vertex_veo_parses_video_without_mutating_response(video: dict) -> None:
+    client = GoogleVideosClient(
+        model=_model("veo-3.1-generate-preview"),
+        provider=Provider.GOOGLE,
+        auth=GoogleADC(project_id="test"),
+    )
+    response = {"response": {"videos": [{**video, "mimeType": "video/mp4"}]}}
+    artifact = client._parse_content(response)
+    assert isinstance(artifact, VideoArtifact)
+    assert artifact.url == video.get("gcsUri")
+    assert artifact.data == (b"vid" if "bytesBase64Encoded" in video else None)
+    assert response["response"]["videos"][0] == {**video, "mimeType": "video/mp4"}
 
 
 def test_omni_model_dispatches_to_interactions_strategy() -> None:

--- a/tests/unit_tests/test_gradium_transport.py
+++ b/tests/unit_tests/test_gradium_transport.py
@@ -1,0 +1,76 @@
+"""WebSocket ownership for Gradium's streaming and unary consumers."""
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from celeste import Modality, Provider, create_client
+from celeste.auth import NoAuth
+from celeste.providers.gradium.text_to_speech import config
+
+
+@pytest.mark.parametrize("mode", ["unary", "stream", "early", "error"])
+async def test_gradium_consumers_close_websocket(mode: str) -> None:
+    class WebSocket:
+        closed = False
+        send = AsyncMock()
+        recv = AsyncMock(return_value='{"type":"ready"}')
+
+        async def __aiter__(self) -> AsyncIterator[str]:
+            yield '{"type":"audio","audio":"aGVsbG8="}'
+            if mode == "error":
+                yield '{"type":"error","message":"failed"}'
+            else:
+                yield '{"type":"end_of_stream"}'
+
+    ws = WebSocket()
+
+    @asynccontextmanager
+    async def connect(
+        url: str, *, additional_headers: dict[str, str]
+    ) -> AsyncIterator[WebSocket]:
+        assert (
+            url
+            == f"{config.BASE_URL}{config.GradiumTextToSpeechEndpoint.CREATE_SPEECH}"
+        )
+        assert additional_headers == {"X-Test": "yes"}
+        try:
+            yield ws
+        finally:
+            ws.closed = True
+
+    client = create_client(
+        modality=Modality.AUDIO,
+        provider=Provider.GRADIUM,
+        model="default",
+        auth=NoAuth(),
+    )
+    with patch("celeste.providers.gradium.text_to_speech.client.ws_connect", connect):
+        if mode in {"unary", "error"}:
+            if mode == "error":
+                with pytest.raises(ValueError, match="Gradium TTS error: failed"):
+                    await client.speak("hello", extra_headers={"X-Test": "yes"})
+            else:
+                output = await client.speak("hello", extra_headers={"X-Test": "yes"})
+                assert output.content.data == b"hello"
+        else:
+            stream = client.stream.speak("hello", extra_headers={"X-Test": "yes"})
+            assert (await anext(stream)).content == b"hello"
+            if mode == "stream":
+                _ = [chunk async for chunk in stream]
+                assert stream.output.content.data == b"hello"
+            await stream.aclose()
+        assert ws.closed
+    assert [json.loads(call.args[0]) for call in ws.send.await_args_list] == [
+        {
+            "type": "setup",
+            "model_name": "default",
+            "voice_id": config.DEFAULT_VOICE_ID,
+            "output_format": "wav",
+        },
+        {"type": "text", "text": "hello"},
+        {"type": "end_of_stream"},
+    ]

--- a/tests/unit_tests/test_http.py
+++ b/tests/unit_tests/test_http.py
@@ -38,19 +38,19 @@ def isolated_registry() -> Generator[None]:
 
 async def test_client_is_lazy_reused_and_closed(transport: AsyncMock) -> None:
     client = HTTPClient(max_connections=7, max_keepalive_connections=3)
-    assert client._client is None
+    assert not client._clients
 
     with patch("celeste.http.httpx.AsyncClient", return_value=transport) as constructor:
         await client.post("https://example.com/one", {}, {})
         await client.post("https://example.com/two", {}, {})
-        created = client._client
+        created = await client._get_client()
         await client.aclose()
 
     assert constructor.call_count == 1
     limits = constructor.call_args.kwargs["limits"]
     assert (limits.max_connections, limits.max_keepalive_connections) == (7, 3)
     assert created is transport
-    assert client._client is None
+    assert not client._clients
     transport.aclose.assert_awaited_once()
 
 
@@ -165,22 +165,30 @@ async def test_close_all_continues_after_a_client_failure() -> None:
     failing_transport = AsyncMock(spec=httpx.AsyncClient)
     healthy_transport = AsyncMock(spec=httpx.AsyncClient)
     failing_transport.aclose.side_effect = RuntimeError("close failed")
-    failing._client = failing_transport
-    healthy._client = healthy_transport
+    with patch(
+        "celeste.http.httpx.AsyncClient",
+        side_effect=[failing_transport, healthy_transport],
+    ):
+        await failing._get_client()
+        await healthy._get_client()
 
     await close_all_http_clients()
 
     failing_transport.aclose.assert_awaited_once()
     healthy_transport.aclose.assert_awaited_once()
-    assert not http_module._http_clients
+    assert not failing._clients
+    assert not healthy._clients
 
 
-def test_clear_registry_does_not_close_clients() -> None:
+async def test_clear_registry_does_not_close_clients() -> None:
     client = get_http_client(Provider.OPENAI, Modality.TEXT)
-    client._client = AsyncMock(spec=httpx.AsyncClient)
+    transport = AsyncMock(spec=httpx.AsyncClient)
+    with patch("celeste.http.httpx.AsyncClient", return_value=transport):
+        await client._get_client()
     clear_http_clients()
-    client._client.aclose.assert_not_called()
+    transport.aclose.assert_not_called()
     assert not http_module._http_clients
+    await client.aclose()
 
 
 async def test_context_manager_closes_on_exception(transport: AsyncMock) -> None:
@@ -193,7 +201,7 @@ async def test_context_manager_closes_on_exception(transport: AsyncMock) -> None
             assert entered is client
             await client.post("https://example.com", {}, {})
             raise RuntimeError("boom")
-    assert client._client is None
+    assert not client._clients
     transport.aclose.assert_awaited_once()
 
 

--- a/tests/unit_tests/test_stream_context.py
+++ b/tests/unit_tests/test_stream_context.py
@@ -1,0 +1,42 @@
+"""Closing a retained stream must release the consumer's request context."""
+
+import asyncio
+import gc
+import weakref
+from collections.abc import AsyncIterator
+from contextvars import ContextVar
+
+import pytest
+
+from celeste.modalities.text.protocols.openresponses.client import (
+    OpenResponsesTextStream,
+)
+
+
+class RequestState:
+    pass
+
+
+@pytest.mark.parametrize("eager", [False, True])
+async def test_closed_stream_releases_caller_context(eager: bool) -> None:
+    async def events() -> AsyncIterator[dict[str, str]]:
+        yield {"type": "response.output_text.delta", "delta": "hello"}
+
+    context: ContextVar[RequestState] = ContextVar("request-state")
+    state = RequestState()
+    reference = weakref.ref(state)
+    token = context.set(state)
+    loop = asyncio.get_running_loop()
+    previous = loop.get_task_factory()
+    loop.set_task_factory(asyncio.eager_task_factory if eager else None)
+    try:
+        stream = OpenResponsesTextStream(events())
+        await anext(stream)
+        await stream.aclose()
+    finally:
+        context.reset(token)
+        loop.set_task_factory(previous)
+    del state, token
+    await asyncio.sleep(0)
+    gc.collect()
+    assert reference() is None

--- a/tests/unit_tests/test_stream_factory.py
+++ b/tests/unit_tests/test_stream_factory.py
@@ -1,0 +1,90 @@
+"""Lazy transport factories and shared stream ownership."""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from celeste.protocols.openresponses.client import OpenResponsesClient
+from celeste.streaming import enrich_stream_errors
+
+from ._http_helpers import _text_client
+
+
+@pytest.mark.parametrize("started", [False, True])
+async def test_stream_factory_runs_only_on_first_pull(started: bool) -> None:
+    closed = []
+
+    async def events() -> AsyncGenerator[dict[str, Any], None]:
+        try:
+            yield {"type": "response.output_text.delta", "delta": "hello"}
+        finally:
+            closed.append(True)
+
+    factory = AsyncMock(return_value=events())
+    with patch.object(OpenResponsesClient, "_make_stream_request", factory):
+        stream = _text_client().stream.generate("hello")
+        factory.assert_not_called()
+        if started:
+            assert (await anext(stream)).content == "hello"
+        await stream.aclose()
+        assert factory.await_count == int(started)
+        assert closed == ([True] if started else [])
+
+
+async def test_close_cancels_a_pending_stream_factory() -> None:
+    started, cancelled = asyncio.Event(), asyncio.Event()
+
+    async def factory(
+        *args: object, **kwargs: object
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+        raise AssertionError("factory should be cancelled")
+
+    with patch.object(OpenResponsesClient, "_make_stream_request", factory):
+        stream = _text_client().stream.generate("hello")
+        pending = asyncio.create_task(anext(stream))
+        await asyncio.wait_for(started.wait(), 2)
+        await asyncio.wait_for(stream.aclose(), 2)
+        assert cancelled.is_set()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+
+@pytest.mark.parametrize("failure", ["factory", "iteration", None])
+async def test_stream_factory_enriches_errors_and_closes(failure: str | None) -> None:
+    response = httpx.Response(
+        401, request=httpx.Request("POST", "https://example.test/v1/chat")
+    )
+    closed = []
+
+    async def events() -> AsyncGenerator[dict[str, Any], None]:
+        try:
+            if failure == "iteration":
+                response.raise_for_status()
+            yield {"delta": "hello"}
+        finally:
+            closed.append(True)
+
+    async def factory() -> AsyncGenerator[dict[str, Any], None]:
+        if failure == "factory":
+            response.raise_for_status()
+        return events()
+
+    handler = Mock(side_effect=RuntimeError("enriched provider error"))
+    stream = enrich_stream_errors(factory, handler)
+    if failure:
+        with pytest.raises(RuntimeError, match="enriched provider error"):
+            _ = [event async for event in stream]
+        handler.assert_called_once_with(response)
+    else:
+        assert [event async for event in stream] == [{"delta": "hello"}]
+        handler.assert_not_called()
+    assert closed == ([] if failure == "factory" else [True])

--- a/tests/unit_tests/test_stream_transport.py
+++ b/tests/unit_tests/test_stream_transport.py
@@ -1,0 +1,139 @@
+"""Stream termination and HTTP body cleanup."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from celeste.exceptions import StreamEventError, StreamNotExhaustedError
+
+from ._http_helpers import _mock_http, _sse, _text_client
+
+
+@pytest.mark.parametrize(
+    ("status", "typed"),
+    [("failed", False), ("incomplete", False), ("incomplete", True)],
+)
+async def test_responses_terminal_status_is_not_silently_dropped(
+    status: str, typed: bool
+) -> None:
+    class Args(BaseModel):
+        value: str
+
+    response: dict[str, Any] = {
+        "id": "resp_test",
+        "status": status,
+        "usage": {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17},
+        "error": {"code": "server_error", "message": "provider failure"}
+        if status == "failed"
+        else None,
+        "incomplete_details": {"reason": "max_output_tokens"}
+        if status == "incomplete"
+        else None,
+        "output": [
+            {
+                "type": "reasoning",
+                "id": "reasoning_test",
+                "encrypted_content": "signature",
+                "summary": [],
+            },
+            *[
+                {
+                    "type": "function_call",
+                    "call_id": call_status or "omitted",
+                    "name": "call",
+                    "arguments": '{"value":"ok"}'
+                    if call_status != "incomplete"
+                    else '{"value":',
+                    **({"status": call_status} if call_status else {}),
+                }
+                for call_status in ("completed", None, "incomplete", "in_progress")
+            ],
+        ],
+    }
+    terminal = {"type": f"response.{status}", "response": response}
+    async with _mock_http(
+        lambda _: _sse(
+            {"type": "response.output_text.delta", "delta": "Partial"},
+            terminal,
+        )
+    ):
+        stream = _text_client().stream.generate(
+            "hello",
+            tools=[
+                {
+                    "name": "call",
+                    "parameters": Args if typed else Args.model_json_schema(),
+                }
+            ],
+        )
+        assert (await anext(stream)).content == "Partial"
+        if status == "failed":
+            with pytest.raises(StreamEventError, match="provider failure") as error:
+                _ = [chunk async for chunk in stream]
+            assert error.value.error_type == "server_error"
+            assert error.value.event_data == terminal
+            with pytest.raises(StreamNotExhaustedError):
+                _ = stream.output
+        else:
+            _ = [chunk async for chunk in stream]
+            assert stream.output.content == "Partial"
+            assert stream.output.usage.total_tokens == 17
+            assert stream.output.finish_reason is not None
+            assert stream.output.finish_reason.reason == "max_output_tokens"
+            assert stream.output.metadata["raw_response"] == response
+            assert stream.output.signature == response["output"][:1]
+            assert [(call.id, call.arguments) for call in stream.output.tool_calls] == [
+                ("completed", {"value": "ok"}),
+                ("omitted", {"value": "ok"}),
+            ]
+
+
+@pytest.mark.parametrize("mode", ["early", "pending_first", "pending_next", "cancel"])
+async def test_stream_close_reaches_http_body_before_returning(mode: str) -> None:
+    blocked = asyncio.Event()
+
+    class Body(httpx.AsyncByteStream):
+        closed = False
+
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            if mode != "pending_first":
+                yield b'data: {"type":"response.output_text.delta","delta":"first"}\n\n'
+            blocked.set()
+            await asyncio.Event().wait()
+            yield b'data: {"type":"response.output_text.delta","delta":"after-close"}\n\n'
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    body = Body()
+    async with _mock_http(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=body,
+        )
+    ):
+        stream = _text_client().stream.generate("hello")
+        if mode != "pending_first":
+            assert (await anext(stream)).content == "first"
+        if mode == "early":
+            await stream.aclose()
+        else:
+            pending = asyncio.create_task(anext(stream))
+            await asyncio.wait_for(blocked.wait(), 2)
+            if mode == "cancel":
+                pending.cancel()
+            else:
+                await asyncio.wait_for(stream.aclose(), 2)
+            with pytest.raises(asyncio.CancelledError):
+                await pending
+        assert body.closed
+        await stream.aclose()
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+        with pytest.raises(StreamNotExhaustedError):
+            _ = stream.output

--- a/tests/unit_tests/test_streaming.py
+++ b/tests/unit_tests/test_streaming.py
@@ -2,15 +2,13 @@
 
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
-from unittest.mock import Mock
 
-import httpx
 import pytest
 
 from celeste.exceptions import StreamEventError, StreamNotExhaustedError
 from celeste.io import Chunk, Output
 from celeste.parameters import Parameters
-from celeste.streaming import Stream, enrich_stream_errors
+from celeste.streaming import Stream
 
 
 class TextOutput(Output[str]):
@@ -224,38 +222,3 @@ async def test_midstream_error_preserves_already_yielded_chunks() -> None:
             chunks.append(chunk)
 
     assert [chunk.content for chunk in chunks] == ["partial"]
-
-
-async def test_enrich_stream_errors_delegates_http_response() -> None:
-    response = httpx.Response(
-        401,
-        request=httpx.Request("POST", "https://example.test/v1/chat"),
-    )
-
-    async def failing_events() -> AsyncIterator[dict[str, Any]]:
-        raise httpx.HTTPStatusError(
-            "unauthorized",
-            request=response.request,
-            response=response,
-        )
-        yield {}
-
-    handler = Mock(side_effect=RuntimeError("enriched provider error"))
-
-    with pytest.raises(RuntimeError, match="enriched provider error"):
-        _ = [event async for event in enrich_stream_errors(failing_events(), handler)]
-    handler.assert_called_once_with(response)
-
-
-async def test_enrich_stream_errors_passes_successful_events_through() -> None:
-    source_events = [{"delta": "Hello"}, {"delta": " world"}]
-
-    result = [
-        event
-        async for event in enrich_stream_errors(
-            events(*source_events),
-            Mock(),
-        )
-    ]
-
-    assert result == source_events

--- a/tests/unit_tests/test_sync_http.py
+++ b/tests/unit_tests/test_sync_http.py
@@ -1,0 +1,101 @@
+"""Connection pool ownership across synchronous calls."""
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from asgiref.sync import async_to_sync
+
+from celeste.http import HTTPClient, close_all_http_clients
+
+from ._http_helpers import _sse, _text_client
+
+
+@pytest.mark.parametrize("mode", ["unary", "stream", "asyncio"])
+def test_owned_loops_close_pools_on_success_and_failure(mode: str) -> None:
+    created: list[httpx.AsyncClient] = []
+    constructor = httpx.AsyncClient
+    calls = 0
+
+    def handle(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            return httpx.Response(400, json={"error": {"message": "bad request"}})
+        if mode == "stream":
+            return _sse({"type": "response.output_text.delta", "delta": "ok"})
+        return httpx.Response(
+            200,
+            json={
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+            },
+        )
+
+    def make_client(**kwargs: Any) -> httpx.AsyncClient:  # noqa: ANN401
+        http = constructor(transport=httpx.MockTransport(handle), **kwargs)
+        created.append(http)
+        return http
+
+    client = _text_client()
+
+    def generate() -> str:
+        if mode == "unary":
+            return client.sync.generate("hello").content
+        if mode == "asyncio":
+            return asyncio.run(client.generate("hello")).content
+        stream = client.stream.generate("hello")
+        _ = list(stream)
+        return stream.output.content
+
+    with patch("celeste.http.httpx.AsyncClient", make_client):
+        assert generate() == generate() == "ok"
+        with pytest.raises(httpx.HTTPStatusError, match="bad request"):
+            generate()
+    assert len(created) == 3
+    assert all(http.is_closed for http in created)
+    assert not client.http_client._clients
+
+
+@pytest.mark.parametrize("mode", ["sync", "asyncio"])
+async def test_owned_loop_cleanup_preserves_another_event_loops_pool(mode: str) -> None:
+    pool = _text_client().http_client
+    original = await pool._get_client()
+    try:
+        other = await asyncio.to_thread(
+            lambda: (
+                async_to_sync(pool._get_client)()
+                if mode == "sync"
+                else asyncio.run(pool._get_client())
+            )
+        )
+        assert other.is_closed
+        assert await pool._get_client() is original
+        assert not original.is_closed
+        assert len(pool._clients) == 1
+    finally:
+        await close_all_http_clients()
+
+
+def test_runner_keeps_pool_between_calls_and_closes_after_cancellation() -> None:
+    pool = HTTPClient()
+
+    async def cancel() -> None:
+        await pool._get_client()
+        raise asyncio.CancelledError
+
+    with asyncio.Runner() as runner:
+        http = runner.run(pool._get_client())
+        assert runner.run(pool._get_client()) is http
+        with pytest.raises(asyncio.CancelledError):
+            runner.run(cancel())
+        assert not http.is_closed
+    assert http.is_closed
+    assert not pool._clients


### PR DESCRIPTION
Short-lived event loops and interrupted streams could leave HTTP resources open. Responses terminal events could lose failure/incomplete status, while audio metadata retained duplicate binary payloads. This change closes pools on their owning loop and closes upstream stream iterators before returning from cancellation or early close.

The provider fixes keep incomplete response metadata while excluding unfinished function calls, offload ADC discovery/refresh, restrict video download credentials to the matching Google origin on each redirect, map Google citation offsets within their referenced Parts, and parse Vertex Veo's documented `gcsUri`. Mixed embedding batches now fail before an input can be discarded. Provider/protocol templates follow the same async auth and stream lifecycle contracts.

Streaming adapters now implement `_make_stream_request` as an async factory returning an unstarted transport generator. Celeste awaits the factory on the first pull and owns the iterator with `aclosing`; provider relay generators are removed. Both dispatchers and templates follow the same contract. Gradium's unary collector also closes the generator it consumes.

Stream-close tasks release caller context after cleanup, including eager task factories and cancelled close waiters.

Transport regressions are split into focused files; duplicated tests and redundant sync cleanup wrappers are removed.

Validation:

- `make ci` passes: 647 unit tests, 73.25% coverage, Ruff lint/format, source and test mypy, and Bandit.
- All 24 Python templates compile; rendered client checks cover async auth, first pull, early close, custom base URLs, and sync pool cleanup. Focused regression tests also cover factory setup errors, closure before the first pull, pending-factory cancellation, and Gradium WebSocket cleanup.
- Real local Unix-socket check: three public `asyncio.run` calls close three keep-alive connections and retain zero pools.
- Provider tests use offline fixtures, without live provider calls. Google transport cases cover `gemini-2.5-flash`, `veo-3.1-generate-preview`, and `gemini-omni-flash-preview`; Responses and audio use synthetic parser/transport fixtures.

Contracts checked against official sources: [Python loop shutdown](https://docs.python.org/3.13/library/asyncio-eventloop.html#asyncio.loop.shutdown_asyncgens), [Responses terminal events](https://developers.openai.com/api/reference/resources/responses/streaming-events), [function-call status](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_function_tool_call.py), [Google grounding segments](https://ai.google.dev/api/generate-content#Segment), [Vertex Veo response](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/generate-videos-from-text?hl=en), [ElevenLabs audio streaming](https://elevenlabs.io/docs/api-reference/text-to-speech/stream), and [Gradium WebSocket events](https://docs.gradium.ai/guides/text-to-speech).

Google streaming continuation across event boundaries follows the earlier official SDK aggregation behavior; current public recordings do not establish more. The parser preserves separate Parts within events and omits mismatched citation spans while retaining sources.

Manual event-loop owners must close clients or call `shutdown_asyncgens()` before closing their loop, as documented on `HTTPClient`.
