### PR TITLE
fix(openai): remove three shut-down direct API registrations

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -102,24 +102,6 @@ MODELS: list[Model] = [
         },
     ),
     Model(
-        id="gpt-5.2-codex",
-        provider=Provider.OPENAI,
-        display_name="GPT-5.2 Codex",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=128000),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["low", "medium", "high", "xhigh"]
-            ),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
-        },
-    ),
-    Model(
         id="gpt-5.3-codex",
         provider=Provider.OPENAI,
         display_name="GPT-5.3 Codex",
@@ -134,21 +116,6 @@ MODELS: list[Model] = [
             TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
             TextParameter.OUTPUT_SCHEMA: Schema(),
             TextParameter.IMAGE: ImagesConstraint(),
-        },
-    ),
-    Model(
-        id="gpt-5.2-chat-latest",
-        provider=Provider.OPENAI,
-        display_name="GPT-5.2 Instant",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.TEMPERATURE: Range(min=0.0, max=2.0),
-            Parameter.MAX_TOKENS: Range(min=1, max=16384),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
         },
     ),
     Model(
@@ -171,25 +138,6 @@ MODELS: list[Model] = [
         id="gpt-5.1",
         provider=Provider.OPENAI,
         display_name="GPT-5.1",
-        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
-        streaming=True,
-        parameter_constraints={
-            Parameter.MAX_TOKENS: Range(min=1, max=128000),
-            TextParameter.THINKING_BUDGET: Choice(
-                options=["minimal", "low", "medium", "high"]
-            ),
-            TextParameter.VERBOSITY: Choice(options=["low", "medium", "high"]),
-            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
-            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
-            TextParameter.OUTPUT_SCHEMA: Schema(),
-            TextParameter.IMAGE: ImagesConstraint(),
-            TextParameter.DOCUMENT: DocumentsConstraint(),
-        },
-    ),
-    Model(
-        id="gpt-5.1-codex",
-        provider=Provider.OPENAI,
-        display_name="GPT-5.1 Codex",
         operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
         streaming=True,
         parameter_constraints={


### PR DESCRIPTION
Remove three expired direct OpenAI API registrations from active text discovery: `gpt-5.1-codex`, `gpt-5.2-codex`, and `gpt-5.2-chat-latest`. Their documented successor `gpt-5.6-sol` is already supported. Retain `gpt-5.3-codex`, useful `chat-latest`/`gpt-5.6` aliases, the GPT-5.6 family and valid predecessors.

The current [deprecation notice](https://developers.openai.com/api/docs/deprecations) states July 23, 2026 shutdown for the two Codex IDs and August 10, 2026 for the chat snapshot. These exact named OpenAI API shutdowns have passed. This does not remove separately hosted models or historical pricing records.

Earlier runs retained these IDs under the repository's paid hard-rejection rule. Renewed policy 2026-09-07.6 explicitly allows current official exact-route effective shutdown evidence; July 22 #331 reported quota exhaustion, not positive availability after shutdown. No conflicting live serving evidence or human instruction to retain these IDs was found. No doomed paid request is needed.

Validation: full `make ci` passed, 647 existing tests, 73.25% coverage, Ruff/format, source/test mypy and Bandit. Disposable registry checks verify all three removals and retained sibling/alias IDs. Initial concurrent CI hit the Google ADC event timeout; an isolated exact-base focused check and serial full retry passed without source/test changes. No pre-existing root cause is claimed. Commit/push hooks and all eight required GitHub checks plus both CodeQL checks passed on final head `880a2b953c939a81ea5b755fdbb499ddc77dce5b`; final diff reviewed and no unresolved review finding.

Pricing already has the successor Sol card and no active cards for these exact retired IDs. Chat's full served-ID/profile/default inventory has none of these IDs and retains Luna/SPARK, Terra/FLOW, Sol/FORGE. No downstream migration or price change is required.

Finding: `openai|/v1/responses|generate-analyze|retired-gpt5-variants|effective-shutdown`.

Tracking: [#429](https://github.com/withceleste/celeste-python/issues/429). Policy `2026-09-07.6 / 2523a2ee166a`; owner: desktop `openai-text-model-maintenance`, configured identity `Kamilbenkirane`. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`. Evidence reopened September 9, 2026. No provider/model-specific tests, fixtures, snapshots or assertion scripts are added.
