### PR TITLE
fix(bfl): honor settled image costs and terminal polling states

### DIFF
--- a/src/celeste/providers/bfl/images/client.py
+++ b/src/celeste/providers/bfl/images/client.py
@@ -90,6 +90,7 @@ class BFLImagesClient(APIMixin):
             poll_response = await self.http_client.get(
                 polling_url,
                 headers=poll_headers,
+                follow_redirects=False,
             )
 
             self._handle_error_response(poll_response)
@@ -102,9 +103,15 @@ class BFLImagesClient(APIMixin):
                     **poll_data,
                     "_submit_metadata": submit_data,
                 }
-            elif status in ("Error", "Failed"):
-                error_msg = poll_data.get("error", "Unknown error")
-                msg = f"{self.provider} image generation failed: {error_msg}"
+            elif status in (
+                "Error",
+                "Failed",
+                "Request Moderated",
+                "Content Moderated",
+                "Task not found",
+            ):
+                error_msg = poll_data.get("error") or poll_data.get("details") or status
+                msg = f"{self.provider} image generation failed ({status}): {error_msg}"
                 raise ValueError(msg)
 
             await asyncio.sleep(config.POLLING_INTERVAL)
@@ -143,8 +150,10 @@ class BFLImagesClient(APIMixin):
         self, response_data: dict[str, Any]
     ) -> dict[str, int | float | None]:
         """Extract usage data from BFL response."""
-        submit_metadata = response_data.get("_submit_metadata", {})
-        return BFLImagesClient.map_usage_fields(submit_metadata)
+        usage_data = dict(response_data.get("_submit_metadata") or {})
+        if response_data.get("cost") is not None:
+            usage_data["cost"] = response_data["cost"]
+        return BFLImagesClient.map_usage_fields(usage_data)
 
     def _parse_content(self, response_data: dict[str, Any]) -> Any:
         """Parse result from response."""


### PR DESCRIPTION
BFL returns settled credits in its final polling response, but Celeste currently reports the submission cost even when the final cost differs or is zero. Moderated and missing tasks also keep polling until timeout.

Prefer a non-null final `cost`, including zero, and fall back to submission cost when it is missing or null. Preserve submission megapixel telemetry and raw metadata. Stop on `Request Moderated`, `Content Moderated`, and `Task not found`, using the existing error handling for terminal failures and retaining provider details.

The change stays in the existing BFL image adapter and preserves its current polling URL and redirect behavior. The [Get Result contract](https://docs.bfl.ai/api-reference/utility/get-result) documents settled credits and the task statuses.

## Validation

- `make ci` passed on `fd435ce40f8b5c5c8f82718ae46a8282a8821cae`: Ruff, formatting, source/test mypy, Bandit, and **647 existing unit tests**; **73.23% coverage** (Python 3.13.15).
- Disposable checks of the unchanged cost/status logic passed for zero, missing/null fallback, retained telemetry, unchanged input dictionaries, intermediate states, and immediate terminal errors with provider details.
- No provider-specific unit tests are added. No live or billed BFL requests were made.

Downstream pricing work is tracked in #404 and [celeste-pricing #31](https://github.com/withceleste/celeste-pricing/pull/31).