### PR TITLE
feat(google): support unary Gemini transcription

### DIFF
--- a/src/celeste/modalities/audio/providers/google/client.py
+++ b/src/celeste/modalities/audio/providers/google/client.py
@@ -4,6 +4,7 @@ import base64
 from typing import Any
 
 from celeste.artifacts import AudioArtifact
+from celeste.core import Modality, Operation
 from celeste.mime_types import AudioMimeType
 from celeste.parameters import ParameterMapper
 from celeste.providers.google.interactions import config
@@ -13,10 +14,12 @@ from celeste.providers.google.interactions.client import (
 from celeste.providers.google.interactions.streaming import (
     GoogleInteractionsStream as _GoogleInteractionsStream,
 )
+from celeste.providers.google.utils import build_content_part
 from celeste.types import AudioContent
 
 from ...client import AudioClient
 from ...io import AudioChunk, AudioInput
+from ...parameters import AudioParameter
 from ...streaming import AudioStream
 from .parameters import GOOGLE_PARAMETER_MAPPERS, OutputFormatMapper
 
@@ -68,17 +71,33 @@ class GoogleAudioStream(_GoogleInteractionsStream, AudioStream):
 
 
 class GoogleAudioClient(GoogleInteractionsMixin, AudioClient):
-    """Google audio client (Interactions API TTS and music generation)."""
+    """Google audio client (Interactions API speech, transcription, and music)."""
 
     _speak_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
     _generate_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
+    _transcribe_endpoint = config.GoogleInteractionsEndpoint.CREATE_INTERACTION
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[AudioContent]]:
         return GOOGLE_PARAMETER_MAPPERS
 
     def _init_request(self, inputs: AudioInput) -> dict[str, Any]:
-        """Initialize request with text input."""
+        """Initialize a transcription or audio generation request."""
+        if inputs.audio is not None:
+            audio = inputs.audio
+            if isinstance(audio, list) and len(audio) == 1:
+                audio = audio[0]
+            if not isinstance(audio, AudioArtifact):
+                msg = "Google transcription requires exactly one AudioArtifact"
+                raise ValueError(msg)
+            self.model.parameter_constraints[AudioParameter.AUDIO](audio)
+            part = build_content_part(audio, "audio")
+            if audio.mime_type == AudioMimeType.PCM:
+                part["mime_type"] = "audio/l16"
+            for field in ("sample_rate", "channels"):
+                if audio.metadata.get(field) is not None:
+                    part[field] = audio.metadata[field]
+            return {"input": [part]}
         return {
             "input": inputs.text,
             "response_format": {"type": "audio"},
@@ -87,9 +106,21 @@ class GoogleAudioClient(GoogleInteractionsMixin, AudioClient):
     def _parse_content(
         self,
         response_data: dict[str, Any],
-    ) -> AudioArtifact:
-        """Parse the final generated audio block from model_output steps."""
+    ) -> AudioArtifact | str:
+        """Parse transcript text or the final generated audio block."""
         steps = super()._parse_content(response_data)
+        if Operation.TRANSCRIBE in self.model.operations.get(Modality.AUDIO, set()):
+            texts = [
+                part["text"]
+                for step in steps
+                if step.get("type") == "model_output"
+                for part in step.get("content", [])
+                if part.get("type") == "text" and part.get("text") is not None
+            ]
+            if texts:
+                return "".join(texts)
+            msg = "No text content in transcription response"
+            raise ValueError(msg)
         audio_part: dict[str, Any] | None = None
         for step in steps:
             if step.get("type") != "model_output":
@@ -113,7 +144,7 @@ class GoogleAudioClient(GoogleInteractionsMixin, AudioClient):
         raise ValueError(msg)
 
     def _build_metadata(self, response_data: dict[str, Any]) -> dict[str, Any]:
-        """Retain ordered lyrics and structure without copying audio payloads."""
+        """Retain ordered text and annotations without copying audio payloads."""
         metadata = super()._build_metadata(response_data)
         text_blocks = [
             part

--- a/src/celeste/modalities/audio/providers/google/models.py
+++ b/src/celeste/modalities/audio/providers/google/models.py
@@ -1,6 +1,6 @@
 """Google models for audio modality."""
 
-from celeste.constraints import Choice, ImagesConstraint
+from celeste.constraints import AudioConstraint, Choice, ImagesConstraint
 from celeste.core import Modality, Operation, Provider
 from celeste.mime_types import AudioMimeType
 from celeste.models import Model
@@ -52,6 +52,27 @@ GOOGLE_SUPPORTED_LANGUAGES = [
 ]
 
 MODELS: list[Model] = [
+    Model(
+        id="gemini-3.5-transcribe",
+        provider=Provider.GOOGLE,
+        display_name="Google Gemini 3.5 Transcribe",
+        operations={Modality.AUDIO: {Operation.TRANSCRIBE}},
+        parameter_constraints={
+            AudioParameter.AUDIO: AudioConstraint(
+                supported_mime_types=[
+                    AudioMimeType.WAV,
+                    AudioMimeType.MP3,
+                    AudioMimeType.AIFF,
+                    AudioMimeType.AAC,
+                    AudioMimeType.OGG,
+                    AudioMimeType.FLAC,
+                    AudioMimeType.M4A,
+                    AudioMimeType.PCM,
+                    AudioMimeType.WEBM,
+                ],
+            ),
+        },
+    ),
     Model(
         id="gemini-2.5-flash-preview-tts",
         provider=Provider.GOOGLE,

--- a/src/celeste/modalities/audio/providers/google/parameters.py
+++ b/src/celeste/modalities/audio/providers/google/parameters.py
@@ -1,8 +1,10 @@
 """Google parameter mappers for audio modality."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
+from celeste.core import Modality, Operation
 from celeste.mime_types import AudioMimeType
+from celeste.models import Model
 from celeste.parameters import ParameterMapper
 from celeste.providers.google.interactions.parameters import (
     AudioMimeTypeMapper as _AudioMimeTypeMapper,
@@ -53,6 +55,35 @@ class LanguageMapper(_LanguageMapper):
         "uk": "uk-UA",
         "ta": "ta-IN",
     }
+    transcribe_locale_map: ClassVar[dict[str, str]] = locale_map | {
+        "zh": "cmn-Hans-CN",
+        "cs": "cs-CZ",
+        "da": "da-DK",
+        "fil": "fil-PH",
+        "fi": "fi-FI",
+        "el": "el-GR",
+        "hu": "hu-HU",
+        "ms": "ms-MY",
+        "no": "nb-NO",
+        "sk": "sk-SK",
+        "sv": "sv-SE",
+    }
+
+    def map(
+        self, request: dict[str, Any], value: object, model: Model
+    ) -> dict[str, Any]:
+        """Route transcription language hints to transcription_config."""
+        if Operation.TRANSCRIBE not in model.operations.get(Modality.AUDIO, set()):
+            return super().map(request, value, model)
+        language = self._validate_value(value, model)
+        if language is not None:
+            config = request.setdefault("generation_config", {}).setdefault(
+                "transcription_config", {}
+            )
+            config["language_codes"] = [
+                self.transcribe_locale_map.get(str(language), str(language))
+            ]
+        return request
 
 
 class OutputFormatMapper(_AudioMimeTypeMapper):


### PR DESCRIPTION
Add `gemini-3.5-transcribe` to Celeste's existing unary AUDIO/TRANSCRIBE operation on API-key `POST https://generativelanguage.googleapis.com/v1beta/interactions`. The SDK currently cannot discover or execute this documented file-transcription model. Live/WebSocket transcription remains a separate product.

Accept exactly one audio artifact (inline data or a caller-provided URI), map supported MIME types including MP4→M4A and PCM→L16, retain provided sample-rate/channel metadata, and send optional language hints to `generation_config.transcription_config.language_codes`. Combine every transcript text part in order, preserve its annotations in `metadata.text_blocks`, and retain request identity, usage, and finish status. Existing `extra_body` carries provider transcription options without introducing a new configuration framework. Duration and mode-specific provider limits remain enforced by Google.

Evidence reopened 2026-09-08:
- [August 26 GA release](https://ai.google.dev/gemini-api/docs/changelog) and [model contract](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-transcribe): canonical unary ID, audio input, text/word-annotation output; one-hour requests, thirty minutes with diarization/timestamps; no Batch/Flex/Priority support. `gemini-3.5-transcribe-live` is a distinct WebSocket ID.
- [File-transcription guide](https://ai.google.dev/gemini-api/docs/transcribe): exact REST route, URI/inline input, language hints and nested mode configuration, ordered transcript blocks and annotations.
- [Matching beta schema](https://ai.google.dev/static/api/interactions.openapi.json): `AudioContent` MIME/sample/channel/URI fields and `TranscriptionConfig.language_codes`. Nine existing Celeste MIME enums are supported; no Opus/A-law/µ-law enum support is advertised. No output-token cap or request duration is invented from the context limit.

This PR is stacked on [#405](https://github.com/withceleste/celeste-python/pull/405), whose text-block retention is reused. The three-file Transcribe diff adds no TTS/Lyria catalog changes. Keep draft until #405 is merged and the branch is refreshed onto current main. All prior Google speech/music entries remain present as defined by #405; transcription stays non-streaming.

Historical decision: closed [#364](https://github.com/withceleste/celeste-python/pull/364) had no recorded objection or replacement for Transcribe. The September 7 renewed policy authorizes independently verified existing-contract maintenance; no human-rejection blocker is inferred from the unexplained closure. The current implementation was scoped against current base and current sources, with no old tests copied into the PR.

Validation:
- Full `make ci`: **647 existing tests passed**, 72.96% coverage; lint/format, source/tests mypy, Bandit, and commit/pre-push hooks passed.
- Disposable request/response probe outside the repository passed: nine MIME mappings, inline/URI input, exact-one validation and unsupported MIME rejection, language routing, ordered and empty transcript handling, missing-text failure, annotation/usage retention.
- Existing Lyria/TTS behavior was inspected and its uncommitted five-case probe passed against this head. No provider/model-specific tests, fixtures, snapshots, or assertion scripts enter the PR.
- Provider-live transcription remains unverified because local network access to the provider failed on a bounded control probe; no generation quality or latency claim.

Pricing handoff: [tracking #403](https://github.com/withceleste/celeste-python/issues/403), standard USD 2/M audio input and USD 12/M text output per the [Developer API pricing table](https://ai.google.dev/gemini-api/docs/pricing). The existing Gemini normalizer matches retained Interactions usage; the sole pricing writer must add the product/card/binding and publish/seed before Chat can serve it. No released version is invented. Pricing 0.2.15 lacks this model.

Chat currently serves Groq Whisper in its two dictation roles and has no documented successor migration to Google. Leave those roles/defaults unchanged; optional exposure or a new tier remains the existing product decision, after SDK availability and pricing delivery. No new session transport, Files upload lifecycle, pricing mutation, or deployment.

Finding: `google|gemini-developer-api/v1beta/interactions|audio.transcribe|gemini-3.5-transcribe|availability`
Policy: `2026-09-07.6` / `b7cba50068e6`. Owner: desktop `google-audio-model-maintenance`, configured identity `Kamilbenkirane`. Default-branch base: `1c3b63aee24b17660fc05069fe238e5cb40f9a48`; stacked base: `baa78bca9612d8c498061d22a9f98e891e57d7da`.

Current review state (2026-09-08): draft at `7f8985c276a985a7384ce3d2d500d727a31ccaf5`, stacked on #405 at `baa78bca9612d8c498061d22a9f98e891e57d7da`. The existing CI workflow only runs pull requests targeting main/develop, so this stacked base has no GitHub check runs. After #405 merges, refresh onto current main and run the required GitHub gates before readiness. The disposable probe also passed through the actual public `AudioClient.transcribe` path with a stubbed provider response, verifying `TextOutput` and usage. All five existing external Lyria/TTS probe cases passed against this head.
