### PR TITLE
feat(google): register Robotics ER 2 text model

### DIFF
--- a/src/celeste/modalities/text/providers/google/models.py
+++ b/src/celeste/modalities/text/providers/google/models.py
@@ -19,6 +19,24 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="gemini-robotics-er-2-preview",
+        provider=Provider.GOOGLE,
+        display_name="Gemini Robotics ER 2 Preview",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=65536),
+            TextParameter.TOOLS: ToolSupport(
+                tools=[WebSearch, CodeExecution, UrlContext]
+            ),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.VIDEO: VideosConstraint(),
+            TextParameter.AUDIO: AudioConstraint(),
+        },
+    ),
+    Model(
         id="gemini-2.5-flash",
         provider=Provider.GOOGLE,
         display_name="Gemini 2.5 Flash",


### PR DESCRIPTION
Register `gemini-robotics-er-2-preview` for the existing Google text GENERATE/ANALYZE client. It becomes discoverable with image/video/audio input, a 65,536-token completion cap, JSON schema, function calling and the three already implemented WebSearch/CodeExecution/UrlContext tools. All eleven existing Google text entries remain unchanged. The separate Live model and retired, never-registered ER 1.6 are not added.

Scoped model/capability evidence rechecked 2026-09-09:
- [Model contract](https://ai.google.dev/gemini-api/docs/models/gemini-robotics-er-2-preview): canonical preview ID, text output, the three media inputs, 131,072 input / 65,536 output limits and supported tools/schema.
- [Interactions reference](https://ai.google.dev/api/interactions-api): exact ID on the existing `/v1beta/interactions` request. [Robotics guide](https://ai.google.dev/gemini-api/docs/robotics-overview): Python example uses the same typed content blocks and `generation_config.thinking_level`. Its REST sample mixes legacy fields; the matching Interactions schema and existing adapter determine the envelope. No exhaustive thinking-level enum is inferred from the base model; callers can still pass documented `high`/`medium` through the existing mapper.
- [Release notes](https://ai.google.dev/gemini-api/docs/changelog): standard ER 2 preview launched July 30, 2026; its similarly named Live endpoint is a separate product.

`streaming=True` describes existing Interactions SSE. The September 7 validation recorded successful model metadata, Celeste unary and Celeste SSE with the supplied key in [#410](https://github.com/withceleste/celeste-python/issues/410). This replaces the older August access blocker with that later route-specific evidence. The September 8 bounded provider control failed with ConnectError before a usable response; no fresh live success is claimed. Vertex availability/regions remain unestablished after checking Cloud lifecycle, pricing, release notes and indexed model documentation; this PR makes no Cloud support claim or auth-routing change.

Validation on the unchanged SDK head (September 8): full `make ci` passed: **647 existing tests**, 73.25% coverage, Ruff, source/test mypy and Bandit, using the installed Python 3.13.3 environment with the worktree source first on PYTHONPATH and synchronization disabled. A disposable probe verifies discovery, Interactions dispatch, all three media inputs, SSE request fields, existing tool/schema mapping and preserved family inventory. No new test/fixture/snapshot or model-specific assertion file enters the PR. No live robot or physical action is executed.

Pricing is tracked in [#410](https://github.com/withceleste/celeste-python/issues/410) and owned batch [celeste-pricing #31](https://github.com/withceleste/celeste-pricing/pull/31). **Pricing evidence corrected September 9:** the [Developer pricing table](https://ai.google.dev/gemini-api/docs/pricing#gemini-robotics-er-2-preview) now explicitly lists standard input/output/cache USD **1/5/0.10 per million tokens through December 31, 2026**, then **2/10/0.20 from January 1, 2027**. Batch is 0.50/2.50/0.05, then 1/5/0.10. Storage is 0.50, then 1 per million token-hours; Search remains 14 per 1,000 queries after the documented shared allowance. This supersedes this PR's earlier undated full-rate claim; the promotion's start date is not established. The batch's current head `67d3f3b37d0b346b2633c703e89f021bbb15ba4f` still charges standard USD 12 for 1M input + 1M output, versus the current USD 6 contract. The designated writer must correct it before publication, retaining dated history and the Developer-only condition. Storage duration and explicit batch execution remain unavailable to the normalizer; no Cloud, Flex or Priority rate is inferred. This is a pricing-only evidence correction; the SDK diff and its verified readiness are unchanged.

Chat at `48c14592a49e79329580519bef54e6333de2d298` serves no Robotics role, so its existing profiles/defaults stay unchanged. Optional exposure needs a product role choice after SDK merge and published/seeded pricing; SDK registration itself has no downstream prerequisite. The Anthropic task owns shared SDK lock delivery, since no remote internal-dependency updater exists. No duplicate Chat lock-only PR.

Finding: `google|gemini-developer-api/v1beta/interactions|text.generate+analyze|gemini-robotics-er-2-preview|catalog-and-pricing`.
Policy `2026-09-07.6` / `43a025e88063`; owner: desktop `google-text-model-maintenance`, configured identity `Kamilbenkirane`, run 2026-09-08. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`. Ready for review: all eight required GitHub checks plus CodeQL passed on the pushed head; current base and final diff verified, with no open review findings. No merge, release or deployment.
