### PR TITLE
fix(openai): preserve speech MIME and enable WAV

### DIFF
--- a/src/celeste/modalities/audio/providers/openai/client.py
+++ b/src/celeste/modalities/audio/providers/openai/client.py
@@ -50,7 +50,9 @@ class OpenAIAudioClient(OpenAIAudioMixin, AudioClient):
             if not audio_bytes:
                 msg = "No audio data in response"
                 raise ValueError(msg)
-            return AudioArtifact(data=audio_bytes)
+            return AudioArtifact(
+                data=audio_bytes, mime_type=response_data.get("mime_type")
+            )
         return super()._parse_content(response_data)
 
     def _parse_finish_reason(self, response_data: dict[str, Any]) -> AudioFinishReason:

--- a/src/celeste/modalities/audio/providers/openai/models.py
+++ b/src/celeste/modalities/audio/providers/openai/models.py
@@ -15,6 +15,7 @@ _RESPONSE_FORMAT_OPTIONS = [
     AudioMimeType.OGG,  # Maps to "opus" in OpenAI API
     AudioMimeType.AAC,
     AudioMimeType.FLAC,
+    AudioMimeType.WAV,
 ]
 
 _OPENAI_TRANSCRIBE_MIME_TYPES = [

--- a/src/celeste/providers/openai/audio/client.py
+++ b/src/celeste/providers/openai/audio/client.py
@@ -11,6 +11,7 @@ from celeste.mime_types import AudioMimeType
 from celeste.utils import detect_mime_type
 
 from . import config
+from .parameters import ResponseFormatMapper
 
 _MIME_TO_EXT: dict[str, str] = {
     AudioMimeType.FLAC: "flac",
@@ -99,8 +100,18 @@ class OpenAIAudioClient(APIMixin):
             json_body=request_body,
         )
         self._handle_error_response(response)
+        content_type = (
+            response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        )
         return {
             "audio_bytes": response.content,
+            "mime_type": (
+                AudioMimeType(content_type)
+                if content_type in AudioMimeType
+                else self._map_response_format_to_mime_type(
+                    request_body.get("response_format")
+                )
+            ),
             "headers": dict(response.headers),
         }
 
@@ -195,15 +206,9 @@ class OpenAIAudioClient(APIMixin):
         self, response_format: str | None
     ) -> AudioMimeType:
         """Map OpenAI response_format to AudioMimeType."""
-        format_map: dict[str, AudioMimeType] = {
-            "mp3": AudioMimeType.MP3,
-            "opus": AudioMimeType.OGG,
-            "aac": AudioMimeType.AAC,
-            "flac": AudioMimeType.FLAC,
-            "wav": AudioMimeType.WAV,
-            "pcm": AudioMimeType.WAV,
-        }
-        return format_map.get(response_format or "", AudioMimeType.MP3)
+        return ResponseFormatMapper._mime_map.get(
+            response_format or "", AudioMimeType.MP3
+        )
 
 
 __all__ = ["OpenAIAudioClient"]

--- a/src/celeste/providers/openai/audio/parameters.py
+++ b/src/celeste/providers/openai/audio/parameters.py
@@ -2,7 +2,6 @@
 
 from typing import Any, ClassVar
 
-from celeste.artifacts import AudioArtifact
 from celeste.mime_types import AudioMimeType
 from celeste.models import Model
 from celeste.parameters import FieldMapper, ParameterMapper
@@ -29,6 +28,8 @@ class ResponseFormatMapper(ParameterMapper[AudioContent]):
         "opus": AudioMimeType.OGG,
         "aac": AudioMimeType.AAC,
         "flac": AudioMimeType.FLAC,
+        "wav": AudioMimeType.WAV,
+        "pcm": AudioMimeType.PCM,
     }
 
     def map(
@@ -38,38 +39,15 @@ class ResponseFormatMapper(ParameterMapper[AudioContent]):
         model: Model,
     ) -> dict[str, Any]:
         """Transform response_format into provider request."""
-        # Convert string values to AudioMimeType enum before validation
-        if isinstance(value, str) and not isinstance(value, AudioMimeType):
-            string_to_mime_type: dict[str, AudioMimeType] = {
-                "mp3": AudioMimeType.MP3,
-                "opus": AudioMimeType.OGG,  # OpenAI uses "opus" for OGG format
-                "aac": AudioMimeType.AAC,
-                "flac": AudioMimeType.FLAC,
-            }
-            value = string_to_mime_type.get(value.lower(), value)
-
+        value = self._mime_map.get(str(value).lower(), value)
         validated_value = self._validate_value(value, model)
         if validated_value is None:
             return request
 
-        # Convert AudioMimeType enum to OpenAI string format
-        mime_type_to_openai_format: dict[AudioMimeType, str] = {
-            AudioMimeType.MP3: "mp3",
-            AudioMimeType.OGG: "opus",  # OpenAI uses "opus" for OGG format
-            AudioMimeType.AAC: "aac",
-            AudioMimeType.FLAC: "flac",
-        }
-
+        mime_type_to_openai_format = {mime: fmt for fmt, mime in self._mime_map.items()}
         response_format = mime_type_to_openai_format.get(validated_value, "mp3")
         request["response_format"] = response_format
         return request
-
-    def parse_output(self, content: AudioContent, value: object | None) -> AudioContent:
-        """Apply response_format → MIME type mapping to parsed content."""
-        if not isinstance(content, AudioArtifact):
-            return content
-        mime_type = self._mime_map.get(str(value) if value else "", AudioMimeType.MP3)
-        return AudioArtifact(data=content.data, mime_type=mime_type)
 
 
 class InstructionsMapper(FieldMapper[AudioContent]):


### PR DESCRIPTION
Non-MP3 speech requested with a MIME string/enum can be labelled MP3, and a response-format override can leave the output metadata describing the original request. This patch preserves a recognized response Content-Type, otherwise uses the format actually sent, and removes the mapper step that overwrote the result. WAV joins selectable formats; raw PCM overrides are labelled PCM.

Applies to the four existing OpenAI speech models on unary `POST /v1/audio/speech`. TTS-1/HD keep nine voices and mini-TTS keeps thirteen. Headerless PCM remains outside selectable formats because Chat's players require a supported container.

Evidence checked 2026-09-08: [speech request contract](https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create) lists all six wire formats; the [TTS guide](https://developers.openai.com/api/docs/guides/text-to-speech#supported-output-formats) distinguishes WAV from raw PCM. This corrects an existing contract, not a newly dated provider release.

SDK #376 was closed unmerged without a recorded objection. SDK #385 later fixed only voices. The remaining defect was reverified on current main; this scoped correction does not restore the old tests or duplicate the merged voice change.

Validation: `UV_NO_CACHE=1 UV_NO_SYNC=1 make ci` passed (647 tests, 73.30% coverage, Ruff, source/test mypy, Bandit). An uncommitted probe outside the repository exercised all four speech models across five formats as wire strings, enums and MIME strings; explicit overrides, header precedence, default MP3, PCM, raw metadata and a transcription sibling passed. No provider/model-specific test or fixture changes. No live provider call.

Pricing: TTS character rates and metering remain unchanged. Chat: existing artifact storage respects this MIME; after merge, the designated Anthropic task owns the shared SDK lock refresh. No Chat model/default migration is required and no downstream package is a prerequisite for this SDK fix.

Tracking: #411. Finding: `openai|/v1/audio/speech|speak|tts-family|format-mime`. Policy `2026-09-07.6`, cell `openai-audio`, automation `openai-audio-model-maintenance`. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`.

Hosted verification: all eight required branch checks plus both CodeQL checks passed at the pushed head. Required checks and branch rules were read; no open review finding was present when this PR was marked ready. Human merge remains manual.
