### PR TITLE
fix(xai): preserve native Responses output and compaction state

### DIFF
--- a/src/celeste/modalities/text/providers/xai/__init__.py
+++ b/src/celeste/modalities/text/providers/xai/__init__.py
@@ -1,6 +1,7 @@
 """xAI provider for text modality."""
 
 from .client import XAITextClient
+from .io import XAITextOutput
 from .models import MODELS
 
-__all__ = ["MODELS", "XAITextClient"]
+__all__ = ["MODELS", "XAITextClient", "XAITextOutput"]

--- a/src/celeste/modalities/text/providers/xai/client.py
+++ b/src/celeste/modalities/text/providers/xai/client.py
@@ -1,33 +1,112 @@
 """xAI text client (modality)."""
 
+import base64
 from typing import Any
 
+from asgiref.sync import async_to_sync
+from pydantic import BaseModel
+
+from celeste.artifacts import ImageArtifact
+from celeste.messages import request_messages
+from celeste.mime_types import ImageMimeType
 from celeste.parameters import ParameterMapper
 from celeste.providers.xai.responses.client import (
     XAIResponsesClient as XAIResponsesMixin,
 )
+from celeste.providers.xai.responses.config import XAIResponsesEndpoint
 from celeste.providers.xai.responses.streaming import (
     XAIResponsesStream as _XAIResponsesStream,
 )
-from celeste.types import TextContent
+from celeste.tools import ToolResult
+from celeste.types import ImagePart, Message, Role, TextContent, TextPart
+from celeste.utils import detect_mime_type
 
-from ...io import TextInput
+from ...client import TextSyncNamespace
+from ...io import TextChunk, TextInput
 from ...protocols.openresponses.client import (
     OpenResponsesTextClient,
+    _serialize_messages,
 )
 from ...protocols.openresponses.client import (
     OpenResponsesTextStream as _OpenResponsesTextStream,
 )
 from ...streaming import TextStream
+from .io import XAITextOutput
 from .parameters import XAI_PARAMETER_MAPPERS
+
+
+def _has_image_output(output: list[dict[str, Any]]) -> bool:
+    """Identify native image output items."""
+    return any(item.get("type") == "image_generation_call" for item in output)
+
+
+def _has_native_output(output: list[dict[str, Any]]) -> bool:
+    """Identify output that must be replayed as a complete native sequence."""
+    return any(
+        item.get("type") in ("image_generation_call", "compaction") for item in output
+    )
+
+
+def _parse_image_content(output: list[dict[str, Any]]) -> list[BaseModel]:
+    """Decode images and text in their original output order."""
+    parts: list[BaseModel] = []
+    for item in output:
+        if item.get("type") == "message":
+            parts.extend(
+                TextPart(text=part.get("text") or "")
+                for part in item.get("content", [])
+                if part.get("type") == "output_text"
+            )
+        elif item.get("type") == "image_generation_call":
+            result = item.get("result")
+            if not isinstance(result, str) or not result:
+                msg = "image_generation_call result must be a base64 string"
+                raise ValueError(msg)
+            data = base64.b64decode(result, validate=True)
+            mime = detect_mime_type(data)
+            parts.append(
+                ImagePart(
+                    image=ImageArtifact(
+                        data=data,
+                        mime_type=mime if isinstance(mime, ImageMimeType) else None,
+                        metadata={k: v for k, v in item.items() if k != "result"},
+                    )
+                )
+            )
+    return parts
 
 
 class XAITextStream(_XAIResponsesStream, _OpenResponsesTextStream):
     """xAI streaming for text modality."""
 
+    _output_class = XAITextOutput
+
+    def _aggregate_content(self, chunks: list[TextChunk]) -> TextContent:
+        """Include completed native images in the final output."""
+        if self._response_data is not None:
+            output = self._response_data.get("output", [])
+            if _has_image_output(output):
+                return _parse_image_content(output)
+        return super()._aggregate_content(chunks)
+
+    def _aggregate_signature(
+        self, chunks: list[TextChunk], raw_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Preserve the complete native sequence for continuation."""
+        if self._response_data is not None:
+            output = self._response_data.get("output", [])
+            if _has_native_output(output):
+                return list(output)
+        return super()._aggregate_signature(chunks, raw_events)
+
 
 class XAITextClient(XAIResponsesMixin, OpenResponsesTextClient):
     """xAI text client."""
+
+    @classmethod
+    def _output_class(cls) -> type[XAITextOutput]:
+        """Return the output type that preserves native images."""
+        return XAITextOutput
 
     @classmethod
     def parameter_mappers(cls) -> list[ParameterMapper[TextContent]]:
@@ -41,11 +120,89 @@ class XAITextClient(XAIResponsesMixin, OpenResponsesTextClient):
         )
         if inputs.messages is None and not has_media:
             return {"input": inputs.prompt or ""}
-        return super()._init_request(inputs)
+        items: list[dict[str, Any]] = []
+        for message in request_messages(
+            prompt=inputs.prompt,
+            messages=inputs.messages,
+            image=inputs.image,
+            video=inputs.video,
+            audio=inputs.audio,
+            document=inputs.document,
+        ):
+            if (
+                isinstance(message, Message)
+                and message.role == Role.ASSISTANT
+                and message.signature
+                and _has_native_output(message.signature)
+            ):
+                items.extend(message.signature)
+            else:
+                items.extend(_serialize_messages([message]))
+        return {"input": items}
+
+    def _parse_content(self, response_data: dict[str, Any]) -> TextContent:
+        """Include native image results alongside text."""
+        output = response_data.get("output", [])
+        if _has_image_output(output):
+            return _parse_image_content(output)
+        return super()._parse_content(response_data)
+
+    def _parse_reasoning(
+        self, response_data: dict[str, Any]
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Preserve opaque compaction and image output for verbatim replay."""
+        reasoning, signature = super()._parse_reasoning(response_data)
+        output = response_data.get("output", [])
+        return reasoning, list(output) if _has_native_output(output) else signature
+
+    async def compact(
+        self,
+        prompt: str | None = None,
+        *,
+        messages: list[Message | ToolResult] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> XAITextOutput:
+        """Compact conversation context into opaque replayable output."""
+        self._check_media_support(messages=messages)
+        return await self._predict(
+            TextInput(prompt=prompt, messages=messages),
+            endpoint=XAIResponsesEndpoint.COMPACT_RESPONSE,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+        )
 
     def _stream_class(self) -> type[TextStream]:
         """Return the Stream class for this provider."""
         return XAITextStream
 
+    @property
+    def sync(self) -> "XAITextSyncNamespace":
+        """Synchronous xAI text operations."""
+        return XAITextSyncNamespace(self)
 
-__all__ = ["XAITextClient", "XAITextStream"]
+
+class XAITextSyncNamespace(TextSyncNamespace):
+    """Synchronous xAI text operations."""
+
+    def __init__(self, client: XAITextClient) -> None:
+        self._client = client
+
+    def compact(
+        self,
+        prompt: str | None = None,
+        *,
+        messages: list[Message | ToolResult] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> XAITextOutput:
+        """Blocking context compaction."""
+        return async_to_sync(self._client.compact)(
+            prompt,
+            messages=messages,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+        )
+
+
+__all__ = ["XAITextClient", "XAITextStream", "XAITextSyncNamespace"]

--- a/src/celeste/modalities/text/providers/xai/io.py
+++ b/src/celeste/modalities/text/providers/xai/io.py
@@ -1,0 +1,65 @@
+"""xAI-specific text IO types."""
+
+from typing import cast
+
+from pydantic import SerializeAsAny, model_validator
+
+from celeste.messages import content_to_text
+from celeste.types import (
+    ImagePart,
+    Message,
+    MessageContent,
+    Role,
+    TextContent,
+    TextPart,
+)
+
+from ...io import TextOutput
+
+
+class XAITextOutput(TextOutput):
+    """xAI text output, including native generated images."""
+
+    content: SerializeAsAny[TextContent]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _restore_image_content(cls, data: object) -> object:
+        """Restore serialized image output without interpreting structured JSON."""
+        if not isinstance(data, dict):
+            return data
+        content = data.get("content")
+        signature = data.get("signature")
+        if (
+            isinstance(content, list)
+            and isinstance(signature, list)
+            and any(
+                isinstance(item, dict) and item.get("type") == "image_generation_call"
+                for item in signature
+            )
+        ):
+            data = dict(data)
+            data["content"] = Message(role=Role.ASSISTANT, content=content).content
+        return data
+
+    @property
+    def message(self) -> Message:
+        """Preserve generated image parts in the assistant message."""
+        content = (
+            cast(MessageContent, self.content)
+            if isinstance(self.content, list)
+            and self.content
+            and all(isinstance(part, (TextPart, ImagePart)) for part in self.content)
+            else content_to_text(self.content)
+        )
+        return Message(
+            role=Role.ASSISTANT,
+            content=content,
+            tool_calls=self.tool_calls if self.tool_calls else None,
+            reasoning=self.reasoning,
+            signature=self.signature,
+            container=self.container,
+        )
+
+
+__all__ = ["XAITextOutput"]

--- a/src/celeste/modalities/text/streaming.py
+++ b/src/celeste/modalities/text/streaming.py
@@ -1,6 +1,7 @@
 """Text streaming primitives."""
 
 from celeste.streaming import Stream
+from celeste.types import TextContent
 
 from .io import TextChunk, TextFinishReason, TextOutput, TextUsage
 from .parameters import TextParameters
@@ -15,7 +16,7 @@ class TextStream(Stream[TextOutput, TextParameters, TextChunk]):
     _output_class = TextOutput
     _empty_content = ""
 
-    def _aggregate_content(self, chunks: list[TextChunk]) -> str:
+    def _aggregate_content(self, chunks: list[TextChunk]) -> TextContent:
         """Aggregate content from chunks into raw text."""
         return "".join(chunk.content for chunk in chunks)
 

--- a/src/celeste/providers/xai/responses/client.py
+++ b/src/celeste/providers/xai/responses/client.py
@@ -1,7 +1,8 @@
 """xAI Responses API client."""
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
+from celeste.io import FinishReason
 from celeste.protocols.openresponses.client import OpenResponsesClient
 
 from . import config
@@ -11,6 +12,12 @@ class XAIResponsesClient(OpenResponsesClient):
     """XAI Responses API client."""
 
     _default_base_url: ClassVar[str] = config.BASE_URL
+
+    def _parse_finish_reason(self, response_data: dict[str, Any]) -> FinishReason:
+        """Recognize completion even when the response contains only native output."""
+        if response_data.get("status") == "completed":
+            return FinishReason(reason="completed")
+        return super()._parse_finish_reason(response_data)
 
 
 __all__ = ["XAIResponsesClient"]

--- a/src/celeste/providers/xai/responses/config.py
+++ b/src/celeste/providers/xai/responses/config.py
@@ -7,6 +7,7 @@ class XAIResponsesEndpoint(StrEnum):
     """Endpoints for XAI Responses API."""
 
     CREATE_RESPONSE = "/v1/responses"
+    COMPACT_RESPONSE = "/v1/responses/compact"
     LIST_MODELS = "/v1/models"
     GET_MODEL = "/v1/models/{model_id}"
 

--- a/src/celeste/providers/xai/responses/streaming.py
+++ b/src/celeste/providers/xai/responses/streaming.py
@@ -1,10 +1,28 @@
 """XAI Responses SSE parsing for streaming."""
 
+from typing import Any
+
 from celeste.protocols.openresponses.streaming import OpenResponsesStream
+from celeste.types import ToolActivity, ToolActivityStatus
 
 
 class XAIResponsesStream(OpenResponsesStream):
     """XAI Responses SSE parsing."""
+
+    def _parse_chunk_tool_activity(
+        self, event_data: dict[str, Any]
+    ) -> ToolActivity | None:
+        """Expose native image generation progress."""
+        event_type = event_data.get("type")
+        if event_type == "response.image_generation_call.in_progress":
+            return ToolActivity(
+                tool_name="generate_image", status=ToolActivityStatus.STARTED
+            )
+        if event_type == "response.image_generation_call.completed":
+            return ToolActivity(
+                tool_name="generate_image", status=ToolActivityStatus.COMPLETED
+            )
+        return super()._parse_chunk_tool_activity(event_data)
 
 
 __all__ = ["XAIResponsesStream"]


### PR DESCRIPTION
## Problem and behavior

xAI Responses can return native image items or opaque compaction state. The text client currently drops the image content and cannot preserve the complete ordered output for subsequent edits; it also has no explicit compaction method.

This correction returns typed text/image content from unary and streaming responses, retains the complete native output in the existing reasoning signature, and replays that sequence verbatim without duplicating messages or tool calls. `XAITextOutput` preserves those image parts through JSON serialization. Explicit `compact()` and `sync.compact()` reuse the existing HTTP, validation, configuration, and usage paths. Image-generation progress uses the existing tool-activity events; native-only successful output receives a completed finish reason. The shared streaming change only widens an annotation to the existing `TextContent` type.

No catalog IDs, limits, flags, or Chat roles change. Retained text IDs: `grok-build-0.1`, `grok-4.20-multi-agent-0309`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4.3`, `grok-4.5`, `grok-4.6`, and `grok-3-mini`. Ordinary text, structured JSON, function calls, and explicit Chat Completions retain their existing paths. No automatic compaction scheduler or new transport is introduced.

## Evidence and ownership

Official pages reopened September 8, 2026: [native image tool](https://docs.x.ai/developers/tools/image-generation) specifies bare-base64 results, progress events, and complete ordered replay; [context compaction](https://docs.x.ai/developers/advanced-api-usage/context-compaction) specifies `POST /v1/responses/compact` and opaque continuation output. [Release notes](https://docs.x.ai/developers/release-notes) date compaction to May 29; the native image-tool REST availability date is unspecified.

The automation's earlier #379 was closed unmerged without recorded objections or replacement. The September 7 policy renews maintenance authorization; these defects were independently reproduced on current main. This is a scoped current correction and restores none of the old provider-specific tests. Ownership is established by the automation's August 31/September 1 run records.

Tracking: #416. Policy `2026-09-07.6`, fingerprint `4af8cd8dcb47`.
Finding: `xai|/v1/responses+compact|text.generate|grok-text-family|native-output-continuation`.
Base: `1c3b63aee24b17660fc05069fe238e5cb40f9a48`.

## Repository impact and delivery

- **SDK:** this PR fixes native output/continuation using the existing adapter. Shared callers and OpenAI/OpenRouter/Ollama text and xAI image consumers were inspected.
- **Pricing:** #416 records independently verified exact-cost and rate-card defects for the sole pricing writer, `anthropic-text-model-maintenance`. This SDK correction does not introduce a new ID or change billing input, and has no unpublished package dependency. The historical pricing PR withceleste/celeste-pricing#28 remains closed.
- **Chat:** default `48c14592a49e79329580519bef54e6333de2d298` serves Grok 4.6 without a tier/default role, and forwards raw usage correctly. No model migration is required. The designated shared dependency owner must refresh its SDK Git pin after merge and pricing package after a real published/seeded correction; no remote internal-dependency updater exists. This PR is not a billing rollout.

## Validation

- Existing `make ci`: **647 tests passed**, 72.89% coverage; formatting, lint, source/test mypy, and Bandit passed. All pre-commit and pre-push hooks passed.
- **18 disposable probes** outside the repository passed using the repository's pytest configuration: mixed native output, image-only streaming, JSON restore, verbatim replay, malformed base64, compaction and repeated compaction.
- Additional disposable public-factory probe passed unary → compaction → JSON restore → continuation → re-compaction, public streaming event adaptation, raw usage, headers/endpoints, and separate Chat Completions dispatch.
- Final diff contains **no test, fixture, snapshot, or assertion-script additions/changes**. `git diff --check` passed.
- These are local/synthetic contract checks, not live xAI inference. Fresh local package resolution was unavailable because of registry DNS; local checks used the existing installed dependencies with the editable source redirected to this isolated checkout. GitHub's eight required checks all passed on head `a91bdcd172cb420e229a74187701a49817719e91`: format, lint, type-check, security, and all four OS/Python test jobs. CodeQL checks also passed. Final head/base/diff were rechecked; no review findings were present.

<!-- model-monitoring:xai-text -->
