### PR TITLE
fix(openai): accept valid GPT Image 2 dimensions

### DIFF
--- a/src/celeste/constraints.py
+++ b/src/celeste/constraints.py
@@ -132,12 +132,17 @@ class Dimensions(Constraint):
     max_aspect_ratio: float
     presets: dict[str, str] | None = None
     multiple_of: int | None = Field(default=None, gt=0)
+    max_edge: int | None = Field(default=None, gt=0)
+    special_values: list[str] | None = None
 
     def __call__(self, value: str) -> str:
         """Validate dimension string against pixel and aspect ratio bounds."""
         if not isinstance(value, str):
             msg = f"Must be string, got {type(value).__name__}"
             raise ConstraintViolationError(msg)
+
+        if self.special_values and value in self.special_values:
+            return value
 
         # Check if value is a preset key
         if self.presets and value in self.presets:
@@ -169,6 +174,10 @@ class Dimensions(Constraint):
 
         if self.multiple_of and (width % self.multiple_of or height % self.multiple_of):
             msg = f"Width and height must be multiples of {self.multiple_of}"
+            raise ConstraintViolationError(msg)
+
+        if self.max_edge is not None and max(width, height) > self.max_edge:
+            msg = f"Width and height must be at most {self.max_edge}"
             raise ConstraintViolationError(msg)
 
         # Validate total pixels

--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -1,6 +1,6 @@
 """OpenAI models for images modality."""
 
-from celeste.constraints import Choice, Range
+from celeste.constraints import Choice, Dimensions, Range
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
@@ -77,17 +77,14 @@ MODELS: list[Model] = [
         streaming=True,
         parameter_constraints={
             ImageParameter.PARTIAL_IMAGES: Range(min=0, max=3),
-            ImageParameter.ASPECT_RATIO: Choice(
-                options=[
-                    "1024x1024",
-                    "1536x1024",
-                    "1024x1536",
-                    "2048x2048",
-                    "2048x1152",
-                    "3840x2160",
-                    "2160x3840",
-                    "auto",
-                ]
+            ImageParameter.ASPECT_RATIO: Dimensions(
+                min_pixels=655_360,
+                max_pixels=8_294_400,
+                min_aspect_ratio=1 / 3,
+                max_aspect_ratio=3,
+                multiple_of=16,
+                max_edge=3840,
+                special_values=["auto"],
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),

--- a/tests/unit_tests/test_constraints.py
+++ b/tests/unit_tests/test_constraints.py
@@ -170,6 +170,22 @@ def test_dimensions_enforce_multiples() -> None:
         constraint("20x32")
 
 
+def test_dimensions_edge_bound_and_special_values() -> None:
+    constraint = Dimensions(
+        min_pixels=100,
+        max_pixels=10_000,
+        min_aspect_ratio=0.5,
+        max_aspect_ratio=2,
+        max_edge=40,
+        special_values=["adaptive"],
+    )
+    assert constraint("adaptive") == "adaptive"
+    assert constraint("40x20") == "40x20"
+    for value in ("41x30", "30x41"):
+        with pytest.raises(ConstraintViolationError, match="at most 40"):
+            constraint(value)
+
+
 @pytest.mark.parametrize("value", [1, "20", "axb", "0x20", "5x5", "10x100"])
 def test_dimensions_reject_invalid_values(value: object) -> None:
     constraint = Dimensions(


### PR DESCRIPTION
GPT Image 2 rejects valid sizes such as `1536x864` locally because the catalog copied seven popular resolutions into a fixed Choice. Use the existing Dimensions constraint, retaining `auto` and all former sizes while enforcing the documented pixel, edge, aspect-ratio and alignment limits. Add optional edge/special-value support to that shared constraint; other models keep their original behavior.

Evidence checked 2026-09-08: [generation request](https://developers.openai.com/api/reference/resources/images/methods/generate), [Python edit request](https://developers.openai.com/api/reference/python/resources/images/methods/edit), and [model-specific dimensions](https://developers.openai.com/api/docs/guides/image-generation#size-and-quality-options) explicitly support arbitrary dimensions: 655,360–8,294,400 pixels, edges ≤3840, multiples of 16, ratios 1/3–3. Outputs above 3,686,400 pixels remain experimental. The original #264 copied popular sizes, not the complete accepted set. Earlier maintenance deferred this because the generic JSON edit schema retained a legacy enum; the model-specific edit reference resolves that overly broad deferral. No separately dated constraint change is asserted.

Before/after: `gpt-image-2` has eight enumerated choices → valid dimensions plus auto; `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, their operations and streaming flags stay intact. No IDs are added or removed. Existing snapshot #392 belongs to an unverified originating routine and is preserved; no duplicate snapshot addition.

Validation: `uv sync --all-extras --offline` succeeded. `UV_NO_CACHE=1 UV_NO_SYNC=1 make ci` passed: **648 tests, 73.27% coverage**, Ruff, both mypy passes and Bandit. The initial command hit an inaccessible default uv cache; disabling that cache after successful installation resolved it. A disposable request probe passed 28 unary/stream generation/edit mappings, invalid bounds, legacy siblings, and all 144 existing BFL/BytePlus dimension presets. The only new permanent test exercises reusable Dimensions edge bounds and an arbitrary special string; it contains no provider/model IDs or catalog assertions. No live provider claim.

Pricing: the current GPT Image 2 standard/Batch token card at `b482cb0` is correct; quantities still come from provider usage. Chat at `48c1459` already serves GPT Image 2 in FORGE with existing price coverage and unchanged defaults. Its locked SDK `edcf009` must advance after merge; the designated Anthropic task owns shared dependency delivery because no remote internal-dependency workflow exists. No Chat role migration or pricing package release is required by this correction.

Tracking: #419. Finding: `openai|/v1/images/generations,/v1/images/edits|generate,edit|gpt-image-2|dimensions`.
Policy `2026-09-07.6` / `1a7cb75727cf`; owner: desktop `openai-images-model-maintenance`, configured identity `Kamilbenkirane`. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`. All eight required GitHub checks and both CodeQL checks passed at `fb7b36d790fe3ab4bf98950bb38120f04f80a695`; no review findings. **Keep draft for downstream compatibility:** the exact frozen tools 0.3.15 schema applies `^\d+x\d+$` to every Dimensions constraint and rejects explicit `auto` for both generation and editing. This was reproduced with the candidate SDK and exact installed tools after frozen Chat sync. Before Chat consumes this change, its existing `celeste-tools` schema builder must honor `Dimensions.special_values`. This dependency repository is outside the configured three-repository scope; #419 records the precise repair needed. No unavailable tools version or completed Chat migration is claimed.

The same schema gap remains on current [tools main at `183f36e`](https://github.com/withceleste/celeste-tools/blob/183f36e9fed5a4f64dad06aab0534b4c0af8eee3/src/celeste_tools/shared/schema.py), whose package version is 0.3.15. There is no open tools PR to consume. Repair and publish the existing schema builder, then coordinate the shared Chat refresh through #419.
