### PR TITLE
fix(openai): preserve image references and masks

### DIFF
--- a/src/celeste/http.py
+++ b/src/celeste/http.py
@@ -127,7 +127,8 @@ class HTTPClient:
         self,
         url: str,
         headers: dict[str, str],
-        files: dict[str, tuple[str, bytes, str]],
+        files: dict[str, tuple[str, bytes, str]]
+        | list[tuple[str, tuple[str, bytes, str]]],
         data: dict[str, str],
         timeout: float = DEFAULT_TIMEOUT,
     ) -> httpx.Response:

--- a/src/celeste/modalities/images/providers/openai/client.py
+++ b/src/celeste/modalities/images/providers/openai/client.py
@@ -41,7 +41,7 @@ class OpenAIImagesClient(OpenAIImagesMixin, ImagesClient):
         return OPENAI_PARAMETER_MAPPERS
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
-        """Keep the primary artifact for the shared JSON request builder."""
+        """Keep the primary artifact for edit request encoding."""
         request: dict[str, Any] = {"prompt": inputs.prompt}
         if inputs.image is not None:
             request["image"] = inputs.image

--- a/src/celeste/modalities/images/providers/openai/client.py
+++ b/src/celeste/modalities/images/providers/openai/client.py
@@ -41,10 +41,9 @@ class OpenAIImagesClient(OpenAIImagesMixin, ImagesClient):
         return OPENAI_PARAMETER_MAPPERS
 
     def _init_request(self, inputs: ImageInput) -> dict[str, Any]:
-        """Initialize request, keeping ImageArtifact for multipart handling."""
+        """Keep the primary artifact for the shared JSON request builder."""
         request: dict[str, Any] = {"prompt": inputs.prompt}
         if inputs.image is not None:
-            # Keep as ImageArtifact - _make_multipart_request handles encoding
             request["image"] = inputs.image
         return request
 

--- a/src/celeste/modalities/images/providers/openai/models.py
+++ b/src/celeste/modalities/images/providers/openai/models.py
@@ -1,6 +1,6 @@
 """OpenAI models for images modality."""
 
-from celeste.constraints import Choice, Range
+from celeste.constraints import Choice, ImageConstraint, ImagesConstraint, Range
 from celeste.core import Modality, Operation, Provider
 from celeste.models import Model
 
@@ -20,6 +20,8 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=16),
+            ImageParameter.MASK: ImageConstraint(),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]
@@ -41,6 +43,8 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=16),
+            ImageParameter.MASK: ImageConstraint(),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]
@@ -61,6 +65,8 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=16),
+            ImageParameter.MASK: ImageConstraint(),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]
@@ -91,6 +97,8 @@ MODELS: list[Model] = [
             ),
             ImageParameter.QUALITY: Choice(options=["low", "medium", "high", "auto"]),
             ImageParameter.NUM_IMAGES: Range(min=1, max=10),
+            ImageParameter.REFERENCE_IMAGES: ImagesConstraint(max_count=16),
+            ImageParameter.MASK: ImageConstraint(),
             ImageParameter.OUTPUT_FORMAT: Choice(options=["png", "jpeg", "webp"]),
             ImageParameter.BACKGROUND: Choice(
                 options=["transparent", "opaque", "auto"]

--- a/src/celeste/modalities/images/providers/openai/parameters.py
+++ b/src/celeste/modalities/images/providers/openai/parameters.py
@@ -4,6 +4,7 @@ from celeste.parameters import ParameterMapper
 from celeste.providers.openai.images.parameters import (
     BackgroundMapper as _BackgroundMapper,
 )
+from celeste.providers.openai.images.parameters import MaskMapper as _MaskMapper
 from celeste.providers.openai.images.parameters import (
     ModerationMapper as _ModerationMapper,
 )
@@ -21,6 +22,9 @@ from celeste.providers.openai.images.parameters import (
 )
 from celeste.providers.openai.images.parameters import (
     QualityMapper as _QualityMapper,
+)
+from celeste.providers.openai.images.parameters import (
+    ReferenceImagesMapper as _ReferenceImagesMapper,
 )
 from celeste.providers.openai.images.parameters import (
     SizeMapper as _SizeMapper,
@@ -78,6 +82,18 @@ class OutputCompressionMapper(_OutputCompressionMapper):
     name = ImageParameter.OUTPUT_COMPRESSION
 
 
+class ReferenceImagesMapper(_ReferenceImagesMapper):
+    """Map reference images to OpenAI edit inputs."""
+
+    name = ImageParameter.REFERENCE_IMAGES
+
+
+class MaskMapper(_MaskMapper):
+    """Map the mask to OpenAI edit inputs."""
+
+    name = ImageParameter.MASK
+
+
 OPENAI_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     AspectRatioMapper(),
     PartialImagesMapper(),
@@ -87,6 +103,8 @@ OPENAI_PARAMETER_MAPPERS: list[ParameterMapper[ImageContent]] = [
     BackgroundMapper(),
     SafetyToleranceMapper(),
     OutputCompressionMapper(),
+    ReferenceImagesMapper(),
+    MaskMapper(),
 ]
 
 __all__ = ["OPENAI_PARAMETER_MAPPERS"]

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -13,7 +13,7 @@ from celeste.client import APIMixin
 from celeste.core import UsageField
 from celeste.exceptions import ConstraintViolationError
 from celeste.io import FinishReason
-from celeste.utils import build_data_url
+from celeste.utils import build_data_url, detect_mime_type
 
 from . import config
 
@@ -46,24 +46,12 @@ class OpenAIImagesClient(APIMixin):
         request_body["model"] = self.model.id
         if image := request_body.pop("image", None):
             request_body["images"] = [image, *request_body.get("images", [])]
-        if images := request_body.get("images"):
-            if len(images) > 16:
-                msg = (
-                    "OpenAI edits accept at most 16 images, including the primary image"
-                )
-                raise ConstraintViolationError(msg)
-            request_body["images"] = [
-                {"image_url": build_data_url(image)}
-                if isinstance(image, ImageArtifact)
-                else image
-                for image in images
-            ]
-        if mask := request_body.get("mask"):
-            if not request_body.get("images"):
-                msg = "An image mask requires a primary or reference image"
-                raise ConstraintViolationError(msg)
-            if isinstance(mask, ImageArtifact):
-                request_body["mask"] = {"image_url": build_data_url(mask)}
+        if len(request_body.get("images", [])) > 16:
+            msg = "OpenAI edits accept at most 16 images, including the primary image"
+            raise ConstraintViolationError(msg)
+        if request_body.get("mask") and not request_body.get("images"):
+            msg = "An image mask requires a primary or reference image"
+            raise ConstraintViolationError(msg)
         if streaming:
             request_body["stream"] = True
         return request_body
@@ -77,8 +65,18 @@ class OpenAIImagesClient(APIMixin):
         **parameters: Any,
     ) -> dict[str, Any]:
         """Make HTTP request to OpenAI Images API."""
-        if request_body.get("images"):
+        if images := request_body.get("images"):
             endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
+            uploads = [*images]
+            if mask := request_body.get("mask"):
+                uploads.append(mask)
+            if all(
+                isinstance(image, ImageArtifact) and (image.data or image.path)
+                for image in uploads
+            ):
+                return await self._make_multipart_request(
+                    request_body, endpoint, extra_headers=extra_headers
+                )
         elif endpoint is None:
             endpoint = config.OpenAIImagesEndpoint.CREATE_IMAGE
 
@@ -87,11 +85,55 @@ class OpenAIImagesClient(APIMixin):
         response = await self.http_client.post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
-            json_body=request_body,
+            json_body=self._encode_image_references(request_body),
         )
         self._handle_error_response(response)
         data: dict[str, Any] = response.json()
         return data
+
+    @staticmethod
+    def _encode_image_references(request_body: dict[str, Any]) -> dict[str, Any]:
+        """Encode artifacts for the JSON edit contract, preserving explicit references."""
+        body = request_body.copy()
+        if images := body.get("images"):
+            body["images"] = [
+                {"image_url": build_data_url(image)}
+                if isinstance(image, ImageArtifact)
+                else image
+                for image in images
+            ]
+        if isinstance(mask := body.get("mask"), ImageArtifact):
+            body["mask"] = {"image_url": build_data_url(mask)}
+        return body
+
+    async def _make_multipart_request(
+        self,
+        request_body: dict[str, Any],
+        endpoint: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Upload local edit images and mask without JSON data-URL size limits."""
+        body = request_body.copy()
+        uploads = [("image[]", image) for image in body.pop("images")]
+        if mask := body.pop("mask", None):
+            uploads.append(("mask", mask))
+        files = []
+        for field, image in uploads:
+            data = image.get_bytes()
+            mime = image.mime_type or detect_mime_type(data)
+            files.append(
+                (field, ("image", data, str(mime or "application/octet-stream")))
+            )
+        response = await self.http_client.post_multipart(
+            f"{config.BASE_URL}{endpoint}",
+            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
+            files=files,
+            data={key: str(value) for key, value in body.items() if value is not None},
+        )
+        self._handle_error_response(response)
+        response_data: dict[str, Any] = response.json()
+        return response_data
 
     async def _make_stream_request(
         self,
@@ -115,7 +157,7 @@ class OpenAIImagesClient(APIMixin):
         return self.http_client.stream_post(
             f"{config.BASE_URL}{endpoint}",
             headers=headers,
-            json_body=request_body,
+            json_body=self._encode_image_references(request_body),
         )
 
     @staticmethod

--- a/src/celeste/providers/openai/images/client.py
+++ b/src/celeste/providers/openai/images/client.py
@@ -8,10 +8,12 @@ Provides shared implementation for capabilities using the OpenAI Images API:
 from collections.abc import AsyncGenerator
 from typing import Any, ClassVar
 
+from celeste.artifacts import ImageArtifact
 from celeste.client import APIMixin
 from celeste.core import UsageField
+from celeste.exceptions import ConstraintViolationError
 from celeste.io import FinishReason
-from celeste.utils import build_data_url, detect_mime_type
+from celeste.utils import build_data_url
 
 from . import config
 
@@ -42,6 +44,26 @@ class OpenAIImagesClient(APIMixin):
             inputs, extra_body=extra_body, streaming=streaming, **parameters
         )
         request_body["model"] = self.model.id
+        if image := request_body.pop("image", None):
+            request_body["images"] = [image, *request_body.get("images", [])]
+        if images := request_body.get("images"):
+            if len(images) > 16:
+                msg = (
+                    "OpenAI edits accept at most 16 images, including the primary image"
+                )
+                raise ConstraintViolationError(msg)
+            request_body["images"] = [
+                {"image_url": build_data_url(image)}
+                if isinstance(image, ImageArtifact)
+                else image
+                for image in images
+            ]
+        if mask := request_body.get("mask"):
+            if not request_body.get("images"):
+                msg = "An image mask requires a primary or reference image"
+                raise ConstraintViolationError(msg)
+            if isinstance(mask, ImageArtifact):
+                request_body["mask"] = {"image_url": build_data_url(mask)}
         if streaming:
             request_body["stream"] = True
         return request_body
@@ -55,28 +77,11 @@ class OpenAIImagesClient(APIMixin):
         **parameters: Any,
     ) -> dict[str, Any]:
         """Make HTTP request to OpenAI Images API."""
-        if endpoint is None:
+        if request_body.get("images"):
+            endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
+        elif endpoint is None:
             endpoint = config.OpenAIImagesEndpoint.CREATE_IMAGE
 
-        # Edit endpoint requires multipart/form-data
-        if endpoint == config.OpenAIImagesEndpoint.CREATE_EDIT:
-            return await self._make_multipart_request(
-                request_body, endpoint, extra_headers=extra_headers
-            )
-
-        # Generate uses JSON
-        return await self._make_json_request(
-            request_body, endpoint, extra_headers=extra_headers
-        )
-
-    async def _make_json_request(
-        self,
-        request_body: dict[str, Any],
-        endpoint: str,
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Make JSON request for generate operations."""
         headers = await self._json_headers(extra_headers)
 
         response = await self.http_client.post(
@@ -88,43 +93,6 @@ class OpenAIImagesClient(APIMixin):
         data: dict[str, Any] = response.json()
         return data
 
-    async def _make_multipart_request(
-        self,
-        request_body: dict[str, Any],
-        endpoint: str,
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Make multipart request for edit operations."""
-        image_artifact = request_body.pop("image")
-
-        # Get image bytes from artifact
-        image_bytes = image_artifact.get_bytes()
-
-        # Detect MIME type if not explicitly set
-        mime = image_artifact.mime_type or detect_mime_type(image_bytes)
-        mime_str = mime.value if mime else "application/octet-stream"
-
-        files = {"image": ("image", image_bytes, mime_str)}
-        # Model is already in request_body from _build_request()
-        model = request_body.pop("model")
-        data = {"model": model}
-
-        # Add remaining fields as form data
-        for key, value in request_body.items():
-            if value is not None:
-                data[key] = str(value)
-
-        response = await self.http_client.post_multipart(
-            f"{config.BASE_URL}{endpoint}",
-            headers=self._merge_headers(await self.auth.aget_headers(), extra_headers),
-            files=files,
-            data=data,
-        )
-        self._handle_error_response(response)
-        response_data: dict[str, Any] = response.json()
-        return response_data
-
     async def _make_stream_request(
         self,
         request_body: dict[str, Any],
@@ -133,22 +101,14 @@ class OpenAIImagesClient(APIMixin):
         extra_headers: dict[str, str] | None = None,
         **parameters: Any,
     ) -> AsyncGenerator[dict[str, Any], None]:
-        """Make streaming request to OpenAI Images API.
-
-        Streaming is only supported for gpt-image-1.
-        """
-        if endpoint is None:
+        """Make streaming request to OpenAI Images API."""
+        if request_body.get("images"):
+            endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
+        elif endpoint is None:
             endpoint = config.OpenAIImagesEndpoint.CREATE_IMAGE
 
         if "partial_images" not in request_body:
             request_body["partial_images"] = 1
-
-        # Serialize ImageArtifact for JSON streaming edit
-        # Non-streaming uses multipart; streaming uses JSON with images array
-        if "image" in request_body and hasattr(request_body["image"], "get_base64"):
-            artifact = request_body.pop("image")
-            request_body["images"] = [{"image_url": build_data_url(artifact)}]
-            endpoint = config.OpenAIImagesEndpoint.CREATE_EDIT
 
         headers = await self._json_headers(extra_headers)
 

--- a/src/celeste/providers/openai/images/parameters.py
+++ b/src/celeste/providers/openai/images/parameters.py
@@ -58,14 +58,28 @@ class NumImagesMapper(FieldMapper[ImageContent]):
     field = "n"
 
 
+class ReferenceImagesMapper(FieldMapper[ImageContent]):
+    """Collect references for the shared JSON edit request builder."""
+
+    field = "images"
+
+
+class MaskMapper(FieldMapper[ImageContent]):
+    """Collect the mask for the shared JSON edit request builder."""
+
+    field = "mask"
+
+
 __all__ = [
     "BackgroundMapper",
+    "MaskMapper",
     "ModerationMapper",
     "NumImagesMapper",
     "OutputCompressionMapper",
     "OutputFormatMapper",
     "PartialImagesMapper",
     "QualityMapper",
+    "ReferenceImagesMapper",
     "SizeMapper",
     "StyleMapper",
 ]


### PR DESCRIPTION
OpenAI image requests currently warn and discard `reference_images` and `mask`. Serialize both through the existing Images edit transports, keeping the primary image first, all references in order, and the mask attached. Generation with references routes to `/v1/images/edits`; plain generation stays on `/v1/images/generations`. Local unary edits retain multipart uploads, using repeated `image[]` parts and a separate mask. Remote/File-ID inputs and streaming use the existing JSON reference format. This preserves multipart input sizes rather than imposing JSON data-URL limits on existing uploads.

All four registered GPT Image models gain reference/mask metadata. Enforce 16 total source images, including the primary image, and reject a mask with no source. Local artifacts use the existing data-URL helper; remote URLs and explicit File API references remain intact. Output lists, completed-event usage, model IDs, dimension choices, streaming flags, moderation and quality settings retain their existing behavior. Masks' format/alpha/dimension and provider byte-size rules remain enforced by OpenAI.

Evidence checked 2026-09-08: the [JSON edit request](https://developers.openai.com/api/reference/resources/images/methods/edit) specifies the `images` array, 16-image ceiling and `mask` reference; the [guide](https://developers.openai.com/api/docs/guides/image-generation) demonstrates reference composition and masks. Existing #180 recorded successful JSON streaming edit and generation tests. Earlier maintenance deferred these fields alongside a size-schema disagreement; their input contract is independently documented and does not depend on the output-size enum. No new transport or Responses integration.

Validation: `UV_NO_CACHE=1 UV_NO_SYNC=1 make ci` passed **647 existing tests, 73.12% coverage**, Ruff, both mypy passes and Bandit. Commit/pre-push hooks passed. An uncommitted capture probe exercised all four models, 16-total generate/edit boundaries and 17-image rejection, source order, mask-without-source rejection, data/remote/File-ID references, multipart/JSON endpoint selection and actual HTTPX multipart encoding, ordered multiple outputs and raw usage, plus six public streaming calls. The bounded live edit attempt with an existing key failed with `ConnectError` before a provider response; no live success is claimed. No provider/model-specific tests, fixtures, snapshots or assertion scripts enter this PR.

**Keep draft for downstream compatibility.** Chat's frozen dependency install at `48c1459` succeeded with exact SDK `edcf009`, pricing 0.2.15 and tools 0.3.15; seven existing model-catalog tests pass. Its `EditImage` resolves reference/mask IDs, but `GenerateImage` resolves only reference IDs even though the shared schema exposes `mask`. A disposable probe with this SDK head and exact tools 0.3.15 confirmed that an accepted mask ID reaches the SDK unresolved and fails. The existing tools adapter must resolve that mask (or intentionally exclude edit-only masks from generation schemas) before Chat adopts this metadata. `celeste-tools` is outside this routine's three-repository deployment scope; this concrete dependency is tracked in #419, not disguised as an architecture proposal. No unavailable tools version or completed Chat migration is claimed.

Pricing: standard response/completed-event usage shape is unchanged and Chat's GPT Image 2 card is correct. Missing legacy/snapshot cards are a verified handoff to sole pricing writer `anthropic-text-model-maintenance` in #419. Chat retains GPT Image 2 FORGE, the Gemini default and all unrelated roles. After the tools fix and upstream merge, the designated Anthropic task owns shared SDK/tools lock delivery; no duplicate lock-only PR. Independent size correction: #421. Existing snapshot #392 is preserved pending ownership provenance.

Tracking: #419. Finding `openai|/v1/images/edits|generate,edit|gpt-image-family|reference-images-mask`.
Policy `2026-09-07.6` / `1a7cb75727cf`; owner: desktop `openai-images-model-maintenance`, configured identity `Kamilbenkirane`. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`; final head `63fbb3c3fe72662ce55faa14a22d790b063860cc`. All eight required GitHub checks and both CodeQL checks passed at this head; no review findings.

The shared HTTP multipart method only widens its files annotation to accept HTTPX’s native repeated-field list; its transport behavior and sibling callers remain unchanged. Full existing SDK checks include all those callers. No permanent provider-specific test was added.

The same downstream mask gap remains on current [tools main at `183f36e`](https://github.com/withceleste/celeste-tools/blob/183f36e9fed5a4f64dad06aab0534b4c0af8eee3/src/celeste_tools/generate_image/generate_image.py), whose package version is 0.3.15. There is no open tools PR to consume. Repair and publish that existing adapter, then coordinate the shared Chat refresh through #419.
