### PR TITLE
fix(google): rebase Interactions citations across text parts

### DIFF
--- a/src/celeste/modalities/text/providers/google/grounding.py
+++ b/src/celeste/modalities/text/providers/google/grounding.py
@@ -108,13 +108,14 @@ def map_grounding_interactions(steps: list[dict[str, Any]]) -> Grounding | None:
     sources: list[GroundingSource] = []
     source_indices: dict[str, int] = {}
     citations: list[Citation] = []
+    offset = 0
     for step in steps:
         if step.get("type") != "model_output":
             continue
         for part in step.get("content", []):
             if part.get("type") != "text":
                 continue
-            part_text = part.get("text", "")
+            part_text = part.get("text") or ""
             for annotation in part.get("annotations", []):
                 if annotation.get("type") != "url_citation":
                     continue
@@ -137,16 +138,17 @@ def map_grounding_interactions(steps: list[dict[str, Any]]) -> Grounding | None:
                     continue
                 start = _byte_offset_to_char_offset(part_text, start)
                 end = _byte_offset_to_char_offset(part_text, end)
-                if start is None or end is None:
+                if start is None or end is None or start > end:
                     continue
                 citations.append(
                     Citation(
-                        start=start,
-                        end=end,
+                        start=offset + start,
+                        end=offset + end,
                         source_indices=[source_indices[url]],
                         cited_text=part_text[start:end] or None,
                     )
                 )
+            offset += len(part_text)
 
     if not queries and not sources and not citations:
         return None


### PR DESCRIPTION
Google Interactions concatenates text across model-output parts and steps, but its citations stayed relative to each part. A citation on a later answer could therefore highlight the preamble instead. Accumulate the preceding visible character count after converting each part's UTF-8 byte offsets. Reject reversed spans while retaining their sources; preserve queries, native steps and source deduplication.

For example, with `Préface 🐈. ` followed by `Café`, a local byte span `[0,5)` now maps to the four characters of `Café` in the full answer. The same mapper serves unary output and reconstructed SSE steps. Thought, image and tool steps do not contribute to the visible-text offset. No model IDs, prices, request fields or streaming flags change.

[The Interactions reference](https://ai.google.dev/api/interactions-api) attaches annotations to each TextContent and defines byte-based starts and exclusive ends; reopened 2026-09-08. Celeste's parser explicitly concatenates those text parts. This completes the remaining Interactions defect tracked in [#410](https://github.com/withceleste/celeste-python/issues/410), after merged #373 fixed Vertex text preservation and #401 converted local byte offsets and repaired Vertex part selection. Neither earlier decision is reversed. The existing contract's introduction date is unspecified.

Validation: full `make ci` passed: **647 existing tests**, 73.25% coverage, Ruff lint/format, source/test mypy and Bandit. Reused the installed Python 3.13.3 environment with this worktree's `src` first on PYTHONPATH and dependency synchronization disabled; no unavailable dependency version is claimed. A disposable probe outside the repository failed on the exact base and passes on this patch for unary multipart Unicode text, SSE reconstruction, invalid boundaries/reversed spans, deduplicated sources and unchanged input. No test, fixture, snapshot or model-specific assertion file enters the PR. `git diff --check` passed. No fresh live generation: the bounded provider control failed with ConnectError before a usable response.

Pricing requires no change: usage and billing metadata are untouched. Chat's Google text roles use API-key Interactions and consume SDK grounding; the three text profiles, title model and defaults are already correct at `48c14592a49e79329580519bef54e6333de2d298`. Chat currently locks SDK `edcf009171d96716981ff337b42d2057abb6117f` and pricing 0.2.15. After SDK merge, the designated Anthropic text task owns shared lock delivery; remote Chat main has no internal-dependency updater. No downstream prerequisite blocks this SDK fix.

Finding: `google|gemini-developer-api/v1beta/interactions|text.generate+analyze|gemini|citation-offsets`.
Policy `2026-09-07.6` / `43a025e88063`; owner: desktop `google-text-model-maintenance`, configured identity `Kamilbenkirane`, run 2026-09-08. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`. Ready for review: all eight required GitHub checks plus CodeQL passed on the pushed head; current base and final diff verified, with no open review findings. No merge, release or deployment.
