### PR TITLE
fix(google): remove discontinued Imagen 4 registrations

### DIFF
--- a/src/celeste/modalities/images/providers/google/models.py
+++ b/src/celeste/modalities/images/providers/google/models.py
@@ -1,53 +1,12 @@
 """Google models for images modality."""
 
-from celeste.constraints import Choice, ImagesConstraint, Range
+from celeste.constraints import Choice, ImagesConstraint
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
 from ...parameters import ImageParameter
 
-# Imagen API models (instances[].prompt → predictions[])
-GOOGLE_IMAGEN_MODELS: list[Model] = [
-    # Imagen 4 models (text-to-image) - Current GA
-    Model(
-        id="imagen-4.0-generate-001",
-        provider=Provider.GOOGLE,
-        display_name="Imagen 4",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
-        parameter_constraints={
-            ImageParameter.NUM_IMAGES: Range(min=1, max=4),
-            ImageParameter.ASPECT_RATIO: Choice(
-                options=["1:1", "3:4", "4:3", "9:16", "16:9"]
-            ),
-            ImageParameter.QUALITY: Choice(options=["1K", "2K"]),
-        },
-    ),
-    Model(
-        id="imagen-4.0-fast-generate-001",
-        provider=Provider.GOOGLE,
-        display_name="Imagen 4 Fast",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
-        parameter_constraints={
-            ImageParameter.NUM_IMAGES: Range(min=1, max=4),
-            ImageParameter.ASPECT_RATIO: Choice(
-                options=["1:1", "3:4", "4:3", "9:16", "16:9"]
-            ),
-        },
-    ),
-    Model(
-        id="imagen-4.0-ultra-generate-001",
-        provider=Provider.GOOGLE,
-        display_name="Imagen 4 Ultra",
-        operations={Modality.IMAGES: {Operation.GENERATE}},
-        parameter_constraints={
-            ImageParameter.NUM_IMAGES: Range(min=1, max=4),
-            ImageParameter.ASPECT_RATIO: Choice(
-                options=["1:1", "3:4", "4:3", "9:16", "16:9"]
-            ),
-            ImageParameter.QUALITY: Choice(options=["1K", "2K"]),
-        },
-    ),
-]
+GOOGLE_IMAGEN_MODELS: list[Model] = []
 
 # Gemini API models (contents[].parts[] → candidates[])
 GOOGLE_GEMINI_MODELS: list[Model] = [

--- a/tests/integration_tests/images/test_generate.py
+++ b/tests/integration_tests/images/test_generate.py
@@ -12,7 +12,6 @@ from celeste.providers.google.auth import GoogleADC
     ("provider", "model", "parameters"),
     [
         (Provider.OPENAI, "gpt-image-1-mini", {}),
-        (Provider.GOOGLE, "imagen-4.0-fast-generate-001", {"num_images": 1}),
         (Provider.BYTEPLUS, "seedream-4-0-250828", {}),
         (Provider.BFL, "flux-2-pro", {}),
         (Provider.XAI, "grok-imagine-image", {}),


### PR DESCRIPTION
Remove `imagen-4.0-generate-001`, `imagen-4.0-fast-generate-001`, and `imagen-4.0-ultra-generate-001` from active Images discovery and the retired live-generation row. All four existing Gemini image models remain registered, including `gemini-2.5-flash-image` until its future October 2 Developer shutdown. Existing low-level Imagen routing checks remain valid protocol checks.

Evidence reopened September 8, 2026:
- The [June 15 Developer release notice](https://ai.google.dev/gemini-api/docs/changelog) explicitly schedules these three IDs for August 17 shutdown; the [lifecycle table](https://ai.google.dev/gemini-api/docs/deprecations) names GA `gemini-3.1-flash-image` as replacement.
- The [Cloud Imagen 4 model contract](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-generate) gives June 30 discontinuation for each exact Generate/Fast/Ultra endpoint, recommending `gemini-2.5-flash-image`. These are distinct products and dates, not contradictory evidence. Its Developer successor chain already ends at the registered GA Flash Image.

Prior runs retained Imagen pending a paid rejection. Current policy explicitly accepts exact-route effective shutdown notices; the model-specific Cloud dates and exact Developer announcement settle the earlier uncertainty. Closed #361 (September 1, no recorded review/comment objection) is historical evidence, not a branch being reopened. Rejected new upscaling in #358 remains excluded.

Cross-repository tracking: #409. Chat at `48c14592a49e79329580519bef54e6333de2d298` already serves Flash/FLOW and Pro/FORGE with Flash default, and no Imagen role. Pricing `b482cb0498a9066b65058295057d9cea404be1b6` is assigned to sole writer `anthropic-text-model-maintenance`: preserve historical Imagen records and complete verified Gemini successor billing. No dependency is required to remove expired SDK discovery; the designated shared Chat refresh consumes this commit after merge. No release, seeding, or deployment here.

Validation: full `make ci` passed: 647 existing unit tests, 73.25% coverage, Ruff lint/format, source/test mypy, and Bandit. Final diff removes one obsolete integration case and adds no provider/model-specific tests. Registered set checked against all three removed IDs and four retained Gemini siblings; no provider-live call needed for the published effective shutdown.

Finding: `google|developer-v1beta-predict+vertex-v1-predict|images.generate|imagen-4|effective-shutdown`.
Policy: `2026-09-07.6` / `f9c1a5ce232c`. Owner: desktop `google-images-model-maintenance`, configured identity `Kamilbenkirane`. Base: `1c3b63aee24b17660fc05069fe238e5cb40f9a48`.

Final GitHub validation, September 8: head `35ccd9a08623b236e8c0a760ef2b5b7c0cdbb85b` has all eight required CI jobs and both available CodeQL checks passing, current base, clean merge state, and no reviews/comments requiring changes. Both `codex` and `codex-automation` labels are applied.

Administrative readiness blocker: the connector rejected the mark-ready action for #418 because approval is required while this unattended run uses approval policy `never`. No readiness transition is claimed or retried through another mechanism; the three verified SDK corrections remain drafts. Maintainer action: review and mark them ready. Pricing/Chat publication is a downstream handoff, not a prerequisite for this SDK correction.
