### PR TITLE
fix(bfl): complete image family parameter contracts

### DIFF
--- a/src/celeste/constraints.py
+++ b/src/celeste/constraints.py
@@ -132,6 +132,8 @@ class Dimensions(Constraint):
     max_aspect_ratio: float
     presets: dict[str, str] | None = None
     multiple_of: int | None = Field(default=None, gt=0)
+    min_dimension: int | None = Field(default=None, gt=0)
+    max_dimension: int | None = Field(default=None, gt=0)
 
     def __call__(self, value: str) -> str:
         """Validate dimension string against pixel and aspect ratio bounds."""
@@ -169,6 +171,13 @@ class Dimensions(Constraint):
 
         if self.multiple_of and (width % self.multiple_of or height % self.multiple_of):
             msg = f"Width and height must be multiples of {self.multiple_of}"
+            raise ConstraintViolationError(msg)
+
+        if self.min_dimension is not None and min(width, height) < self.min_dimension:
+            msg = f"Width and height must be at least {self.min_dimension}"
+            raise ConstraintViolationError(msg)
+        if self.max_dimension is not None and max(width, height) > self.max_dimension:
+            msg = f"Width and height must be at most {self.max_dimension}"
             raise ConstraintViolationError(msg)
 
         # Validate total pixels

--- a/src/celeste/modalities/images/providers/bfl/models.py
+++ b/src/celeste/modalities/images/providers/bfl/models.py
@@ -1,6 +1,14 @@
 """BFL (Black Forest Labs) models for images modality."""
 
-from celeste.constraints import Choice, Dimensions, ImagesConstraint, Int, Range
+from celeste.constraints import (
+    Bool,
+    Choice,
+    Dimensions,
+    ImagesConstraint,
+    Int,
+    Range,
+    Str,
+)
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
@@ -16,21 +24,22 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,  # 4,096
                 max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
                     "Portrait 9:21": "832x1920",
                 },
             ),
-            # Note: flux-2-max always upsamples prompts (no prompt_upsampling parameter)
-            # Includes grounding search for real-time information integration
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=8),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
@@ -46,19 +55,22 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,  # 4,096
                 max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
                     "Portrait 9:21": "832x1920",
                 },
             ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=8),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
@@ -74,19 +86,22 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,
                 max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
                     "Portrait 9:21": "832x1920",
                 },
             ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=8),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
@@ -102,13 +117,15 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,
                 max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
@@ -130,13 +147,15 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,
                 max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
@@ -158,13 +177,15 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,
                 max_pixels=2048 * 2048,
-                min_aspect_ratio=9 / 21,
-                max_aspect_ratio=21 / 9,
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
@@ -186,19 +207,22 @@ MODELS: list[Model] = [
             ImageParameter.ASPECT_RATIO: Dimensions(
                 min_pixels=64 * 64,  # 4,096
                 max_pixels=2048 * 2048,  # 4,194,304 (4MP)
-                min_aspect_ratio=9 / 21,  # ~0.429
-                max_aspect_ratio=21 / 9,  # ~2.333
+                min_aspect_ratio=1 / 1024,
+                max_aspect_ratio=1024,
+                min_dimension=64,
+                multiple_of=16,
                 presets={
                     "Square 1K": "1024x1024",
                     "Square 2K": "2048x2048",
-                    "HD 16:9": "1920x1080",
-                    "Portrait HD": "1080x1920",
+                    "HD 16:9": "1920x1088",
+                    "Portrait HD": "1088x1920",
                     "4:3": "1280x960",
                     "3:4": "960x1280",
                     "Ultra-wide 21:9": "1920x832",
                     "Portrait 9:21": "832x1920",
                 },
             ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
             ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=8),
             ImageParameter.SEED: Int(),
             ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=5),
@@ -212,30 +236,97 @@ MODELS: list[Model] = [
         provider=Provider.BFL,
         display_name="FLUX.1 Kontext [max]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Str(
+                description="Width:height ratio between 9:21 and 21:9"
+            ),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(
+                max_count=4,
+                description="Experimental multi-reference inputs, including the primary edit image",
+            ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
+            ImageParameter.SEED: Int(),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+        },
     ),
     Model(
         id="flux-kontext-pro",
         provider=Provider.BFL,
         display_name="FLUX.1 Kontext [pro]",
         operations={Modality.IMAGES: {Operation.GENERATE, Operation.EDIT}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Str(
+                description="Width:height ratio between 9:21 and 21:9"
+            ),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(
+                max_count=4,
+                description="Experimental multi-reference inputs, including the primary edit image",
+            ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
+            ImageParameter.SEED: Int(),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+        },
     ),
     Model(
         id="flux-pro-1.1-ultra",
         provider=Provider.BFL,
         display_name="FLUX1.1 [pro] Ultra",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Str(
+                description="Width:height ratio between 9:21 and 21:9"
+            ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
+            ImageParameter.SEED: Int(),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+        },
     ),
     Model(
         id="flux-pro-1.1",
         provider=Provider.BFL,
         display_name="FLUX1.1 [pro]",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Dimensions(
+                min_pixels=256 * 256,
+                max_pixels=1440 * 1440,
+                min_aspect_ratio=256 / 1440,
+                max_aspect_ratio=1440 / 256,
+                min_dimension=256,
+                max_dimension=1440,
+                multiple_of=32,
+            ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
+            ImageParameter.SEED: Int(),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+        },
     ),
     Model(
         id="flux-dev",
         provider=Provider.BFL,
         display_name="FLUX.1 [dev]",
         operations={Modality.IMAGES: {Operation.GENERATE}},
+        parameter_constraints={
+            ImageParameter.ASPECT_RATIO: Dimensions(
+                min_pixels=256 * 256,
+                max_pixels=1440 * 1440,
+                min_aspect_ratio=256 / 1440,
+                max_aspect_ratio=1440 / 256,
+                min_dimension=256,
+                max_dimension=1440,
+                multiple_of=32,
+            ),
+            ImageParameter.PROMPT_UPSAMPLING: Bool(),
+            ImageParameter.SEED: Int(),
+            ImageParameter.SAFETY_TOLERANCE: Range(min=0, max=6),
+            ImageParameter.OUTPUT_FORMAT: Choice(options=["jpeg", "png", "webp"]),
+            ImageParameter.STEPS: Range(min=1, max=50),
+            ImageParameter.GUIDANCE: Range(min=1.5, max=5.0),
+        },
     ),
 ]
 

--- a/src/celeste/modalities/images/providers/bfl/parameters.py
+++ b/src/celeste/modalities/images/providers/bfl/parameters.py
@@ -7,10 +7,10 @@ from celeste.exceptions import ConstraintViolationError
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.bfl.images.parameters import (
-    GuidanceMapper as _GuidanceMapper,
+    AspectRatioMapper as _AspectRatioMapper,
 )
 from celeste.providers.bfl.images.parameters import (
-    HeightMapper as _HeightMapper,
+    GuidanceMapper as _GuidanceMapper,
 )
 from celeste.providers.bfl.images.parameters import (
     OutputFormatMapper as _OutputFormatMapper,
@@ -27,47 +27,14 @@ from celeste.providers.bfl.images.parameters import (
 from celeste.providers.bfl.images.parameters import (
     StepsMapper as _StepsMapper,
 )
-from celeste.providers.bfl.images.parameters import (
-    WidthMapper as _WidthMapper,
-)
 from celeste.providers.bfl.images.utils import add_reference_images
 from celeste.types import ImageContent
 
 from ...parameters import ImageParameter
 
 
-class AspectRatioMapper(ParameterMapper[ImageContent]):
-    """Map aspect_ratio to BFL width/height parameters.
-
-    Converts 'WxH' string to width/height, rounded to nearest multiple of 16.
-    Delegates to provider's WidthMapper and HeightMapper for the actual mapping.
-    """
-
+class AspectRatioMapper(_AspectRatioMapper):
     name = ImageParameter.ASPECT_RATIO
-
-    def map(
-        self,
-        request: dict[str, Any],
-        value: object,
-        model: Model,
-    ) -> dict[str, Any]:
-        """Transform aspect_ratio into provider request."""
-        validated_value = self._validate_value(value, model)
-        if validated_value is None:
-            return request
-
-        parts = validated_value.split("x")
-        width = int(parts[0])
-        height = int(parts[1])
-
-        # Round to nearest multiple of 16 as required by BFL API
-        width = ((width + 8) // 16) * 16
-        height = ((height + 8) // 16) * 16
-
-        # Delegate to provider mappers
-        request = _WidthMapper().map(request, width, model)
-        request = _HeightMapper().map(request, height, model)
-        return request
 
 
 class PromptUpsamplingMapper(_PromptUpsamplingMapper):

--- a/src/celeste/modalities/images/providers/bfl/parameters.py
+++ b/src/celeste/modalities/images/providers/bfl/parameters.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from celeste.constraints import ImagesConstraint
+from celeste.exceptions import ConstraintViolationError
 from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.bfl.images.parameters import (
@@ -105,6 +107,19 @@ class ReferenceImagesMapper(ParameterMapper[ImageContent]):
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
+
+        constraint = model.parameter_constraints.get(self.name)
+        if (
+            "input_image" in request
+            and isinstance(constraint, ImagesConstraint)
+            and constraint.max_count is not None
+            and len(validated_value) + 1 > constraint.max_count
+        ):
+            msg = (
+                f"{model.id} supports at most {constraint.max_count} input images, "
+                "including the primary edit image"
+            )
+            raise ConstraintViolationError(msg)
 
         return add_reference_images(request, validated_value)
 

--- a/src/celeste/providers/bfl/images/parameters.py
+++ b/src/celeste/providers/bfl/images/parameters.py
@@ -42,10 +42,38 @@ class HeightMapper(ParameterMapper[ImageContent]):
         return request
 
 
-class PromptUpsamplingMapper(FieldMapper[ImageContent]):
-    """Map prompt_upsampling to BFL prompt_upsampling field."""
+class AspectRatioMapper(ParameterMapper[ImageContent]):
+    """Map native ratios or validated pixel dimensions for the BFL family."""
 
-    field = "prompt_upsampling"
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        validated_value = self._validate_value(value, model)
+        if validated_value is None:
+            return request
+        if model.id in ("flux-kontext-pro", "flux-kontext-max", "flux-pro-1.1-ultra"):
+            request["aspect_ratio"] = validated_value
+        else:
+            width, height = validated_value.split("x")
+            request = WidthMapper().map(request, width, model)
+            request = HeightMapper().map(request, height, model)
+        return request
+
+
+class PromptUpsamplingMapper(ParameterMapper[ImageContent]):
+    """Map the prompt control supported by each BFL family."""
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        validated_value = self._validate_value(value, model)
+        if validated_value is None or model.id.startswith("flux-2-klein-"):
+            return request
+        if model.id in ("flux-2-max", "flux-2-pro", "flux-2-pro-preview"):
+            request["disable_pup"] = not validated_value
+        else:
+            request["prompt_upsampling"] = validated_value
+        return request
 
 
 class SeedMapper(FieldMapper[ImageContent]):
@@ -79,6 +107,7 @@ class GuidanceMapper(FieldMapper[ImageContent]):
 
 
 __all__ = [
+    "AspectRatioMapper",
     "GuidanceMapper",
     "HeightMapper",
     "OutputFormatMapper",

--- a/tests/unit_tests/test_constraints.py
+++ b/tests/unit_tests/test_constraints.py
@@ -157,6 +157,22 @@ def test_dimensions_parse_presets_and_bounds() -> None:
     assert constraint("10X20") == "10x20"
 
 
+def test_dimensions_enforce_axis_bounds() -> None:
+    constraint = Dimensions(
+        min_pixels=1,
+        max_pixels=10_000,
+        min_aspect_ratio=0.01,
+        max_aspect_ratio=100,
+        min_dimension=10,
+        max_dimension=30,
+    )
+    assert constraint("10x30") == "10x30"
+    assert constraint("30x10") == "30x10"
+    for value in ("9x20", "20x9", "31x20", "20x31"):
+        with pytest.raises(ConstraintViolationError):
+            constraint(value)
+
+
 def test_dimensions_enforce_multiples() -> None:
     constraint = Dimensions(
         min_pixels=100,

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -4,7 +4,6 @@ import pytest
 from pydantic import BaseModel
 
 from celeste.artifacts import ImageArtifact
-from celeste.exceptions import ConstraintViolationError
 from celeste.mime_types import AudioMimeType, ImageMimeType
 from celeste.modalities.audio.parameters import AudioParameter
 from celeste.modalities.audio.providers.elevenlabs import parameters as elevenlabs_audio
@@ -12,11 +11,8 @@ from celeste.modalities.audio.providers.google import parameters as google_audio
 from celeste.modalities.audio.providers.groq import parameters as groq_audio
 from celeste.modalities.audio.providers.mistral import parameters as mistral_audio
 from celeste.modalities.audio.providers.openai import parameters as openai_audio
-from celeste.modalities.images.io import ImageInput
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.bfl import parameters as bfl
-from celeste.modalities.images.providers.bfl.client import BFLImagesClient
-from celeste.modalities.images.providers.bfl.models import MODELS as BFL_MODELS
 from celeste.modalities.images.providers.google import parameters as google_images
 from celeste.modalities.images.providers.topazlabs import parameters as topazlabs
 from celeste.modalities.segmentation.parameters import SegmentationParameter
@@ -477,36 +473,6 @@ def test_bfl_reference_images_follow_primary_image_numbering() -> None:
         [IMAGE],
         {"input_image": "primary"},
     ) == {"input_image": "primary", "input_image_2": IMAGE.url}
-
-
-@pytest.mark.parametrize(
-    "model",
-    [model for model in BFL_MODELS if model.id.startswith("flux-2-")],
-    ids=lambda model: model.id,
-)
-@pytest.mark.parametrize("editing", [False, True], ids=["generate", "edit"])
-def test_bfl_reference_images_respect_total_slots(model: Model, editing: bool) -> None:
-    limit = 4 if "klein" in model.id else 8
-    client = BFLImagesClient.model_construct(model=model)
-    request = client._init_request(
-        ImageInput(prompt="Combine images", image=IMAGE if editing else None)
-    )
-    references = [
-        ImageArtifact(url=f"https://example.com/reference-{i}.png")
-        for i in range(limit - int(editing))
-    ]
-    mapper = _mapper(BFL, IP.REFERENCE_IMAGES)
-    mapped = mapper.map(request.copy(), references, model)
-    expected = ([IMAGE.url] if editing else []) + [image.url for image in references]
-    assert {k: v for k, v in mapped.items() if k.startswith("input_image")} == {
-        "input_image" if i == 1 else f"input_image_{i}": url
-        for i, url in enumerate(expected, 1)
-    }
-    with pytest.raises(ConstraintViolationError):
-        mapper.map(request, [*references, IMAGE], model)
-    assert request == client._init_request(
-        ImageInput(prompt="Combine images", image=IMAGE if editing else None)
-    )
 
 
 def test_chat_completions_reasoning_fields() -> None:

--- a/tests/unit_tests/test_parameter_wire_contracts.py
+++ b/tests/unit_tests/test_parameter_wire_contracts.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from celeste.artifacts import ImageArtifact
+from celeste.exceptions import ConstraintViolationError
 from celeste.mime_types import AudioMimeType, ImageMimeType
 from celeste.modalities.audio.parameters import AudioParameter
 from celeste.modalities.audio.providers.elevenlabs import parameters as elevenlabs_audio
@@ -11,8 +12,11 @@ from celeste.modalities.audio.providers.google import parameters as google_audio
 from celeste.modalities.audio.providers.groq import parameters as groq_audio
 from celeste.modalities.audio.providers.mistral import parameters as mistral_audio
 from celeste.modalities.audio.providers.openai import parameters as openai_audio
+from celeste.modalities.images.io import ImageInput
 from celeste.modalities.images.parameters import ImageParameter
 from celeste.modalities.images.providers.bfl import parameters as bfl
+from celeste.modalities.images.providers.bfl.client import BFLImagesClient
+from celeste.modalities.images.providers.bfl.models import MODELS as BFL_MODELS
 from celeste.modalities.images.providers.google import parameters as google_images
 from celeste.modalities.images.providers.topazlabs import parameters as topazlabs
 from celeste.modalities.segmentation.parameters import SegmentationParameter
@@ -473,6 +477,36 @@ def test_bfl_reference_images_follow_primary_image_numbering() -> None:
         [IMAGE],
         {"input_image": "primary"},
     ) == {"input_image": "primary", "input_image_2": IMAGE.url}
+
+
+@pytest.mark.parametrize(
+    "model",
+    [model for model in BFL_MODELS if model.id.startswith("flux-2-")],
+    ids=lambda model: model.id,
+)
+@pytest.mark.parametrize("editing", [False, True], ids=["generate", "edit"])
+def test_bfl_reference_images_respect_total_slots(model: Model, editing: bool) -> None:
+    limit = 4 if "klein" in model.id else 8
+    client = BFLImagesClient.model_construct(model=model)
+    request = client._init_request(
+        ImageInput(prompt="Combine images", image=IMAGE if editing else None)
+    )
+    references = [
+        ImageArtifact(url=f"https://example.com/reference-{i}.png")
+        for i in range(limit - int(editing))
+    ]
+    mapper = _mapper(BFL, IP.REFERENCE_IMAGES)
+    mapped = mapper.map(request.copy(), references, model)
+    expected = ([IMAGE.url] if editing else []) + [image.url for image in references]
+    assert {k: v for k, v in mapped.items() if k.startswith("input_image")} == {
+        "input_image" if i == 1 else f"input_image_{i}": url
+        for i, url in enumerate(expected, 1)
+    }
+    with pytest.raises(ConstraintViolationError):
+        mapper.map(request, [*references, IMAGE], model)
+    assert request == client._init_request(
+        ImageInput(prompt="Combine images", image=IMAGE if editing else None)
+    )
 
 
 def test_chat_completions_reasoning_fields() -> None:


### PR DESCRIPTION
Celeste sends pixel dimensions to native-ratio endpoints, ignores Max/Pro prompt controls, and accepts too many additional edit references. Map each existing BFL image family to its documented fields and make its catalog match the request.

| Family | Before → after |
| --- | --- |
| FLUX.2 Max, Pro, Pro Preview | `prompt_upsampling` → inverse `disable_pup`; expose the existing boolean control |
| FLUX.2 Flex / Klein | Expose Flex's native prompt control; Klein emits neither unsupported prompt field |
| All seven FLUX.2 IDs | Stop rounding requested dimensions; use 16-pixel steps, minimum 64 per axis, maximum 4MP and all feasible ratios; HD presets use 1088 |
| Kontext Pro/Max and Ultra | Pixel dimensions → native `aspect_ratio`; expose mapped seed, prompt, safety and format controls |
| FLUX1.1 Pro / FLUX.1 Dev | Enforce 256–1440 per axis in steps of 32; expose mapped controls and Dev's own guidance/steps |
| FLUX.2 references | Preserve #399's accepted 8/4 generation limits; primary image leaves 7/3 additional edit references |
| Kontext references | Expose the four total experimental input slots; primary image leaves three additional references |

All 12 model IDs and 21 operations remain. Legacy `image_prompt` is not advertised as numbered reference inputs: its singular/base64 contract differs. Native ratio strings remain provider-validated within their documented 9:21–21:9 range. Optional axis bounds extend the existing reusable `Dimensions` constraint; BytePlus defaults remain unchanged.

Evidence reopened 2026-09-08: [exact OpenAPI](https://api.bfl.ai/openapi.json), [Max request](https://docs.bfl.ai/api-reference/models/generate-or-edit-an-image-with-flux2-%5Bmax%5D), [Flex request](https://docs.bfl.ai/api-reference/models/generate-or-edit-an-image-with-flux2-%5Bflex%5D), [Kontext](https://docs.bfl.ai/api-reference/models/edit-or-create-an-image-with-flux1-kontext-%5Bpro%5D), [Ultra](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux11-%5Bpro%5D-ultra-mode), [Pro 1.1](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux11-%5Bpro%5D), [Dev](https://docs.bfl.ai/api-reference/models/generate-an-image-with-flux1-%5Bdev%5D), and [dimension rules](https://help.bfl.ai/articles/8916739058-what-aspect-ratios-and-output-dimensions-are-supported). Serving route is `POST https://api.bfl.ai/v1/{model_id}`, Images generate/edit. The provider introduction date for these existing controls is unspecified. Playground's ten inputs do not apply to the API. OpenAPI and exact legacy references explicitly include WebP; the older contextual how-to omission does not override them. The integration quick-start's 810-pixel example is not dimension-specific; the current dimension guide explicitly prescribes 16-pixel steps and 1088-pixel HD.

This continues the owned #407 and completes related parameter findings from closed #378. The September 1 closure had no recorded objection, review or replacement. Current policy explicitly renews scoped maintenance after fresh verification; the old closed PR remains historical. #399's merged union-limit decision is preserved. The September 7 claim that advisory Claude review must succeed before readiness is corrected: branch protection requires eight other checks. No automated review is claimed from that failed job.

Validation at current head:
- `UV_NO_SYNC=1 UV_NO_CACHE=1 make ci`: **648 passed**, 73.24% coverage; lint, format, source/test mypy, Bandit pass. One new generic axis-bound test covers reusable logic with non-catalog values. Removed the prior 34-line BFL-specific addition; no new provider/model-specific tests, fixtures or snapshots remain.
- Disposable OpenAPI-backed parameter probe: **246 checks pass**, all 12 IDs/21 operations, prompt true/false/omitted, exact fields, reference ordering/overflow and unchanged request on rejection, dimension bounds and presets. Recorded base fails on Max's wrong prompt field.
- Chat's exact locked tools0.3.15 / celeste9 0.7.2 / pricing0.2.15: **21 tool schemas**, model discovery, Max/Forge + Pro/Flow, generation/edit slots, normalizer coverage and raw billing retention pass with the candidate SDK imported in a fresh process. This is candidate compatibility, not a lock update or full Chat-suite run.
- Commit and pre-push hooks pass. All eight required GitHub checks plus both CodeQL checks pass at `8e3cbec335e85538eea078937f4888161767599b`; no inline review finding or human comment. No advisory Claude review ran on this follow-up head. No provider-live generation is claimed. Combined with [polling #426](https://github.com/withceleste/celeste-python/pull/426) in an isolated checkout: full `make ci` passes 648 tests, all 387 disposable parameter/poll probes pass, and all 21 Chat schemas pass.

Pricing cards/rates do not change for this concern. The separate settled-cost billing correction is verified and handed to sole writer `anthropic-text-model-maintenance` in [#404](https://github.com/withceleste/celeste-python/issues/404). Chat source roles/defaults already match. Its locked SDK is `edcf009`; the shared Anthropic lock owner consumes this PR after merge and corrected pricing after actual release. Current remote Chat main has no deployed dependency updater; no workflow or lock-only PR is added here. Separate unowned video #346 was inspected and must retain these Images corrections when rebased.

Refs #404; fixes #369. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`.
Finding keys: `bfl|POST /v1/flux-2-*|images.generate+edit|flux-2|total-image-slots`; `bfl|POST /v1/{image-model}|images.generate+edit|hosted-flux|family-parameters`.
Policy `2026-09-07.6` / `35a680ff8c05`. Owner: desktop `bfl-images-model-maintenance`, configured identity `Kamilbenkirane`; provenance retained from September 7 run.

Downstream status checked 2026-09-09: the sole pricing writer included settled-cost precedence and explicit rated zero in [pricing #31](https://github.com/withceleste/celeste-pricing/pull/31), candidate 0.2.16. That batch remains draft at `67d3f3b` because required pytest throughput validation fails; version validation passes. This SDK PR remains independently reviewable at its unchanged head with all eight required checks passing and no review findings. Chat dependency adoption remains with the shared Anthropic task after actual SDK merge and pricing release/seeding. No dependency version is claimed available.
