### PR TITLE
fix(google): drop reference images from veo-3.1-lite-generate-preview

### DIFF
--- a/src/celeste/modalities/videos/providers/google/models.py
+++ b/src/celeste/modalities/videos/providers/google/models.py
@@ -67,10 +67,6 @@ GOOGLE_VEO_MODELS: list[Model] = [
             VideoParameter.ASPECT_RATIO: Choice(options=["16:9", "9:16"]),
             VideoParameter.RESOLUTION: Choice(options=["720p", "1080p"]),
             VideoParameter.DURATION: Choice(options=[4, 6, 8]),
-            VideoParameter.REFERENCE_IMAGES: ImagesConstraint(
-                supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
-                max_count=3,
-            ),
             VideoParameter.FIRST_FRAME: ImageConstraint(
                 supported_mime_types=GOOGLE_SUPPORTED_MIME_TYPES,
             ),


### PR DESCRIPTION
## What

Drops the `reference_images` constraint from `veo-3.1-lite-generate-preview`. `veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview` keep theirs.

## Why

The Gemini API Veo model spec marks `referenceImages` as `n/a` in the Veo 3.1 Lite column, and Google Cloud's Veo 3.1 Lite model reference lists "Use reference images: Not supported". Date unknown; the model launched March 31, 2026.

## Evidence

- `referenceImages` is `n/a` for Veo 3.1 Lite (Instances table): [Veo video generation](https://ai.google.dev/gemini-api/docs/veo)
- `veo-3.1-lite-generate-001` capabilities: "Use reference images — Not supported": [Veo Google Cloud model reference](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate)
- `veo-3.1-lite-generate-preview` launched March 31, 2026: [Gemini API release notes](https://ai.google.dev/gemini-api/docs/changelog)

## Files

- `src/celeste/modalities/videos/providers/google/models.py`

## Validation

`make ci`: **pass**
Live call: **none**

## Depends on

none


---
_Generated by [Claude Code](https://claude.ai/code/session_01DXymJSYYb4PCheudwciPWe)_