### PR TITLE
feat(openai): register GPT-6 Astra text model

### DIFF
--- a/src/celeste/modalities/text/providers/openai/models.py
+++ b/src/celeste/modalities/text/providers/openai/models.py
@@ -17,6 +17,24 @@ from ...parameters import TextParameter
 
 MODELS: list[Model] = [
     Model(
+        id="gpt-6-astra",
+        provider=Provider.OPENAI,
+        display_name="GPT-6 Astra",
+        operations={Modality.TEXT: {Operation.GENERATE, Operation.ANALYZE}},
+        streaming=True,
+        parameter_constraints={
+            Parameter.MAX_TOKENS: Range(min=1, max=128000),
+            TextParameter.THINKING_BUDGET: Choice(
+                options=["low", "medium", "high", "xhigh", "max"]
+            ),
+            TextParameter.TOOLS: ToolSupport(tools=[WebSearch]),
+            TextParameter.TOOL_CHOICE: ToolChoiceSupport(),
+            TextParameter.OUTPUT_SCHEMA: Schema(),
+            TextParameter.IMAGE: ImagesConstraint(),
+            TextParameter.DOCUMENT: DocumentsConstraint(),
+        },
+    ),
+    Model(
         id="gpt-4o",
         provider=Provider.OPENAI,
         display_name="GPT-4o",


### PR DESCRIPTION
Register `gpt-6-astra` through Celeste's existing OpenAI Responses text client for GENERATE and ANALYZE. Expose 128,000 maximum output tokens, low/medium/high/xhigh/max effort, text with image/document inputs, structured outputs, function/hosted tools and the existing SSE adapter. No custom temperature/top-p support is advertised and no new transport is added.

[Model contract](https://developers.openai.com/api/docs/models/gpt-6-astra), [September 3 release](https://developers.openai.com/api/docs/changelog) and [Astra guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra) establish the canonical ID, output cap, effort set and Responses/SSE support. Tool calling requires Responses, which is already Celeste's OpenAI route. All older valid entries remain unchanged; exact shutdown cleanup is a separate concern in #429.

Validation: full `make ci` passed, 647 existing tests, 73.25% coverage, Ruff/format, source/test mypy and Bandit. A disposable probe checks all ten effort/unary/SSE request combinations, invalid choices/output caps, model registration, URL, image/PDF input, JSON Schema, function/Web Search tools, raw cache controls and terminal SSE text/usage/metadata. Initial concurrent CI hit the Google ADC event timeout; isolated base focused and serial full retry passed without changes. No live provider inference/access claim. Commit/push hooks and all eight required GitHub checks plus both CodeQL checks passed on final head `8212026f2ee058b2d16a6d22fadcc811a0c8c0fc`; final diff reviewed and no unresolved review finding.

Pricing is a verified downstream handoff to sole writer for [pricing #31](https://github.com/withceleste/celeste-pricing/pull/31): Standard/Batch/Flex/Fast, both 272K bands, cache-write and hosted-tool charges are recorded exactly in #429. Do not infer regional endpoint usage. SDK availability and published/seeded pricing must precede future Chat serving. Astra is not promoted to a Chat tier: current Sol/FORGE remains supported and Astra has a materially different per-token cost contract. No Chat lock-only PR or untested package pin.

Finding: `openai|/v1/responses|generate-analyze|gpt-6-astra|catalog`.

Tracking: [#429](https://github.com/withceleste/celeste-python/issues/429). Policy `2026-09-07.6 / 2523a2ee166a`; owner: desktop `openai-text-model-maintenance`, configured identity `Kamilbenkirane`. Base `1c3b63aee24b17660fc05069fe238e5cb40f9a48`. Evidence reopened September 9, 2026. No provider/model-specific tests, fixtures, snapshots or assertion scripts are added.
